### PR TITLE
Change BTS image name

### DIFF
--- a/Test/docker-compose.yml
+++ b/Test/docker-compose.yml
@@ -106,7 +106,7 @@ services:
 
   dev_bts:
     container_name: beaver_triple_service
-    image: ghcr.io/acompany-develop/bts_dev:s20220427
+    image: ghcr.io/acompany-develop/quickmpc-bts:s20220808
     environment:
       - STAGE=dev
     volumes:


### PR DESCRIPTION
# Summary

- Change BTS image which is used in Test/ directory

# Purpose

- Making demo runnable

# Contents

- Change BTS image which is used in Test/ directory
  - reason: https://github.com/acompany-develop/QuickMPC-BTS/pull/1

# Testing Methods Performed

- check that demo can be performed by following
  - server
    ```console
    dev@host:/path/to/QuickMPC/Test$ docker login ghcr.io -u ${USER}  # it is needed for getting public image in ghcr.io
    dev@host:/path/to/QuickMPC/Test$ make debug
    ```
  - client
    ```console
    dev@host:/path/to/QuickMPC-libClient-py/demo/integration_demo$ pipenv install --skip-lock
    dev@host:/path/to/QuickMPC-libClient-py/demo/integration_demo$ pipenv run python execute_demo.py
    ```