### PR TITLE
refactor: enable sorting of include statements

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -6,8 +6,7 @@ AlignAfterOpenBracket: BlockIndent
 BreakConstructorInitializers: BeforeComma
 BinPackParameters: false
 BinPackArguments: false
-# include順に依存している部分があるので並び変えないようにする
-SortIncludes: false
+SortIncludes: true
 AccessModifierOffset: -4
 BreakBeforeBinaryOperators: NonAssignment
 ColumnLimit: 100

--- a/src/ComputationContainer/Client/AnyToDb/Client.cpp
+++ b/src/ComputationContainer/Client/AnyToDb/Client.cpp
@@ -1,16 +1,15 @@
 #include "Client.hpp"
 
-#include <chrono>
-
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 
-#include "ConfigParse/ConfigParse.hpp"
+#include <chrono>
 #include <stdexcept>
 
+#include "ConfigParse/ConfigParse.hpp"
 #include "LogHeader/Logger.hpp"
 #include "Logging/Logger.hpp"
 namespace AnyToDb

--- a/src/ComputationContainer/Client/AnyToDb/Client.hpp
+++ b/src/ComputationContainer/Client/AnyToDb/Client.hpp
@@ -8,18 +8,18 @@
 
 namespace AnyToDb
 {
-    class Client
-    {
-        const std::string host;
-        const std::shared_ptr<grpc::Channel> channel;
-        const std::unique_ptr<anytodbgate::AnyToDbGate::Stub> stub_;
-        static std::shared_ptr<grpc::Channel> connect();
-        bool reconnect() const;
+class Client
+{
+    const std::string host;
+    const std::shared_ptr<grpc::Channel> channel;
+    const std::unique_ptr<anytodbgate::AnyToDbGate::Stub> stub_;
+    static std::shared_ptr<grpc::Channel> connect();
+    bool reconnect() const;
 
-    public:
-        Client() = delete;
-        Client(const std::string &);
+public:
+    Client() = delete;
+    Client(const std::string &);
 
-        std::string executeQuery(const std::string &) const;
-    };
-} // namespace AnyToDb
+    std::string executeQuery(const std::string &) const;
+};
+}  // namespace AnyToDb

--- a/src/ComputationContainer/Client/AnyToDb/N1QL.cpp
+++ b/src/ComputationContainer/Client/AnyToDb/N1QL.cpp
@@ -7,199 +7,177 @@
 
 namespace AnyToDb
 {
-    /* N1QlValue statementの実装 */
-    N1QLValue::N1QLValue(const std::string &value, const std::string &key) : value(value), key(key) {}
+/* N1QlValue statementの実装 */
+N1QLValue::N1QLValue(const std::string &value, const std::string &key) : value(value), key(key) {}
 
-    auto N1QLValue::toValueSetString() const -> std::string
+auto N1QLValue::toValueSetString() const -> std::string
+{
+    return "(\"" + key + "\"," + value + ")";
+}
+
+/* N1Ql statementの実装 */
+N1QL::N1QL(const std::string &bucket) : clause(bucket) {}
+
+auto N1QL::insert(const N1QLValue &data) const -> std::string
+{
+    return clause.insert(data.toValueSetString()) + clause.returning();
+}
+
+auto N1QL::bulkinsert(const std::vector<N1QLValue> &datas) const -> std::string
+{
+    // バルク用のstring
+    std::string values;
+
+    for (std::size_t i = 0; i < datas.size(); i++)
     {
-        return "(\"" + key + "\"," + value + ")";
-    }
-
-    /* N1Ql statementの実装 */
-    N1QL::N1QL(const std::string &bucket) : clause(bucket) {}
-
-    auto N1QL::insert(const N1QLValue &data) const -> std::string
-    {
-        return clause.insert(data.toValueSetString()) +
-               clause.returning();
-    }
-
-    auto N1QL::bulkinsert(const std::vector<N1QLValue> &datas) const -> std::string
-    {
-        // バルク用のstring
-        std::string values;
-
-        for (std::size_t i = 0; i < datas.size(); i++)
+        values += datas[i].toValueSetString();
+        if (i != datas.size() - 1)
         {
-            values += datas[i].toValueSetString();
-            if (i != datas.size() - 1)
-            {
-                values += ",";
-            }
+            values += ",";
         }
-
-        return clause.insert(values) +
-               clause.returning();
     }
 
-    auto N1QL::update(
-        const std::pair<std::string, std::string> &cond,
-        const std::pair<std::string, std::string> &path_expr
-    ) const -> std::string
-    {
-        return clause.update(path_expr.first, path_expr.second) +
-               clause.where(cond.first, cond.second) +
-               clause.returning();
-    }
+    return clause.insert(values) + clause.returning();
+}
 
-    auto N1QL::select() const -> std::string
-    {
-        return clause.select();
-    }
+auto N1QL::update(
+    const std::pair<std::string, std::string> &cond,
+    const std::pair<std::string, std::string> &path_expr
+) const -> std::string
+{
+    return clause.update(path_expr.first, path_expr.second) + clause.where(cond.first, cond.second)
+           + clause.returning();
+}
 
-    auto N1QL::select_id(const std::string &id_name, const std::string &id) const -> std::string
-    {
-        return clause.select() +
-               clause.where(id_name, id);
-    }
+auto N1QL::select() const -> std::string { return clause.select(); }
 
-    auto N1QL::delete_id(const std::string &id_name, const std::string &id) const -> std::string
-    {
-        return clause.delete_f() +
-               clause.where(id_name, id) +
-               clause.returning();
-    }
+auto N1QL::select_id(const std::string &id_name, const std::string &id) const -> std::string
+{
+    return clause.select() + clause.where(id_name, id);
+}
 
-    auto N1QL::delete_order(unsigned int amount) const -> std::string
-    {
-        return clause.delete_f() +
-               clause.limit(amount) +
-               clause.returning();
-    }
+auto N1QL::delete_id(const std::string &id_name, const std::string &id) const -> std::string
+{
+    return clause.delete_f() + clause.where(id_name, id) + clause.returning();
+}
 
-    /* N1QL clauseの実装 */
-    N1QL::N1QLClause::N1QLClause(const std::string &bucket) : bucket(bucket) {}
+auto N1QL::delete_order(unsigned int amount) const -> std::string
+{
+    return clause.delete_f() + clause.limit(amount) + clause.returning();
+}
 
-    auto N1QL::N1QLClause::insert(const std::string &value) const -> std::string
-    {
-        return "INSERT INTO `" + bucket + "` (KEY, VALUE) VALUES " + value;
-    }
+/* N1QL clauseの実装 */
+N1QL::N1QLClause::N1QLClause(const std::string &bucket) : bucket(bucket) {}
 
-    auto N1QL::N1QLClause::update(const std::string &path, const std::string &expr) const -> std::string
-    {
-        return "UPDATE `" + bucket + "` x SET x." +
-               path +
-               " = " +
-               expr +
-               " ";
-    }
+auto N1QL::N1QLClause::insert(const std::string &value) const -> std::string
+{
+    return "INSERT INTO `" + bucket + "` (KEY, VALUE) VALUES " + value;
+}
 
-    auto N1QL::N1QLClause::select() const -> std::string
-    {
-        return "SELECT x.*, meta().id FROM `" + bucket + "` x ";
-    }
+auto N1QL::N1QLClause::update(const std::string &path, const std::string &expr) const -> std::string
+{
+    return "UPDATE `" + bucket + "` x SET x." + path + " = " + expr + " ";
+}
 
-    auto N1QL::N1QLClause::delete_f() const -> std::string
-    {
-        return "DELETE FROM `" + bucket + "` x ";
-    }
+auto N1QL::N1QLClause::select() const -> std::string
+{
+    return "SELECT x.*, meta().id FROM `" + bucket + "` x ";
+}
 
-    auto N1QL::N1QLClause::where(const std::string &key, const std::string &data) const -> std::string
-    {
-        return "WHERE x." +
-               escape_injection(key, N1QL_WHERE_PARAM) +
-               " = \"" +
-               escape_injection(data, N1QL_WHERE_PARAM) +
-               "\" ";
-    }
+auto N1QL::N1QLClause::delete_f() const -> std::string { return "DELETE FROM `" + bucket + "` x "; }
 
-    auto N1QL::N1QLClause::returning() const -> std::string
-    {
-        return "RETURNING x.*, meta().id ";
-    }
+auto N1QL::N1QLClause::where(const std::string &key, const std::string &data) const -> std::string
+{
+    return "WHERE x." + escape_injection(key, N1QL_WHERE_PARAM) + " = \""
+           + escape_injection(data, N1QL_WHERE_PARAM) + "\" ";
+}
 
-    auto N1QL::N1QLClause::limit(unsigned int lim) const -> std::string
-    {
-        return "LIMIT " + std::to_string(lim) + " ";
-    }
+auto N1QL::N1QLClause::returning() const -> std::string { return "RETURNING x.*, meta().id "; }
 
-    /*
-    N1QLインジェクション対策用パラメータ埋め込み前処理関数
-    param_typeでパラメータの種類を指定するとサニタイズを行う
-    N1QLのメソッドを追加する開発者はこの関数でインジェクション対策を行う必要がある
-    */
-    auto N1QL::N1QLClause::escape_injection(const std::string &target, const n1ql_param_type param_type) const -> std::string
+auto N1QL::N1QLClause::limit(unsigned int lim) const -> std::string
+{
+    return "LIMIT " + std::to_string(lim) + " ";
+}
+
+/*
+N1QLインジェクション対策用パラメータ埋め込み前処理関数
+param_typeでパラメータの種類を指定するとサニタイズを行う
+N1QLのメソッドを追加する開発者はこの関数でインジェクション対策を行う必要がある
+*/
+auto N1QL::N1QLClause::escape_injection(const std::string &target, const n1ql_param_type param_type)
+    const -> std::string
+{
+    switch (param_type)
     {
-        switch (param_type)
-        {
         case N1QL_SELECT_PARAM:
-            return std::regex_replace(
-                target,
-                std::regex("`"), "`");
+            return std::regex_replace(target, std::regex("`"), "`");
 
         case N1QL_WHERE_PARAM:
             return std::regex_replace(
-                std::regex_replace(target, std::regex("'"), "''"),
-                std::regex("\""), "\"\"");
+                std::regex_replace(target, std::regex("'"), "''"), std::regex("\""), "\"\""
+            );
 
         default:
             // 上記ケース以外は無効なのでエラーを起こす
             // 現在の実装では，ここに到達する可能性はない
-            const std::string msg = "An invalid clause type other than SELECT or WHERE clause was passed during injection escaping";
+            const std::string msg =
+                "An invalid clause type other than SELECT or WHERE clause was passed during "
+                "injection escaping";
             spdlog::error(msg);
             throw std::invalid_argument(msg);
-        }
     }
+}
 
-    /* my cas */
-    // タイムスタンプを返す
-    uint64_t getTimeStamp()
+/* my cas */
+// タイムスタンプを返す
+uint64_t getTimeStamp()
+{
+    // 現在日時を取得
+    const std::chrono::system_clock::time_point p = std::chrono::system_clock::now();
+
+    // エポックからの経過時間(ナノ秒)を取得
+    const std::chrono::nanoseconds nsec =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(p.time_since_epoch());
+
+    const uint64_t timestamp = nsec.count();
+
+    return timestamp;
+}
+
+// 論理カウンタを返す
+uint16_t getLogicalCounter()
+{
+    static uint16_t counter = 0;
+    return counter++;
+}
+
+// とりあえずcasを生成する
+uint64_t createCas()
+{
+    const uint64_t timestamp = getTimeStamp();
+    const uint16_t logicalcounter = getLogicalCounter();
+    // 64bit timestampの下位16bitを切り捨てるために使用するビットマスク
+    constexpr uint64_t MASK = 0xffffffffffff0000ULL;
+    // 64bit timestampの下位16bitを捨てたものとlogicalcounterの下位16bitをOR
+    // logicalcounterはuint16_tなのでビットマスクは不要
+    const uint64_t cas = (MASK & timestamp) | logicalcounter;
+
+    return cas;
+}
+
+// 推移律が成り立つcasを返す
+uint64_t getCas()
+{
+    static uint64_t precas = 0;
+    uint64_t cas = createCas();
+
+    while (precas != 0 && cas < precas)
     {
-        // 現在日時を取得
-        const std::chrono::system_clock::time_point p = std::chrono::system_clock::now();
-
-        // エポックからの経過時間(ナノ秒)を取得
-        const std::chrono::nanoseconds nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(p.time_since_epoch());
-
-        const uint64_t timestamp = nsec.count();
-
-        return timestamp;
+        cas = createCas();
     }
 
-    // 論理カウンタを返す
-    uint16_t getLogicalCounter()
-    {
-        static uint16_t counter = 0;
-        return counter++;
-    }
+    precas = cas;
 
-    // とりあえずcasを生成する
-    uint64_t createCas()
-    {
-        const uint64_t timestamp = getTimeStamp();
-        const uint16_t logicalcounter = getLogicalCounter();
-        // 64bit timestampの下位16bitを切り捨てるために使用するビットマスク
-        constexpr uint64_t MASK = 0xffffffffffff0000ULL;
-        // 64bit timestampの下位16bitを捨てたものとlogicalcounterの下位16bitをOR
-        // logicalcounterはuint16_tなのでビットマスクは不要
-        const uint64_t cas = (MASK & timestamp) | logicalcounter;
-
-        return cas;
-    }
-
-    // 推移律が成り立つcasを返す
-    uint64_t getCas()
-    {
-        static uint64_t precas = 0;
-        uint64_t cas = createCas();
-
-        while (precas != 0 && cas < precas)
-        {
-            cas = createCas();
-        }
-
-        precas = cas;
-
-        return cas;
-    }
-} // namespace AnyToDb
+    return cas;
+}
+}  // namespace AnyToDb

--- a/src/ComputationContainer/Client/AnyToDb/N1QL.hpp
+++ b/src/ComputationContainer/Client/AnyToDb/N1QL.hpp
@@ -5,94 +5,94 @@
 
 namespace AnyToDb
 {
-    // 推移律が成り立つcasを返す
-    uint64_t getCas();
+// 推移律が成り立つcasを返す
+uint64_t getCas();
 
-    /*
-    N1QLのクエリに埋め込むvalueの型
-    keyはid
-    valueはDbに入れる値で
-    (e.g. jsonstrings ("{"a":123,"b":23,"c":1}""),
-            simple value ("234"))
-    といった形にする
-    valueはどの形式で来るか不明なのでとりあえずstringで
-    */
-    class N1QLValue
+/*
+N1QLのクエリに埋め込むvalueの型
+keyはid
+valueはDbに入れる値で
+(e.g. jsonstrings ("{"a":123,"b":23,"c":1}""),
+        simple value ("234"))
+といった形にする
+valueはどの形式で来るか不明なのでとりあえずstringで
+*/
+class N1QLValue
+{
+    const std::string value;
+    const std::string key;
+
+public:
+    N1QLValue() = delete;
+    N1QLValue(const std::string &value, const std::string &key = std::to_string(getCas()));
+
+    auto toValueSetString() const -> std::string;
+};
+
+// statement
+class N1QL
+{
+    // clause
+    class N1QLClause
     {
-        const std::string value;
-        const std::string key;
-
-    public:
-        N1QLValue() = delete;
-        N1QLValue(const std::string &value, const std::string &key = std::to_string(getCas()));
-
-        auto toValueSetString() const -> std::string;
-    };
-
-    // statement
-    class N1QL
-    {
-
-        // clause
-        class N1QLClause
+        const std::string bucket;
+        typedef enum
         {
-            const std::string bucket;
-            typedef enum
-            {
-                N1QL_SELECT_PARAM = 0,
-                N1QL_WHERE_PARAM = 1,
-            } n1ql_param_type;
-
-        public:
-            N1QLClause() = delete;
-            N1QLClause(const std::string &bucket);
-
-            auto insert(const std::string &) const -> std::string;
-            auto update(const std::string &, const std::string &) const -> std::string;
-            auto select() const -> std::string;
-            auto select_count() const -> std::string;
-            auto delete_f() const -> std::string;
-            auto where(const std::string &, const std::string &) const -> std::string;
-            auto returning() const -> std::string;
-            auto limit(unsigned int lim) const -> std::string;
-            auto escape_injection(const std::string &, const n1ql_param_type param_type) const -> std::string;
-        };
-
-        const N1QLClause clause;
+            N1QL_SELECT_PARAM = 0,
+            N1QL_WHERE_PARAM = 1,
+        } n1ql_param_type;
 
     public:
-        N1QL() = delete;
-        N1QL(const std::string &bucket);
+        N1QLClause() = delete;
+        N1QLClause(const std::string &bucket);
 
-        // `bucket`にdataを新規保存するクエリ
-        // N1QLがstring一つでもコンストラクタが走るので，string単体なら引数に入れられる
-        auto insert(const N1QLValue &) const -> std::string;
-        // `bucket`にvaluesを一括で保存するクエリ
-        auto bulkinsert(const std::vector<N1QLValue> &) const -> std::string;
-        /// `bucket`のデータを更新するクエリ
-        /// @param cond      ".first"が".second"であるデータに対して処理を行う
-        /// @param path_expr ".first"を".second"の値に更新する
-        auto update(
-            const std::pair<std::string, std::string> &cond,
-            const std::pair<std::string, std::string> &path_expr
-        ) const -> std::string;
-        // "バケット内のすべてのデータを参照するクエリ
+        auto insert(const std::string &) const -> std::string;
+        auto update(const std::string &, const std::string &) const -> std::string;
         auto select() const -> std::string;
-        // "id_name"が"id"であるデータを参照するクエリ
-        auto select_id(const std::string &, const std::string &) const -> std::string;
-        // "id_name"が"id"であるデータを削除するクエリ
-        auto delete_id(const std::string &, const std::string &) const -> std::string;
-        // meta id昇順でデータをamount個削除するクエリ
-        auto delete_order(unsigned int) const -> std::string;
+        auto select_count() const -> std::string;
+        auto delete_f() const -> std::string;
+        auto where(const std::string &, const std::string &) const -> std::string;
+        auto returning() const -> std::string;
+        auto limit(unsigned int lim) const -> std::string;
+        auto escape_injection(const std::string &, const n1ql_param_type param_type) const
+            -> std::string;
     };
 
-    // タイムスタンプを返す
-    uint64_t getTimeStamp();
+    const N1QLClause clause;
 
-    // 論理カウンタを返す
-    uint16_t getLogicalCounter();
+public:
+    N1QL() = delete;
+    N1QL(const std::string &bucket);
 
-    // とりあえずcasを生成する
-    uint64_t createCas();
+    // `bucket`にdataを新規保存するクエリ
+    // N1QLがstring一つでもコンストラクタが走るので，string単体なら引数に入れられる
+    auto insert(const N1QLValue &) const -> std::string;
+    // `bucket`にvaluesを一括で保存するクエリ
+    auto bulkinsert(const std::vector<N1QLValue> &) const -> std::string;
+    /// `bucket`のデータを更新するクエリ
+    /// @param cond      ".first"が".second"であるデータに対して処理を行う
+    /// @param path_expr ".first"を".second"の値に更新する
+    auto update(
+        const std::pair<std::string, std::string> &cond,
+        const std::pair<std::string, std::string> &path_expr
+    ) const -> std::string;
+    // "バケット内のすべてのデータを参照するクエリ
+    auto select() const -> std::string;
+    // "id_name"が"id"であるデータを参照するクエリ
+    auto select_id(const std::string &, const std::string &) const -> std::string;
+    // "id_name"が"id"であるデータを削除するクエリ
+    auto delete_id(const std::string &, const std::string &) const -> std::string;
+    // meta id昇順でデータをamount個削除するクエリ
+    auto delete_order(unsigned int) const -> std::string;
+};
 
-} // namespace AnyToDb
+// タイムスタンプを返す
+uint64_t getTimeStamp();
+
+// 論理カウンタを返す
+uint16_t getLogicalCounter();
+
+// とりあえずcasを生成する
+uint64_t createCas();
+
+}  // namespace AnyToDb

--- a/src/ComputationContainer/Client/ComputationToBts/Client.cpp
+++ b/src/ComputationContainer/Client/ComputationToBts/Client.cpp
@@ -1,14 +1,4 @@
 #include "Client.hpp"
-#include "ConfigParse/ConfigParse.hpp"
-#include "Client/Helper/Helper.hpp"
-
-#include <thread>
-#include <chrono>
-
-#include <iostream>
-#include <string>
-#include <fstream>
-#include <sstream>
 
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
@@ -16,6 +6,15 @@
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#include "Client/Helper/Helper.hpp"
+#include "ConfigParse/ConfigParse.hpp"
 #include "LogHeader/Logger.hpp"
 #include "Logging/Logger.hpp"
 

--- a/src/ComputationContainer/Client/ComputationToComputationContainer/Client.cpp
+++ b/src/ComputationContainer/Client/ComputationToComputationContainer/Client.cpp
@@ -1,11 +1,13 @@
 #include "Client.hpp"
-#include "Share/AddressId.hpp"
-#include <string>
+
 #include <unistd.h>
-#include <thread>
+
 #include <chrono>
+#include <string>
+#include <thread>
 
 #include "LogHeader/Logger.hpp"
+#include "Share/AddressId.hpp"
 
 namespace qmpc::ComputationToComputation
 {

--- a/src/ComputationContainer/Client/ComputationToComputationContainer/Client.hpp
+++ b/src/ComputationContainer/Client/ComputationToComputationContainer/Client.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
-#include <iostream>
-#include <string>
-
-#include "ConfigParse/ConfigParse.hpp"
-#include "Client/Helper/Helper.hpp"
-#include "external/Proto/ComputationToComputationContainer/computation_to_computation.grpc.pb.h"
-#include "Share/AddressId.hpp"
-
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
+
+#include <iostream>
+#include <string>
+
+#include "Client/Helper/Helper.hpp"
+#include "ConfigParse/ConfigParse.hpp"
+#include "Share/AddressId.hpp"
+#include "external/Proto/ComputationToComputationContainer/computation_to_computation.grpc.pb.h"
 
 namespace qmpc::ComputationToComputation
 {

--- a/src/ComputationContainer/Client/ComputationToComputationContainerForJob/Client.cpp
+++ b/src/ComputationContainer/Client/ComputationToComputationContainerForJob/Client.cpp
@@ -1,11 +1,13 @@
 #include "Client.hpp"
-#include "Share/AddressId.hpp"
-#include <string>
+
 #include <unistd.h>
-#include <thread>
+
 #include <chrono>
+#include <string>
+#include <thread>
 
 #include "LogHeader/Logger.hpp"
+#include "Share/AddressId.hpp"
 namespace qmpc::ComputationToComputationForJob
 {
 Client::Client(const Url &endpoint) noexcept

--- a/src/ComputationContainer/Client/ComputationToComputationContainerForJob/Client.hpp
+++ b/src/ComputationContainer/Client/ComputationToComputationContainerForJob/Client.hpp
@@ -1,18 +1,17 @@
 #pragma once
 
-#include <string>
-
-#include "ConfigParse/ConfigParse.hpp"
-#include "Client/Helper/Helper.hpp"
-#include "external/Proto/ComputationToComputationContainerForJob/computation_to_computation_for_job.grpc.pb.h"
-
-#include "Share/AddressId.hpp"
-
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
+
+#include <string>
+
+#include "Client/Helper/Helper.hpp"
+#include "ConfigParse/ConfigParse.hpp"
+#include "Share/AddressId.hpp"
+#include "external/Proto/ComputationToComputationContainerForJob/computation_to_computation_for_job.grpc.pb.h"
 
 namespace qmpc::ComputationToComputationForJob
 {

--- a/src/ComputationContainer/Client/ComputationToDbGate/Client.cpp
+++ b/src/ComputationContainer/Client/ComputationToDbGate/Client.cpp
@@ -1,7 +1,7 @@
 #include "Client.hpp"
 
-#include <map>
 #include <chrono>
+#include <map>
 #include <thread>
 
 namespace qmpc::ComputationToDbGate

--- a/src/ComputationContainer/Client/ComputationToDbGate/Client.hpp
+++ b/src/ComputationContainer/Client/ComputationToDbGate/Client.hpp
@@ -1,17 +1,16 @@
 #pragma once
 
-#include <string>
-#include <vector>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
-#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
-
-#include "Client/AnyToDb/N1QL.hpp"
-#include "nlohmann/json.hpp"
 #include "Client/AnyToDb/Client.hpp"
+#include "Client/AnyToDb/N1QL.hpp"
 #include "Client/ComputationToDbGate/ValueTable.hpp"
+#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
+#include "nlohmann/json.hpp"
 
 namespace qmpc::ComputationToDbGate
 {

--- a/src/ComputationContainer/Client/Helper/Helper.hpp
+++ b/src/ComputationContainer/Client/Helper/Helper.hpp
@@ -1,26 +1,27 @@
 #pragma once
 
-#include "ConfigParse/ConfigParse.hpp"
-
-#include <iostream>
-#include <memory>
-#include <string>
-#include <sstream>
-#include <fstream>
-#include <vector>
-
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "ConfigParse/ConfigParse.hpp"
+
 /**
  * gRPC チャンネル生成時に渡すデフォルト設定を返す
  */
 static grpc::ChannelArguments getDefaultChannelArguments(
-    const int keepalive_time_ms=10000,
-    const int keepalive_timeout_ms=10000,
-    const bool keepalive_permit_without_calls=true)
+    const int keepalive_time_ms = 10000,
+    const int keepalive_timeout_ms = 10000,
+    const bool keepalive_permit_without_calls = true
+)
 {
     grpc::ChannelArguments args;
     /*
@@ -42,8 +43,8 @@ static grpc::ChannelArguments getDefaultChannelArguments(
  */
 template <typename T>
 static std::unique_ptr<typename T::Stub> createStub(
-    const Url& target,
-    const grpc::ChannelArguments& args = getDefaultChannelArguments())
+    const Url& target, const grpc::ChannelArguments& args = getDefaultChannelArguments()
+)
 {
     // プロトコルに合わせて credentials を設定
     std::shared_ptr<grpc::ChannelCredentials> creds;
@@ -57,5 +58,6 @@ static std::unique_ptr<typename T::Stub> createStub(
     }
 
     auto channel = CreateCustomChannel(target.getAddress(), creds, args);
-    return T::NewStub(channel);;
+    return T::NewStub(channel);
+    ;
 }

--- a/src/ComputationContainer/Computation/Computation.cpp
+++ b/src/ComputationContainer/Computation/Computation.cpp
@@ -1,4 +1,5 @@
 #include "Computation.hpp"
+
 #include "LogHeader/Logger.hpp"
 
 bool is_computing = false;

--- a/src/ComputationContainer/Computation/Computation.hpp
+++ b/src/ComputationContainer/Computation/Computation.hpp
@@ -1,12 +1,12 @@
 #pragma once
+#include <chrono>
 #include <iostream>
 #include <string>
-#include <vector>
 #include <typeinfo>
-#include <chrono>
+#include <vector>
 
-#include "Share/Share.hpp"
 #include "Math/Math.hpp"
+#include "Share/Share.hpp"
 #include "nlohmann/json.hpp"
 
 // 計算の状態を管理

--- a/src/ComputationContainer/ComputationParty/ComputationParty.cpp
+++ b/src/ComputationContainer/ComputationParty/ComputationParty.cpp
@@ -1,19 +1,19 @@
 #include "ComputationParty.hpp"
-#include <iostream>
-#include <string>
-#include <thread>
-#include <regex>
-#include "unistd.h"
 
 #include <grpcpp/health_check_service_interface.h>
 
+#include <iostream>
+#include <regex>
+#include <string>
+#include <thread>
+
 #include "ConfigParse/ConfigParse.hpp"
+#include "Job/JobManager.hpp"
+#include "LogHeader/Logger.hpp"
 #include "Server/ComputationToComputationContainer/Server.hpp"
 #include "Server/ComputationToComputationContainerForJob/Server.hpp"
 #include "Server/ManageToComputationContainer/Server.hpp"
-#include "Job/JobManager.hpp"
-
-#include "LogHeader/Logger.hpp"
+#include "unistd.h"
 
 int main()
 {

--- a/src/ComputationContainer/ConfigParse/ConfigParse.hpp
+++ b/src/ComputationContainer/ConfigParse/ConfigParse.hpp
@@ -7,8 +7,8 @@
 #include <stdexcept>
 #include <string>
 
-#include "nlohmann/json.hpp"
 #include "Logging/Logger.hpp"
+#include "nlohmann/json.hpp"
 
 struct Url
 {

--- a/src/ComputationContainer/FixedPoint/FixedPoint.hpp
+++ b/src/ComputationContainer/FixedPoint/FixedPoint.hpp
@@ -1,219 +1,221 @@
 #pragma once
 
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/operators.hpp>
+#include <cmath>
+#include <iomanip>
 #include <iostream>
 #include <type_traits>
-#include <iomanip>
-#include <cmath>
-
-#include <boost/operators.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
-#include <boost/multiprecision/cpp_dec_float.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace qmpc::Utils
 {
-    template <typename T, typename U>
-    inline static constexpr T mypow(T a_, U n_) noexcept
+template <typename T, typename U>
+inline static constexpr T mypow(T a_, U n_) noexcept
+{
+    T a = a_;
+    U n = n_;
+    T ret = 1;
+    while (n > 0)
     {
-        T a = a_;
-        U n = n_;
-        T ret = 1;
-        while (n > 0)
-        {
-            if (n & 1)
-                ret *= a;
-            a *= a;
-            n >>= 1;
-        }
-        return ret;
+        if (n & 1) ret *= a;
+        a *= a;
+        n >>= 1;
     }
-    namespace mp = boost::multiprecision;
-    using cpp_dec_float = mp::number<mp::cpp_dec_float<50>>;
-    /*
-    T:保持する整数型
-    D:変換する浮動小数点型
-    length:10^length が最大値
-    resolution:10^resolutionを1とする
-    */
-    template <typename T = boost::multiprecision::cpp_int,
-              typename D = cpp_dec_float,
-              int length = 18,
-              int resolution = 8>
-    class FixedPointImpl : private boost::operators<FixedPointImpl<>>
-    {
-    private:
-        constexpr static long long shift = mypow(10ll, resolution);
-        constexpr static long long maxInt = mypow(10ll, length - resolution); // FixedPointImplがとりうる整数の最大値
-        T value;
+    return ret;
+}
+namespace mp = boost::multiprecision;
+using cpp_dec_float = mp::number<mp::cpp_dec_float<50>>;
+/*
+T:保持する整数型
+D:変換する浮動小数点型
+length:10^length が最大値
+resolution:10^resolutionを1とする
+*/
+template <
+    typename T = boost::multiprecision::cpp_int,
+    typename D = cpp_dec_float,
+    int length = 18,
+    int resolution = 8>
+class FixedPointImpl : private boost::operators<FixedPointImpl<>>
+{
+private:
+    constexpr static long long shift = mypow(10ll, resolution);
+    constexpr static long long maxInt =
+        mypow(10ll, length - resolution);  // FixedPointImplがとりうる整数の最大値
+    T value;
 
-    public:
-        FixedPointImpl() : value(0) {}
-        FixedPointImpl(const FixedPointImpl &v) : value(v.value) {}
-        FixedPointImpl(FixedPointImpl &&v) : value(std::move(v.value)) {}
-        template <typename U, std::enable_if_t<std::is_arithmetic_v<std::remove_reference_t<U>> or std::is_convertible_v<T, std::remove_reference_t<U>>, std::nullptr_t> = nullptr>
-        FixedPointImpl(const U &v)
+public:
+    FixedPointImpl() : value(0) {}
+    FixedPointImpl(const FixedPointImpl &v) : value(v.value) {}
+    FixedPointImpl(FixedPointImpl &&v) : value(std::move(v.value)) {}
+    template <
+        typename U,
+        std::enable_if_t<
+            std::is_arithmetic_v<
+                std::remove_reference_t<U>> or std::is_convertible_v<T, std::remove_reference_t<U>>,
+            std::nullptr_t> = nullptr>
+    FixedPointImpl(const U &v)
+    {
+        if constexpr (std::is_floating_point_v<U>)
         {
-            if constexpr (std::is_floating_point_v<U>)
+            if (boost::math::isinf(v))
             {
-                if (boost::math::isinf(v))
-                {
-                    value = static_cast<T>(std::numeric_limits<U>::max());
-                }
-                else
-                    value = static_cast<T>(v * shift);
+                value = static_cast<T>(std::numeric_limits<U>::max());
             }
             else
                 value = static_cast<T>(v * shift);
         }
-        FixedPointImpl(const std::string &str)
-        {
-            D v_{str};
-            if (boost::math::isinf(v_))
-            {
-                value = static_cast<T>(std::numeric_limits<D>::max());
-            }
-            else
-                value = static_cast<T>(v_ * shift);
-        }
-        FixedPointImpl &operator=(const FixedPointImpl &obj)
-        {
-            value = obj.value;
-            return *this;
-        }
-        FixedPointImpl &operator=(FixedPointImpl &&obj)
-        {
-            value = std::move(obj.value);
-            return *this;
-        }
-        template <typename U = T>
-        U getVal() const
-        {
-            return value.template convert_to<U>();
-        }
-        std::string getStrVal() const
-        {
-            D ret{this->getVal<D>()};
-            if (boost::math::isinf(ret))
-            {
-                ret = std::numeric_limits<D>::max();
-            }
-            ret /= shift;
-            return ret.str(20, std::ios_base::fixed);
-        }
-        double getDoubleVal() const
-        {
-            auto ret{this->getVal<double>()};
-            if (boost::math::isinf(ret))
-            {
-                ret = std::numeric_limits<double>::max();
-            }
-            return ret / shift;
-        }
-        constexpr static auto getShift() noexcept { return shift; }
-        constexpr static auto getMaxInt() noexcept { return maxInt; }
-        FixedPointImpl getInv() const
-        {
-            D inv{this->getVal<D>()};
-            if (boost::math::isinf(inv))
-            {
-                inv = std::numeric_limits<D>::max();
-            }
-            return FixedPointImpl(D{shift} / inv);
-        }
-        FixedPointImpl operator-() const
-        {
-            FixedPointImpl ret{};
-            ret.value = -value;
-            return ret;
-        }
-
-        FixedPointImpl &operator+=(const FixedPointImpl &obj)
-        {
-            value += obj.value;
-            return *this;
-        }
-        FixedPointImpl &operator-=(const FixedPointImpl &obj)
-        {
-            value -= obj.value;
-            return *this;
-        }
-        /*
-        TODO:
-        オーバーフローの可能性が10^shift^2 = 10^12の掛け算でかなり高くなってしまうので
-        一時的に浮動小数点に戻してから演算を行うことも考慮しておく
-        */
-        FixedPointImpl &operator*=(const FixedPointImpl &obj)
-        {
-            //直接変換でオーバーフローする場合は以下のように文字列に変換する
-            // D tmp{D(value.template str()) * D(obj.value.template str())};
-            // std::string str = tmp.template str();
-            // value = T(str);
-            // value /= shift;
-            value *= obj.value;
-            value /= shift; //整数で保持するため余分なshiftを除算する
-            return *this;
-        }
-        FixedPointImpl &operator/=(const FixedPointImpl &obj)
-        {
-            D inv{obj.getVal<D>()};
-            if (boost::math::isinf(inv))
-            {
-                inv = std::numeric_limits<D>::max();
-            }
-            D v = (this->getVal<D>() / inv) * shift;
-            value = v.template convert_to<T>();
-            return *this;
-        }
-        FixedPointImpl &operator%=(const FixedPointImpl &obj)
-        {
-            value %= obj.value;
-            return *this;
-        }
-        FixedPointImpl &operator++()
-        {
-            value += shift; // shift分ずれるので1*shift
-            return *this;
-        }
-        FixedPointImpl &operator--()
-        {
-            value -= shift; // shift分ずれるので1*shift
-            return *this;
-        }
-        bool operator==(const FixedPointImpl &obj) const noexcept
-        {
-            return (value - obj.value >= -1 and value - obj.value <= 1) ? true : false;
-        }
-        bool operator<(const FixedPointImpl &obj) const noexcept
-        {
-            return value < obj.value;
-        }
-        /*
-        標準入出力に入力するとShiftで割った結果が出力される。
-        FixedPoint a{5};
-        std::cout << a << std::endl;
-
-        5が出力される
-
-        */
-        friend std::ostream &operator<<(std::ostream &os, const FixedPointImpl &fp)
-        {
-            os << std::fixed;
-            os << std::setprecision(10);
-            os << fp.value.template convert_to<D>() / shift;
-            os << std::resetiosflags(std::ios_base::floatfield);
-            return os;
-        }
-    };
-    inline auto abs(const FixedPointImpl<> &x)
+        else
+            value = static_cast<T>(v * shift);
+    }
+    FixedPointImpl(const std::string &str)
     {
-        if (x < FixedPointImpl<>("0.0"))
+        D v_{str};
+        if (boost::math::isinf(v_))
         {
-            return -x;
+            value = static_cast<T>(std::numeric_limits<D>::max());
         }
         else
+            value = static_cast<T>(v_ * shift);
+    }
+    FixedPointImpl &operator=(const FixedPointImpl &obj)
+    {
+        value = obj.value;
+        return *this;
+    }
+    FixedPointImpl &operator=(FixedPointImpl &&obj)
+    {
+        value = std::move(obj.value);
+        return *this;
+    }
+    template <typename U = T>
+    U getVal() const
+    {
+        return value.template convert_to<U>();
+    }
+    std::string getStrVal() const
+    {
+        D ret{this->getVal<D>()};
+        if (boost::math::isinf(ret))
         {
-            return x;
+            ret = std::numeric_limits<D>::max();
         }
+        ret /= shift;
+        return ret.str(20, std::ios_base::fixed);
+    }
+    double getDoubleVal() const
+    {
+        auto ret{this->getVal<double>()};
+        if (boost::math::isinf(ret))
+        {
+            ret = std::numeric_limits<double>::max();
+        }
+        return ret / shift;
+    }
+    constexpr static auto getShift() noexcept { return shift; }
+    constexpr static auto getMaxInt() noexcept { return maxInt; }
+    FixedPointImpl getInv() const
+    {
+        D inv{this->getVal<D>()};
+        if (boost::math::isinf(inv))
+        {
+            inv = std::numeric_limits<D>::max();
+        }
+        return FixedPointImpl(D{shift} / inv);
+    }
+    FixedPointImpl operator-() const
+    {
+        FixedPointImpl ret{};
+        ret.value = -value;
+        return ret;
+    }
+
+    FixedPointImpl &operator+=(const FixedPointImpl &obj)
+    {
+        value += obj.value;
+        return *this;
+    }
+    FixedPointImpl &operator-=(const FixedPointImpl &obj)
+    {
+        value -= obj.value;
+        return *this;
+    }
+    /*
+    TODO:
+    オーバーフローの可能性が10^shift^2 = 10^12の掛け算でかなり高くなってしまうので
+    一時的に浮動小数点に戻してから演算を行うことも考慮しておく
+    */
+    FixedPointImpl &operator*=(const FixedPointImpl &obj)
+    {
+        //直接変換でオーバーフローする場合は以下のように文字列に変換する
+        // D tmp{D(value.template str()) * D(obj.value.template str())};
+        // std::string str = tmp.template str();
+        // value = T(str);
+        // value /= shift;
+        value *= obj.value;
+        value /= shift;  //整数で保持するため余分なshiftを除算する
+        return *this;
+    }
+    FixedPointImpl &operator/=(const FixedPointImpl &obj)
+    {
+        D inv{obj.getVal<D>()};
+        if (boost::math::isinf(inv))
+        {
+            inv = std::numeric_limits<D>::max();
+        }
+        D v = (this->getVal<D>() / inv) * shift;
+        value = v.template convert_to<T>();
+        return *this;
+    }
+    FixedPointImpl &operator%=(const FixedPointImpl &obj)
+    {
+        value %= obj.value;
+        return *this;
+    }
+    FixedPointImpl &operator++()
+    {
+        value += shift;  // shift分ずれるので1*shift
+        return *this;
+    }
+    FixedPointImpl &operator--()
+    {
+        value -= shift;  // shift分ずれるので1*shift
+        return *this;
+    }
+    bool operator==(const FixedPointImpl &obj) const noexcept
+    {
+        return (value - obj.value >= -1 and value - obj.value <= 1) ? true : false;
+    }
+    bool operator<(const FixedPointImpl &obj) const noexcept { return value < obj.value; }
+    /*
+    標準入出力に入力するとShiftで割った結果が出力される。
+    FixedPoint a{5};
+    std::cout << a << std::endl;
+
+    5が出力される
+
+    */
+    friend std::ostream &operator<<(std::ostream &os, const FixedPointImpl &fp)
+    {
+        os << std::fixed;
+        os << std::setprecision(10);
+        os << fp.value.template convert_to<D>() / shift;
+        os << std::resetiosflags(std::ios_base::floatfield);
+        return os;
+    }
+};
+inline auto abs(const FixedPointImpl<> &x)
+{
+    if (x < FixedPointImpl<>("0.0"))
+    {
+        return -x;
+    }
+    else
+    {
+        return x;
     }
 }
+}  // namespace qmpc::Utils
 using FixedPoint = qmpc::Utils::FixedPointImpl<>;

--- a/src/ComputationContainer/GBDT/SGBM.hpp
+++ b/src/ComputationContainer/GBDT/SGBM.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include "Share/Share.hpp"
-#include "Math/Math.hpp"
-#include "GBDT/SID3Regression.hpp"
 #include <set>
+
+#include "GBDT/SID3Regression.hpp"
+#include "Math/Math.hpp"
+#include "Share/Share.hpp"
 namespace qmpc::GBDT
 {
 

--- a/src/ComputationContainer/GBDT/SID3.cpp
+++ b/src/ComputationContainer/GBDT/SID3.cpp
@@ -1,248 +1,250 @@
 #include "SID3.hpp"
+
 #include <set>
 
 namespace qmpc::GBDT
 {
 
-    /**
-     * @brief 分割したデータの中で最も多い属性を返す
-     *
-     * @param U 目的変数で分割したデータ
-     * @return Share
-     */
-    Share SID3::majorityClass(const std::vector<std::vector<Share>> &U) const
+/**
+ * @brief 分割したデータの中で最も多い属性を返す
+ *
+ * @param U 目的変数で分割したデータ
+ * @return Share
+ */
+Share SID3::majorityClass(const std::vector<std::vector<Share>> &U) const
+{
+    std::vector<std::pair<int, int>> base_count;
+    int index = 0;
+    for (const auto &u : U)
     {
-        std::vector<std::pair<int, int>> base_count;
-        int index = 0;
-        for (const auto &u : U)
-        {
-            auto count_share = qmpc::Math::sum(u);
-            open(count_share);
-            auto count = recons(count_share);
-            base_count.emplace_back(static_cast<int>(count.getDoubleVal()), index);
-            index++;
-        }
-        auto [max_num, max_num_index] = *max_element(base_count.begin(), base_count.end());
-        // TODO:正確にShare化する必要があるが分類の場合はこのままで良い
-        Share ret = qmpc::Share::getConstantShare(FixedPoint(max_num_index));
-        return ret;
+        auto count_share = qmpc::Math::sum(u);
+        open(count_share);
+        auto count = recons(count_share);
+        base_count.emplace_back(static_cast<int>(count.getDoubleVal()), index);
+        index++;
     }
-    /**
-     * @brief 目的変数の値に従ってデータを分割する
-     *
-     * @return std::vector<std::vector<Share>>
-     */
-    std::vector<std::vector<Share>> SID3::splitTransaction() const
+    auto [max_num, max_num_index] = *max_element(base_count.begin(), base_count.end());
+    // TODO:正確にShare化する必要があるが分類の場合はこのままで良い
+    Share ret = qmpc::Share::getConstantShare(FixedPoint(max_num_index));
+    return ret;
+}
+/**
+ * @brief 目的変数の値に従ってデータを分割する
+ *
+ * @return std::vector<std::vector<Share>>
+ */
+std::vector<std::vector<Share>> SID3::splitTransaction() const
+{
+    //分割データ管理
+    // U[目標変数の取れる値][dataindex] = {1 or 0}
+    std::vector<std::vector<Share>> U;
+    for (const auto &target : targets)
     {
-        //分割データ管理
-        // U[目標変数の取れる値][dataindex] = {1 or 0}
-        std::vector<std::vector<Share>> U;
-        for (const auto &target : targets)
-        {
-            auto si = target * T;
-            U.emplace_back(si);
-        }
-        return U;
+        auto si = target * T;
+        U.emplace_back(si);
     }
+    return U;
+}
 
-    Share SID3::dot(const std::vector<Share> &x, const std::vector<Share> &y) const
+Share SID3::dot(const std::vector<Share> &x, const std::vector<Share> &y) const
+{
+    auto ret = x * y;
+    return qmpc::Math::sum(ret);
+}
+/**
+ * @brief 最大Gini係数の計数値と属性列インデックスを返す
+ *
+ * @param U
+ * @return auto
+ */
+auto SID3::getMaxGini(const std::vector<std::vector<Share>> &U) const
+{
+    auto gini_indexies = calcGini(U, R);
+    for (const auto &[gini_, index] : gini_indexies)
     {
-        auto ret = x * y;
-        return qmpc::Math::sum(ret);
+        // spdlog::info("gini_ is {}",gini_);
+        // spdlog::info("index is {}",index);
     }
-    /**
-     * @brief 最大Gini係数の計数値と属性列インデックスを返す
-     *
-     * @param U
-     * @return auto
-     */
-    auto SID3::getMaxGini(const std::vector<std::vector<Share>> &U) const
-    {
-        auto gini_indexies = calcGini(U, R);
-        for (const auto &[gini_, index] : gini_indexies)
-        {
-            // spdlog::info("gini_ is {}",gini_);
-            // spdlog::info("index is {}",index);
-        }
-        if (gini_indexies.empty())
-            return std::make_pair<double, int>(-1, -1);
-        auto ret = *std::max_element(gini_indexies.begin(), gini_indexies.end());
-        return ret;
-    }
+    if (gini_indexies.empty()) return std::make_pair<double, int>(-1, -1);
+    auto ret = *std::max_element(gini_indexies.begin(), gini_indexies.end());
+    return ret;
+}
 
-    /**
-     * @brief Gini不純度を計算する
-     * セキュアなGini係数計算らしいがいらない気がする
-     * 普通にGini係数計算にしたほうがいいかもしれない
-     * @return double
-     */
-    std::vector<std::pair<double, int>> SID3::calcGini(
-        const std::vector<std::vector<Share>> &U, const std::set<int> &R) const
-    {
-        //これが一番gini係数に近くなるらしい
-        constexpr int a = 8;
-        int attribute_size = R.size();
-        int target_value_size = std::size(targets);
+/**
+ * @brief Gini不純度を計算する
+ * セキュアなGini係数計算らしいがいらない気がする
+ * 普通にGini係数計算にしたほうがいいかもしれない
+ * @return double
+ */
+std::vector<std::pair<double, int>> SID3::calcGini(
+    const std::vector<std::vector<Share>> &U, const std::set<int> &R
+) const
+{
+    //これが一番gini係数に近くなるらしい
+    constexpr int a = 8;
+    int attribute_size = R.size();
+    int target_value_size = std::size(targets);
 
-        std::vector<Share> Gini;
-        std::vector<int> gini_index;
-        Gini.reserve(attribute_size);
-        gini_index.reserve(attribute_size);
-        for (const auto &r : R)
+    std::vector<Share> Gini;
+    std::vector<int> gini_index;
+    Gini.reserve(attribute_size);
+    gini_index.reserve(attribute_size);
+    for (const auto &r : R)
+    {
+        int attribute_value_size = std::size(S[r]);
+        for (int j = 0; j < attribute_value_size; ++j)
         {
-            int attribute_value_size = std::size(S[r]);
-            for (int j = 0; j < attribute_value_size; ++j)
+            Share y;
+            std::vector<Share> x(target_value_size);
+            for (int i = 0; i < target_value_size; ++i)
             {
-                Share y;
-                std::vector<Share> x(target_value_size);
-                for (int i = 0; i < target_value_size; ++i)
-                {
-                    x[i] = dot(U[i], S[r][j]);
-                    y += x[i];
-                }
-                auto xx_ = x * x;
-                auto xx = qmpc::Math::sum(xx_);
-                y *= FixedPoint(a);
-                y += 1;
-                Gini.emplace_back(xx / y);
-                gini_index.emplace_back(r);
+                x[i] = dot(U[i], S[r][j]);
+                y += x[i];
             }
+            auto xx_ = x * x;
+            auto xx = qmpc::Math::sum(xx_);
+            y *= FixedPoint(a);
+            y += 1;
+            Gini.emplace_back(xx / y);
+            gini_index.emplace_back(r);
         }
-        open(Gini);
-        auto recGini = recons(Gini);
-
-        std::vector<std::pair<double, int>> ret;
-        int index = 0;
-        for (auto &&gini : recGini)
-        {
-            ret.emplace_back(gini.getDoubleVal(), gini_index[index]);
-            index++;
-        }
-        return ret;
     }
-    /**
-     * @brief 情報重要度を出力する。（これを使って条件分割を最適化する）
-     *
-     * @return double
-     */
-    // double SID3::infomationGain(const std::vector<Share> &category)
-    // {
-    //     auto infoGain = I();
-    //     for (const auto &child : children)
-    //     {
-    //         infoGain -= child->I();
-    //     }
-    //     spdlog::info("information gain is {}",infoGain);
-    //     return infoGain;
-    // }
-    // /**
-    //  * @brief 指定した属性の個数を返す
-    //  *
-    //  * @param classes
-    //  * @return int
-    //  */
-    // int SID3::countClassAttr(const std::vector<Share> &classes)
-    // {
-    //     Share ret;
-    //     size_t n = std::size(T);
-    //     size_t classSize = std::size(classes);
-    //     for (int i = 0; i < n; ++i)
-    //     {
-    //         for (int class_index = 0; class_index < classSize; ++class_index)
-    //         {
-    //             Share zeroOrone = qmpc::Math::sum(S[i][class_index] * classes);
-    //             ret += zeroOrone;
-    //         }
-    //     }
-    //     open(ret);
-    //     auto count = recons(ret);
-    //     return static_cast<int>(count.getDoubleVal());
-    // }
-    /**
-     * @brief 決定木のJsonを返す（この関数を呼び出した元オブジェクトをルートとした）
-     *
-     * @return nlohmann::json
-     */
-    nlohmann::json SID3::createTreeJson() const
+    open(Gini);
+    auto recGini = recons(Gini);
+
+    std::vector<std::pair<double, int>> ret;
+    int index = 0;
+    for (auto &&gini : recGini)
     {
-        nlohmann::json ret;
-        ret["gini"] = gini_index;
-        ret["size"] = size;
-        ret["class"] = y.getDoubleVal();
-        auto arr = nlohmann::json::array();
-        for (const auto &child : children)
-        {
-            auto tree = child->createTreeJson();
-            arr.emplace_back(tree);
-        }
-        if (not isTerminal())
-            ret["att_class"] = att_class;
-        ret["children"] = arr;
-        return ret;
+        ret.emplace_back(gini.getDoubleVal(), gini_index[index]);
+        index++;
     }
-
-    /**
-     * @brief　このオブジェクトをルートとした決定木Fの予測値y^を返す。
-     *
-     * @param data 予測したいデータbitの配列にしたもの
-     * 注意：学習で使ったデータ配列ではなく[属性][属性値]の配列を扱う
-     * 例）1列目1,2,3 2列目1,2 3列目1,2,3,4 {{0,0,1}, { 0,1,} ,{0,0,1,0}}
-     * 　　この場合は1列目3 2列目2 3列目３　のデータという意味
-     * 学習で作成した分岐条件配列との内積が1の時に子ノードに進む
-     * 分岐がない場合のclassが予測値y^
-     * @return Share
-     */
-    Share SID3::predict(const std::vector<std::vector<Share>> &data) const
+    return ret;
+}
+/**
+ * @brief 情報重要度を出力する。（これを使って条件分割を最適化する）
+ *
+ * @return double
+ */
+// double SID3::infomationGain(const std::vector<Share> &category)
+// {
+//     auto infoGain = I();
+//     for (const auto &child : children)
+//     {
+//         infoGain -= child->I();
+//     }
+//     spdlog::info("information gain is {}",infoGain);
+//     return infoGain;
+// }
+// /**
+//  * @brief 指定した属性の個数を返す
+//  *
+//  * @param classes
+//  * @return int
+//  */
+// int SID3::countClassAttr(const std::vector<Share> &classes)
+// {
+//     Share ret;
+//     size_t n = std::size(T);
+//     size_t classSize = std::size(classes);
+//     for (int i = 0; i < n; ++i)
+//     {
+//         for (int class_index = 0; class_index < classSize; ++class_index)
+//         {
+//             Share zeroOrone = qmpc::Math::sum(S[i][class_index] * classes);
+//             ret += zeroOrone;
+//         }
+//     }
+//     open(ret);
+//     auto count = recons(ret);
+//     return static_cast<int>(count.getDoubleVal());
+// }
+/**
+ * @brief 決定木のJsonを返す（この関数を呼び出した元オブジェクトをルートとした）
+ *
+ * @return nlohmann::json
+ */
+nlohmann::json SID3::createTreeJson() const
+{
+    nlohmann::json ret;
+    ret["gini"] = gini_index;
+    ret["size"] = size;
+    ret["class"] = y.getDoubleVal();
+    auto arr = nlohmann::json::array();
+    for (const auto &child : children)
     {
-        if (isTerminal())
-        {
-            return y;
-        }
-        int index = 0;
-        auto attribute_value = data[att_class];
-        Share ret;
-        // spdlog::info("att class is {}",att_class);
-        // spdlog::info("attribute size {}",attribute_value.size());
-        // spdlog::info("children size is {}",children.size());
-        for (const auto &child : children)
-        {
-            ret += attribute_value[index] * child->predict(data);
-            index++;
-        }
-        return ret;
+        auto tree = child->createTreeJson();
+        arr.emplace_back(tree);
     }
-    /**
-     * @brief 決定木を作成する
-     *
-     * @return std::shared_ptr<SID3>
-     */
-    std::shared_ptr<SID3> SID3::createTree(
-        const std::vector<Share> &T,
-        const std::vector<std::vector<std::vector<Share>>> &S,
-        const std::vector<std::vector<Share>> &targets,
-        const std::set<int> &R)
+    if (not isTerminal()) ret["att_class"] = att_class;
+    ret["children"] = arr;
+    return ret;
+}
+
+/**
+ * @brief　このオブジェクトをルートとした決定木Fの予測値y^を返す。
+ *
+ * @param data 予測したいデータbitの配列にしたもの
+ * 注意：学習で使ったデータ配列ではなく[属性][属性値]の配列を扱う
+ * 例）1列目1,2,3 2列目1,2 3列目1,2,3,4 {{0,0,1}, { 0,1,} ,{0,0,1,0}}
+ * 　　この場合は1列目3 2列目2 3列目３　のデータという意味
+ * 学習で作成した分岐条件配列との内積が1の時に子ノードに進む
+ * 分岐がない場合のclassが予測値y^
+ * @return Share
+ */
+Share SID3::predict(const std::vector<std::vector<Share>> &data) const
+{
+    if (isTerminal())
     {
-        auto current = std::make_shared<SID3>(T, S, targets, R);
-        auto U = current->splitTransaction();
-        current->y = current->majorityClass(U);
-        // spdlog::info("T is {}",current->size);
-        // spdlog::info("R size is {}",R.size());
+        return y;
+    }
+    int index = 0;
+    auto attribute_value = data[att_class];
+    Share ret;
+    // spdlog::info("att class is {}",att_class);
+    // spdlog::info("attribute size {}",attribute_value.size());
+    // spdlog::info("children size is {}",children.size());
+    for (const auto &child : children)
+    {
+        ret += attribute_value[index] * child->predict(data);
+        index++;
+    }
+    return ret;
+}
+/**
+ * @brief 決定木を作成する
+ *
+ * @return std::shared_ptr<SID3>
+ */
+std::shared_ptr<SID3> SID3::createTree(
+    const std::vector<Share> &T,
+    const std::vector<std::vector<std::vector<Share>>> &S,
+    const std::vector<std::vector<Share>> &targets,
+    const std::set<int> &R
+)
+{
+    auto current = std::make_shared<SID3>(T, S, targets, R);
+    auto U = current->splitTransaction();
+    current->y = current->majorityClass(U);
+    // spdlog::info("T is {}",current->size);
+    // spdlog::info("R size is {}",R.size());
 
-        std::tie(current->gini_index, current->att_class) = current->getMaxGini(U);
+    std::tie(current->gini_index, current->att_class) = current->getMaxGini(U);
 
-        // spdlog::info("max gini is {}",current->gini_index);
-        // spdlog::info("gini index is {}",current->att_class);
-        // TODO:ここではデータ数に対してうまく調整したほうが良いかも
-        if (R.empty() or T.size() / 2u >= (unsigned int)(current->size) or 0 == current->size or current->gini_index <= eps)
-            return current;
-        auto R_ = R;
-        R_.erase(current->att_class);
-        for (size_t j = 0; j < S[current->att_class].size(); ++j)
-        {
-            auto T_ = T * S[current->att_class][j];
-            auto child = createTree(T_, S, targets, R_);
-            current->children.emplace_back(child);
-        }
+    // spdlog::info("max gini is {}",current->gini_index);
+    // spdlog::info("gini index is {}",current->att_class);
+    // TODO:ここではデータ数に対してうまく調整したほうが良いかも
+    if (R.empty() or T.size() / 2u >= (unsigned int)(current->size) or 0 == current->size
+        or current->gini_index <= eps)
         return current;
+    auto R_ = R;
+    R_.erase(current->att_class);
+    for (size_t j = 0; j < S[current->att_class].size(); ++j)
+    {
+        auto T_ = T * S[current->att_class][j];
+        auto child = createTree(T_, S, targets, R_);
+        current->children.emplace_back(child);
     }
-} // namespace qmpc::GBDT
+    return current;
+}
+}  // namespace qmpc::GBDT

--- a/src/ComputationContainer/GBDT/SID3.hpp
+++ b/src/ComputationContainer/GBDT/SID3.hpp
@@ -1,142 +1,148 @@
 #pragma once
-#include "Share/Share.hpp"
 #include "Math/Math.hpp"
+#include "Share/Share.hpp"
 
 namespace qmpc::GBDT
 {
-    using Share = qmpc::Share::Share<FixedPoint>;
-    /**
-     * @brief SID3に使用するデータクラス
-     * T：全データのビット　例）4つのデータなら{1,1,1,1}　-> 1番目を使うと {0,1,1,1}
-     * S：[属性列][属性値][index]
-     * target : [属性値][index]
-     *
-     */
-    class bitParam
+using Share = qmpc::Share::Share<FixedPoint>;
+/**
+ * @brief SID3に使用するデータクラス
+ * T：全データのビット　例）4つのデータなら{1,1,1,1}　-> 1番目を使うと {0,1,1,1}
+ * S：[属性列][属性値][index]
+ * target : [属性値][index]
+ *
+ */
+class bitParam
+{
+    //全体のデータ管理
+    std::vector<Share> T;
+    //ビットシェアデータ
+    // [属性列][属性値][dataindex] = {1 or 0}
+    // TODO：分類での使用の場合はデータ容量削減のため専用のクラスを使用を要検討
+    std::vector<std::vector<std::vector<Share>>> S;
+    //目的値分類 S0i
+    // target[目標変数の取れる値][dataindex] = {0 or 1}で保持する
+    std::vector<std::vector<Share>> targets;
+
+public:
+    bitParam() = delete;
+    bitParam(
+        const std::vector<Share> &T,
+        const std::vector<std::vector<std::vector<Share>>> &S,
+        const std::vector<std::vector<Share>> &targets
+    )
+        : T(T), S(S), targets(targets)
     {
-        //全体のデータ管理
-        std::vector<Share> T;
-        //ビットシェアデータ
-        // [属性列][属性値][dataindex] = {1 or 0}
-        // TODO：分類での使用の場合はデータ容量削減のため専用のクラスを使用を要検討
-        std::vector<std::vector<std::vector<Share>>> S;
-        //目的値分類 S0i
-        // target[目標変数の取れる値][dataindex] = {0 or 1}で保持する
-        std::vector<std::vector<Share>> targets;
+    }
+};
 
-    public:
-        bitParam() = delete;
-        bitParam(
-            const std::vector<Share> &T,
-            const std::vector<std::vector<std::vector<Share>>> &S,
-            const std::vector<std::vector<Share>> &targets)
-            : T(T), S(S), targets(targets)
-        {
-        }
-    };
+/**
+ * @brief ブースティング決定木　基本アルゴリズムはID3
+ * 入力：属性の分類配列R、データxの属性のbitベクトル、
+ * 基本的にはID3になるので分類は離散的になる
+ * 例）1.5,4.2,10.3,50 入力
+ * 　　1~5:0,6~10:1,10以上:2　分類項目
+ * 　　0,0,1,2,1 〜という値で扱う
+ * 　　データ数3とすると
+ * 　　attribute[0] ={1,0,1}
+ * 　　attribute[1] ={0,1,0}
+ * 　　attribute[2] ={0,0,0}
+ * 　　のようにする
+ */
 
-    /**
-     * @brief ブースティング決定木　基本アルゴリズムはID3
-     * 入力：属性の分類配列R、データxの属性のbitベクトル、
-     * 基本的にはID3になるので分類は離散的になる
-     * 例）1.5,4.2,10.3,50 入力
-     * 　　1~5:0,6~10:1,10以上:2　分類項目
-     * 　　0,0,1,2,1 〜という値で扱う
-     * 　　データ数3とすると
-     * 　　attribute[0] ={1,0,1}
-     * 　　attribute[1] ={0,1,0}
-     * 　　attribute[2] ={0,0,0}
-     * 　　のようにする
-     */
+class SID3
+{
+    //全体のデータ管理
+    std::vector<Share> T;
+    //ビットシェアデータ
+    // [属性列][属性値][dataindex] = {1 or 0}
+    // TODO：分類での使用の場合はデータ容量削減のため専用のクラスを使用を要検討
+    std::vector<std::vector<std::vector<Share>>> S;
+    //目的値分類 S0i
+    // target[目標変数の取れる値][dataindex] = {0 or 1}で保持する
+    std::vector<std::vector<Share>> targets;
+    /*
+    目的変数の値を分類するための変数
+    二値分類の場合は1,0
+    多値分類の場合は離散値のどれか
+    TODO：回帰の場合は不動小数等で保存する必要がある
+    */
+    int att_class;
+    //ジニ係数
+    double gini_index;
+    //現在の目的変数の予測属性値
+    int currentAttribute;
+    //トランザクションサイズ
+    int size;
+    //属性値管理
+    std::set<int> R;
+    //子ノード
+    // CART等の場合は２個で確定、ID3等では複数もあり
+    std::vector<std::shared_ptr<SID3>> children;
+    //予測値（回帰と分類で表示内容が異なる
+    Share y;
+    inline static const double eps = 0.000001;
 
-    class SID3
+private:
+    Share dot(const std::vector<Share> &, const std::vector<Share> &) const;
+    int countClassAttr(const std::vector<Share> &classes);
+    double infomationGain(const std::vector<Share> &category) const;
+    std::vector<std::pair<double, int>> calcGini(
+        const std::vector<std::vector<Share>> &U, const std::set<int> &R
+    ) const;
+    int dataSize() const
     {
-        //全体のデータ管理
-        std::vector<Share> T;
-        //ビットシェアデータ
-        // [属性列][属性値][dataindex] = {1 or 0}
-        // TODO：分類での使用の場合はデータ容量削減のため専用のクラスを使用を要検討
-        std::vector<std::vector<std::vector<Share>>> S;
-        //目的値分類 S0i
-        // target[目標変数の取れる値][dataindex] = {0 or 1}で保持する
-        std::vector<std::vector<Share>> targets;
-        /*
-        目的変数の値を分類するための変数
-        二値分類の場合は1,0
-        多値分類の場合は離散値のどれか
-        TODO：回帰の場合は不動小数等で保存する必要がある
-        */
-        int att_class;
-        //ジニ係数
-        double gini_index;
-        //現在の目的変数の予測属性値
-        int currentAttribute;
-        //トランザクションサイズ
-        int size;
-        //属性値管理
-        std::set<int> R;
-        //子ノード
-        // CART等の場合は２個で確定、ID3等では複数もあり
-        std::vector<std::shared_ptr<SID3>> children;
-        //予測値（回帰と分類で表示内容が異なる
-        Share y;
-        inline static const double eps = 0.000001;
+        auto T_size = qmpc::Math::sum(T);
+        open(T_size);
+        auto size = recons(T_size);
+        return static_cast<int>(size.getDoubleVal() + 0.1);
+    }
+    bool isTerminal() const { return children.empty(); }
+    std::vector<std::vector<Share>> splitTransaction() const;
+    Share majorityClass(const std::vector<std::vector<Share>> &U) const;
+    auto getMaxGini(const std::vector<std::vector<Share>> &U) const;
 
-    private:
-        Share dot(const std::vector<Share> &, const std::vector<Share> &) const;
-        int countClassAttr(const std::vector<Share> &classes);
-        double infomationGain(const std::vector<Share> &category) const;
-        std::vector<std::pair<double, int>> calcGini(
-            const std::vector<std::vector<Share>> &U, const std::set<int> &R) const;
-        int dataSize() const
-        {
-            auto T_size = qmpc::Math::sum(T);
-            open(T_size);
-            auto size = recons(T_size);
-            return static_cast<int>(size.getDoubleVal() + 0.1);
-        }
-        bool isTerminal() const { return children.empty(); }
-        std::vector<std::vector<Share>> splitTransaction() const;
-        Share majorityClass(const std::vector<std::vector<Share>> &U) const;
-        auto getMaxGini(const std::vector<std::vector<Share>> &U) const;
+public:
+    SID3() = delete;
+    //入力にはビットシェア化したデータとそれを分類するためのクラスビットシェアが必要
+    //分類される項目は事前に区分を決めておく
 
-    public:
-        SID3() = delete;
-        //入力にはビットシェア化したデータとそれを分類するためのクラスビットシェアが必要
-        //分類される項目は事前に区分を決めておく
-
-        SID3(
-            const std::vector<Share> &T,
-            const std::vector<std::vector<std::vector<Share>>> &bit_data,
-            const std::vector<std::vector<Share>> &targets,
-            const std::set<int> &R)
-            : T(T), S(bit_data), targets(targets), R(R), att_class(-1), y(FixedPoint(-1))
+    SID3(
+        const std::vector<Share> &T,
+        const std::vector<std::vector<std::vector<Share>>> &bit_data,
+        const std::vector<std::vector<Share>> &targets,
+        const std::set<int> &R
+    )
+        : T(T), S(bit_data), targets(targets), R(R), att_class(-1), y(FixedPoint(-1))
+    {
+        size = dataSize();
+    }
+    SID3(const nlohmann::json &json)
+        : gini_index(json["gini"])
+        , size(json["size"])
+        , y(Share(FixedPoint(json["class"].get<double>())))
+    {
+        if (json.find("att_class") != json.end())
         {
-            size = dataSize();
+            att_class = json["att_class"];
         }
-        SID3(const nlohmann::json &json)
-            : gini_index(json["gini"]), size(json["size"]), y(Share(FixedPoint(json["class"].get<double>())))
+        children.reserve(json["children"].size());
+        for (const auto &child_json : json["children"])
         {
-            if (json.find("att_class") != json.end())
-            {
-                att_class = json["att_class"];
-            }
-            children.reserve(json["children"].size());
-            for (const auto &child_json : json["children"])
-            {
-                children.emplace_back(std::make_unique<SID3>(child_json));
-            }
+            children.emplace_back(std::make_unique<SID3>(child_json));
         }
-        ~SID3()
-        {
-            // spdlog::info("destructor {}",size);
-        }
-        nlohmann::json createTreeJson() const;
-        Share predict(const std::vector<std::vector<Share>> &data) const;
-        static std::shared_ptr<SID3> createTree(
-            const std::vector<Share> &T,
-            const std::vector<std::vector<std::vector<Share>>> &S,
-            const std::vector<std::vector<Share>> &targets,
-            const std::set<int> &R);
-    };
-} // namespace qmpc::GBDT
+    }
+    ~SID3()
+    {
+        // spdlog::info("destructor {}",size);
+    }
+    nlohmann::json createTreeJson() const;
+    Share predict(const std::vector<std::vector<Share>> &data) const;
+    static std::shared_ptr<SID3> createTree(
+        const std::vector<Share> &T,
+        const std::vector<std::vector<std::vector<Share>>> &S,
+        const std::vector<std::vector<Share>> &targets,
+        const std::set<int> &R
+    );
+};
+}  // namespace qmpc::GBDT

--- a/src/ComputationContainer/GBDT/SID3Regression.cpp
+++ b/src/ComputationContainer/GBDT/SID3Regression.cpp
@@ -1,193 +1,191 @@
 #include "SID3Regression.hpp"
+
 #include <set>
 
 namespace qmpc::GBDT
 {
-    /**
-     * @brief この決定木での勾配を出力する
-     * 最小二乗の場合は(t_i - y_i)が勾配になる
-     *
-     * @return std::vector<Share>
-     */
-    std::vector<Share> SID3Regression::grad() const
+/**
+ * @brief この決定木での勾配を出力する
+ * 最小二乗の場合は(t_i - y_i)が勾配になる
+ *
+ * @return std::vector<Share>
+ */
+std::vector<Share> SID3Regression::grad() const
+{
+    if (isTerminal())
     {
-        if (isTerminal())
-        {
-            return grads;
-        }
-        std::vector<Share> ret(T.size());
-        for (const auto &child : children)
-        {
-            auto child_grad = child->grad();
-            for (int i = 0; i < size; ++i)
-            {
-                ret[i] += child_grad[i];
-            }
-        }
-        return ret;
+        return grads;
     }
+    std::vector<Share> ret(T.size());
+    for (const auto &child : children)
+    {
+        auto child_grad = child->grad();
+        for (int i = 0; i < size; ++i)
+        {
+            ret[i] += child_grad[i];
+        }
+    }
+    return ret;
+}
 
-    Share SID3Regression::dot(const std::vector<Share> &x, const std::vector<Share> &y) const
+Share SID3Regression::dot(const std::vector<Share> &x, const std::vector<Share> &y) const
+{
+    auto ret = x * y;
+    return qmpc::Math::sum(ret);
+}
+/**
+ * @brief 情報重要度を出力する。（これを使って条件分割を最適化する）
+ *
+ * @return Share
+ */
+Share SID3Regression::infomationGain(const std::vector<Share> &category) const
+{
+    auto mask = category * T;
+    auto mask_size_share = qmpc::Math::sum(mask);
+    open(mask_size_share);
+    auto mask_size = recons(mask_size_share);
+    if (mask_size == 0)
     {
-        auto ret = x * y;
-        return qmpc::Math::sum(ret);
+        // TODO:個数が0の場合はとりあえず最大値
+        return Share(FixedPoint(1000000000));
     }
-    /**
-     * @brief 情報重要度を出力する。（これを使って条件分割を最適化する）
-     *
-     * @return Share
-     */
-    Share SID3Regression::infomationGain(const std::vector<Share> &category) const
+    auto average = dot(mask, targets) / mask_size;
+    std::vector<Share> averageVec(T.size(), average);
+    auto average_mask = averageVec * mask;
+    auto target_mask = targets * mask;
+    Share ret;
+    for (int i = 0; i < T.size(); ++i)
     {
-        auto mask = category * T;
-        auto mask_size_share = qmpc::Math::sum(mask);
-        open(mask_size_share);
-        auto mask_size = recons(mask_size_share);
-        if (mask_size == 0)
-        {
-            // TODO:個数が0の場合はとりあえず最大値
-            return Share(FixedPoint(1000000000));
-        }
-        auto average = dot(mask, targets) / mask_size;
-        std::vector<Share> averageVec(T.size(), average);
-        auto average_mask = averageVec * mask;
-        auto target_mask = targets * mask;
-        Share ret;
-        for (int i = 0; i < T.size(); ++i)
-        {
-            Share cur = target_mask[i] - average_mask[i];
-            cur *= cur;
-            ret += cur;
-        }
-        ret /= FixedPoint(2);
-        return ret;
+        Share cur = target_mask[i] - average_mask[i];
+        cur *= cur;
+        ret += cur;
     }
-    /**
-     * @brief 最適な分割の説明変数を選択して返却する
-     *
-     * @return std::pair<double, int> 最小二乗誤差、インデックス
-     */
-    std::pair<double, int> SID3Regression::IG() const
+    ret /= FixedPoint(2);
+    return ret;
+}
+/**
+ * @brief 最適な分割の説明変数を選択して返却する
+ *
+ * @return std::pair<double, int> 最小二乗誤差、インデックス
+ */
+std::pair<double, int> SID3Regression::IG() const
+{
+    std::vector<std::pair<double, int>> categoryErrors;
+    for (const auto &r : R)
     {
-        std::vector<std::pair<double, int>> categoryErrors;
-        for (const auto &r : R)
+        Share sumError;
+        auto categories = S[r];
+        for (auto &&category : categories)
         {
-            Share sumError;
-            auto categories = S[r];
-            for (auto &&category : categories)
-            {
-                sumError += infomationGain(category);
-            }
-            open(sumError);
-            auto categoryError = recons(sumError);
-            categoryErrors.emplace_back(categoryError.getDoubleVal(), r);
+            sumError += infomationGain(category);
         }
-        if (categoryErrors.empty())
-            return {-1, -1};
-        return *min_element(categoryErrors.begin(), categoryErrors.end());
+        open(sumError);
+        auto categoryError = recons(sumError);
+        categoryErrors.emplace_back(categoryError.getDoubleVal(), r);
     }
-    // /**
-    //  * @brief 指定した属性の個数を返す
-    //  *
-    //  * @param classes
-    //  * @return int
-    //  */
-    // int SID3Regression::countClassAttr(const std::vector<Share> &classes)
-    // {
-    //     Share ret;
-    //     size_t n = std::size(T);
-    //     size_t classSize = std::size(classes);
-    //     for (int i = 0; i < n; ++i)
-    //     {
-    //         for (int class_index = 0; class_index < classSize; ++class_index)
-    //         {
-    //             Share zeroOrone = qmpc::Math::sum(S[i][class_index] * classes);
-    //             ret += zeroOrone;
-    //         }
-    //     }
-    //     open(ret);
-    //     auto count = recons(ret);
-    //     return static_cast<int>(count.getDoubleVal());
-    // }
-    /**
-     * @brief 決定木のJsonを返す（この関数を呼び出した元オブジェクトをルートとした）
-     *
-     * @return nlohmann::json
-     */
-    nlohmann::json SID3Regression::createTreeJson() const
+    if (categoryErrors.empty()) return {-1, -1};
+    return *min_element(categoryErrors.begin(), categoryErrors.end());
+}
+// /**
+//  * @brief 指定した属性の個数を返す
+//  *
+//  * @param classes
+//  * @return int
+//  */
+// int SID3Regression::countClassAttr(const std::vector<Share> &classes)
+// {
+//     Share ret;
+//     size_t n = std::size(T);
+//     size_t classSize = std::size(classes);
+//     for (int i = 0; i < n; ++i)
+//     {
+//         for (int class_index = 0; class_index < classSize; ++class_index)
+//         {
+//             Share zeroOrone = qmpc::Math::sum(S[i][class_index] * classes);
+//             ret += zeroOrone;
+//         }
+//     }
+//     open(ret);
+//     auto count = recons(ret);
+//     return static_cast<int>(count.getDoubleVal());
+// }
+/**
+ * @brief 決定木のJsonを返す（この関数を呼び出した元オブジェクトをルートとした）
+ *
+ * @return nlohmann::json
+ */
+nlohmann::json SID3Regression::createTreeJson() const
+{
+    nlohmann::json ret;
+    ret["size"] = size;
+    if (not isTerminal()) ret["att_class"] = att_class;
+    ret["error_value"] = error_value;
+    auto arr = nlohmann::json::array();
+    for (const auto &child : children)
     {
-        nlohmann::json ret;
-        ret["size"] = size;
-        if (not isTerminal())
-            ret["att_class"] = att_class;
-        ret["error_value"] = error_value;
-        auto arr = nlohmann::json::array();
-        for (const auto &child : children)
-        {
-            auto tree = child->createTreeJson();
-            arr.emplace_back(tree);
-        }
-        if (isTerminal())
-            ret["y_dash"] = y.getVal().getDoubleVal();
-        ret["children"] = arr;
-        return ret;
+        auto tree = child->createTreeJson();
+        arr.emplace_back(tree);
     }
+    if (isTerminal()) ret["y_dash"] = y.getVal().getDoubleVal();
+    ret["children"] = arr;
+    return ret;
+}
 
-    /**
-     * @brief　このオブジェクトをルートとした決定木Fの予測値y^を返す。
-     *
-     * @param data 予測したいデータbitの配列にしたもの
-     * 注意：学習で使ったデータ配列ではなく[属性][属性値]の配列を扱う
-     * 例）1列目1,2,3 2列目1,2 3列目1,2,3,4 {{0,0,1}, { 0,1,} ,{0,0,1,0}}
-     * 　　この場合は1列目3 2列目2 3列目３　のデータという意味
-     * 学習で作成した分岐条件配列との内積が1の時に子ノードに進む
-     * 分岐がない場合のclassが予測値y^
-     * @return Share
-     */
-    Share SID3Regression::predict(const std::vector<std::vector<Share>> &data) const
+/**
+ * @brief　このオブジェクトをルートとした決定木Fの予測値y^を返す。
+ *
+ * @param data 予測したいデータbitの配列にしたもの
+ * 注意：学習で使ったデータ配列ではなく[属性][属性値]の配列を扱う
+ * 例）1列目1,2,3 2列目1,2 3列目1,2,3,4 {{0,0,1}, { 0,1,} ,{0,0,1,0}}
+ * 　　この場合は1列目3 2列目2 3列目３　のデータという意味
+ * 学習で作成した分岐条件配列との内積が1の時に子ノードに進む
+ * 分岐がない場合のclassが予測値y^
+ * @return Share
+ */
+Share SID3Regression::predict(const std::vector<std::vector<Share>> &data) const
+{
+    if (isTerminal())
     {
-        if (isTerminal())
-        {
-            return y;
-        }
-        int index = 0;
-        auto attribute_value = data[att_class];
-        Share ret;
-        // spdlog::info("att class is {}",att_class);
-        // spdlog::info("sttribute size {}",attribute_value.size());
-        // spdlog::info("children size is {}",children.size());
-        for (const auto &child : children)
-        {
-            ret += attribute_value[index] * child->predict(data);
-            index++;
-        }
-        return ret;
+        return y;
     }
-    /**
-     * @brief 決定木を作成する
-     *
-     * @return std::shared_ptr<SID3Regression>
-     */
-    std::shared_ptr<SID3Regression> SID3Regression::createTree(
-        const std::vector<Share> &T,
-        const std::vector<std::vector<std::vector<Share>>> &S,
-        const std::vector<Share> &targets,
-        const std::set<int> &R)
+    int index = 0;
+    auto attribute_value = data[att_class];
+    Share ret;
+    // spdlog::info("att class is {}",att_class);
+    // spdlog::info("sttribute size {}",attribute_value.size());
+    // spdlog::info("children size is {}",children.size());
+    for (const auto &child : children)
     {
-        auto current = std::make_shared<SID3Regression>(T, S, targets, R);
-        std::tie(current->error_value, current->att_class) = current->IG();
+        ret += attribute_value[index] * child->predict(data);
+        index++;
+    }
+    return ret;
+}
+/**
+ * @brief 決定木を作成する
+ *
+ * @return std::shared_ptr<SID3Regression>
+ */
+std::shared_ptr<SID3Regression> SID3Regression::createTree(
+    const std::vector<Share> &T,
+    const std::vector<std::vector<std::vector<Share>>> &S,
+    const std::vector<Share> &targets,
+    const std::set<int> &R
+)
+{
+    auto current = std::make_shared<SID3Regression>(T, S, targets, R);
+    std::tie(current->error_value, current->att_class) = current->IG();
 
-        // TODO:ここではデータ数に対してうまく調整したほうが良いかも
-        if (R.empty() or (T.size() >= 3 * current->size) or (0 == current->size))
-            return current;
-        auto R_ = R;
-        R_.erase(current->att_class);
-        for (int j = 0; j < S[current->att_class].size(); ++j)
-        {
-            auto T_ = T * S[current->att_class][j];
-            auto child = createTree(T_, S, targets, R_);
-            current->children.emplace_back(child);
-        }
-        return current;
+    // TODO:ここではデータ数に対してうまく調整したほうが良いかも
+    if (R.empty() or (T.size() >= 3 * current->size) or (0 == current->size)) return current;
+    auto R_ = R;
+    R_.erase(current->att_class);
+    for (int j = 0; j < S[current->att_class].size(); ++j)
+    {
+        auto T_ = T * S[current->att_class][j];
+        auto child = createTree(T_, S, targets, R_);
+        current->children.emplace_back(child);
     }
-} // namespace qmpc::GBDT
+    return current;
+}
+}  // namespace qmpc::GBDT

--- a/src/ComputationContainer/GBDT/SID3Regression.hpp
+++ b/src/ComputationContainer/GBDT/SID3Regression.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "Share/Share.hpp"
 #include "Math/Math.hpp"
+#include "Share/Share.hpp"
 
 namespace qmpc::GBDT
 {

--- a/src/ComputationContainer/Job/JobBase.hpp
+++ b/src/ComputationContainer/Job/JobBase.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <vector>
-#include <map>
 #include <atomic>
 #include <list>
-#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
-#include "Share/Share.hpp"
+#include <map>
+#include <vector>
+
 #include "Client/ComputationToDbGate/Client.hpp"
 #include "Client/ComputationToDbGate/ValueTable.hpp"
-#include "JobStatus.hpp"
 #include "JobParameter.hpp"
-
+#include "JobStatus.hpp"
 #include "LogHeader/Logger.hpp"
+#include "Share/Share.hpp"
+#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
 
 namespace qmpc::Job
 {

--- a/src/ComputationContainer/Job/JobManager.hpp
+++ b/src/ComputationContainer/Job/JobManager.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
-#include <vector>
 #include <future>
+#include <memory>
 #include <thread>
 #include <unordered_map>
-#include <memory>
-#include "ConfigParse/ConfigParse.hpp"
-#include "TransactionQueue/TransactionQueue.hpp"
-#include "JobBase.hpp"
-#include "JobSelector.hpp"
-#include "JobParameter.hpp"
-#include "Client/ComputationToComputationContainerForJob/Client.hpp"
+#include <vector>
 
+#include "Client/ComputationToComputationContainerForJob/Client.hpp"
+#include "ConfigParse/ConfigParse.hpp"
+#include "JobBase.hpp"
+#include "JobParameter.hpp"
+#include "JobSelector.hpp"
 #include "LogHeader/Logger.hpp"
+#include "TransactionQueue/TransactionQueue.hpp"
 
 namespace qmpc::Job
 {

--- a/src/ComputationContainer/Job/JobSelector.hpp
+++ b/src/ComputationContainer/Job/JobSelector.hpp
@@ -1,16 +1,16 @@
 #pragma once
 #include <memory>
-#include "Math/Math.hpp"
+
+#include "JobParameter.hpp"
 #include "Jobs/CorrelJob.hpp"
-#include "Jobs/MathJob.hpp"
 #include "Jobs/JoinTableJob.hpp"
 #include "Jobs/LinearRegressionJob.hpp"
 #include "Jobs/LogisticRegressionJob.hpp"
+#include "Jobs/MathJob.hpp"
 #include "Jobs/MeshCodeJob.hpp"
 #include "Jobs/SID3Job.hpp"
-#include "JobParameter.hpp"
-
 #include "LogHeader/Logger.hpp"
+#include "Math/Math.hpp"
 #include "external/Proto/common_types/common_types.pb.h"
 
 namespace qmpc::Job

--- a/src/ComputationContainer/Job/JobStatus.hpp
+++ b/src/ComputationContainer/Job/JobStatus.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <stdexcept>
+#include <boost/format.hpp>
 #include <optional>
+#include <stdexcept>
 
 #include "Client/ComputationToDbGate/Client.hpp"
-#include "external/Proto/common_types/common_types.pb.h"
-#include <boost/format.hpp>
 #include "Logging/Logger.hpp"
+#include "external/Proto/common_types/common_types.pb.h"
 namespace qmpc::Job
 {
 // Protocol Buffers の定義を引っ張ってくる

--- a/src/ComputationContainer/Job/Jobs/CorrelJob.hpp
+++ b/src/ComputationContainer/Job/Jobs/CorrelJob.hpp
@@ -2,9 +2,9 @@
 
 #include <list>
 
-#include "Share/Share.hpp"
-#include "Math/Math.hpp"
 #include "Job/JobBase.hpp"
+#include "Math/Math.hpp"
+#include "Share/Share.hpp"
 
 namespace qmpc::Job
 {

--- a/src/ComputationContainer/Job/Jobs/JoinTableJob.hpp
+++ b/src/ComputationContainer/Job/Jobs/JoinTableJob.hpp
@@ -2,9 +2,9 @@
 #include <functional>
 #include <unordered_set>
 
-#include "Share/Share.hpp"
-#include "Math/Math.hpp"
 #include "Job/JobBase.hpp"
+#include "Math/Math.hpp"
+#include "Share/Share.hpp"
 
 namespace qmpc::Job
 {

--- a/src/ComputationContainer/Job/Jobs/LinearRegressionJob.hpp
+++ b/src/ComputationContainer/Job/Jobs/LinearRegressionJob.hpp
@@ -2,8 +2,8 @@
 
 #include <list>
 
-#include "Job/JobBase.hpp"
 #include "ConfigParse/ConfigParse.hpp"
+#include "Job/JobBase.hpp"
 #include "Share/Matrix.hpp"
 
 namespace qmpc::Job

--- a/src/ComputationContainer/Job/Jobs/LogisticRegressionJob.hpp
+++ b/src/ComputationContainer/Job/Jobs/LogisticRegressionJob.hpp
@@ -1,16 +1,15 @@
 #pragma once
 
-#include <list>
 #include <iostream>
+#include <list>
 
 #include "Job/JobBase.hpp"
-#include "Share/Matrix.hpp"
 #include "Math/Math.hpp"
+#include "Share/Matrix.hpp"
 // TODO: 最適化関数と損失関数は全て同じインクルードにまとめる
-#include "Optimizer/optimizer.hpp"
-#include "ObjectiveFunction/CrossEntropyError.hpp"
-
 #include "LogHeader/Logger.hpp"
+#include "ObjectiveFunction/CrossEntropyError.hpp"
+#include "Optimizer/optimizer.hpp"
 
 namespace qmpc::Job
 {

--- a/src/ComputationContainer/Job/Jobs/MathJob.hpp
+++ b/src/ComputationContainer/Job/Jobs/MathJob.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "Share/Share.hpp"
-#include "Math/Math.hpp"
-#include "Job/JobBase.hpp"
 #include <functional>
+
+#include "Job/JobBase.hpp"
+#include "Math/Math.hpp"
+#include "Share/Share.hpp"
 
 namespace qmpc::Job
 {

--- a/src/ComputationContainer/Job/Jobs/MeshCodeJob.hpp
+++ b/src/ComputationContainer/Job/Jobs/MeshCodeJob.hpp
@@ -2,8 +2,8 @@
 
 #include <list>
 
-#include "Share/Share.hpp"
 #include "Job/JobBase.hpp"
+#include "Share/Share.hpp"
 
 namespace qmpc::Job
 {

--- a/src/ComputationContainer/Job/Jobs/SID3Job.hpp
+++ b/src/ComputationContainer/Job/Jobs/SID3Job.hpp
@@ -2,10 +2,10 @@
 
 #include <list>
 
-#include "Job/JobBase.hpp"
 #include "ConfigParse/ConfigParse.hpp"
-#include "Share/Matrix.hpp"
 #include "GBDT/SID3.hpp"
+#include "Job/JobBase.hpp"
+#include "Share/Matrix.hpp"
 
 namespace qmpc::Job
 {

--- a/src/ComputationContainer/LogHeader/Logger.hpp
+++ b/src/ComputationContainer/LogHeader/Logger.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
-#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
+//clang-format off
+#include "spdlog/fmt/ostr.h"
+//clang-format on

--- a/src/ComputationContainer/LogHeader/Logger.hpp
+++ b/src/ComputationContainer/LogHeader/Logger.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-#include "spdlog/spdlog.h"
-#include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/fmt/ostr.h"
+#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/spdlog.h"

--- a/src/ComputationContainer/Logging/Logger.hpp
+++ b/src/ComputationContainer/Logging/Logger.hpp
@@ -1,88 +1,92 @@
 #pragma once
-#include <boost/stacktrace.hpp>
 #include <boost/exception/all.hpp>
 #include <boost/format.hpp>
-#include <sstream>
-#include <iomanip>
+#include <boost/stacktrace.hpp>
 #include <ctime>
-
+#include <iomanip>
+#include <sstream>
 #include <variant>
 
 namespace qmpc
 {
-    // TODO: std::coutをspdlogに差し替え
-    // TODO: クラスにする必要がないが念のためクラス構造にしておく
-    class Log
+// TODO: std::coutをspdlogに差し替え
+// TODO: クラスにする必要がないが念のためクラス構造にしておく
+class Log
+{
+    enum class LogLevel
     {
-        enum class LogLevel
-        {
-            Info,
-            Debug,
-            Error
-        };
-        Log::LogLevel level;
-        static inline std::unordered_map<qmpc::Log::LogLevel, std::string> logLevelStr = {
-            {Log::LogLevel::Info, "INFO"},
-            {Log::LogLevel::Debug, "DEBUG"},
-            {Log::LogLevel::Error, "ERROR"}};
+        Info,
+        Debug,
+        Error
+    };
+    Log::LogLevel level;
+    static inline std::unordered_map<qmpc::Log::LogLevel, std::string> logLevelStr = {
+        {Log::LogLevel::Info, "INFO"},
+        {Log::LogLevel::Debug, "DEBUG"},
+        {Log::LogLevel::Error, "ERROR"}};
 
-    private:
-        std::string getTime() const
-        {
+private:
+    std::string getTime() const
+    {
+        char tt[100];
+        auto t = time(nullptr);
+        tm local;
+        [[maybe_unused]] auto ret =
+            localtime_r(&t, &local);  // ローカル時間(タイムゾーンに合わせた時間)を取得
+        // TODO:osの環境変数にタイムゾーンの設定がない場合は時間がずれる
+        strftime(tt, 256, "%Y-%m-%d %H:%M:%S%z", &local);
+        return std::string(tt);
+    }
+    template <typename First, typename... Args>
+    void write(std::ostream &os, First &&first, Args &&...args) const
+    {
+        std::stringstream ss;
+        const char *delim = "|";
+        ss << first;
+        ((ss << delim << args), ...);
+        os << ss.str() << std::endl;
+    }
 
-            char tt[100];
-            auto t = time(nullptr);
-            tm local;
-            [[maybe_unused]] auto ret = localtime_r(&t, &local); // ローカル時間(タイムゾーンに合わせた時間)を取得
-            // TODO:osの環境変数にタイムゾーンの設定がない場合は時間がずれる
-            strftime(tt, 256, "%Y-%m-%d %H:%M:%S%z", &local);
-            return std::string(tt);
-        }
-        template <typename First, typename... Args>
-        void write(std::ostream &os, First &&first, Args &&...args) const
-        {
-            std::stringstream ss;
-            const char *delim = "|";
-            ss << first;
-            ((ss << delim << args), ...);
-            os << ss.str() << std::endl;
-        }
+public:
+    using traced = boost::error_info<struct tag_stacktrace, boost::stacktrace::stacktrace>;
+    Log() = delete;
+    Log &operator=(Log &&) = delete;
+    Log &operator=(const Log &) = delete;
+    constexpr Log(Log::LogLevel level) : level(level) {}
+    //例外生成用関数
+    template <class E>
+    static void throw_with_trace(const E &e)
+    {
+        throw boost::enable_error_info(e) << traced(boost::stacktrace::stacktrace());
+    }
 
-    public:
-        using traced = boost::error_info<struct tag_stacktrace, boost::stacktrace::stacktrace>;
-        Log() = delete;
-        Log &operator=(Log &&) = delete;
-        Log &operator=(const Log &) = delete;
-        constexpr Log(Log::LogLevel level) : level(level) {}
-        //例外生成用関数
-        template <class E>
-        static void throw_with_trace(const E &e)
-        {
-            throw boost::enable_error_info(e) << traced(boost::stacktrace::stacktrace());
-        }
+    template <typename... Args>
+    static void writeLog(Log::LogLevel level, std::ostream &os, Args &&...args)
+    {
+        Log log(level);
+        log.write(os, log.getTime(), Log::logLevelStr[level], std::forward<Args>(args)...);
+    }
+    template <typename... Args>
+    static void Info(Args &&...message)
+    {
+        writeLog(Log::LogLevel::Info, std::cout, std::forward<Args>(message)...);
+    }
 
-        template <typename... Args>
-        static void writeLog(Log::LogLevel level, std::ostream &os, Args &&...args)
-        {
-            Log log(level);
-            log.write(os, log.getTime(), Log::logLevelStr[level], std::forward<Args>(args)...);
-        }
-        template <typename... Args>
-        static void Info(Args &&...message)
-        {
-            writeLog(Log::LogLevel::Info, std::cout, std::forward<Args>(message)...);
-        }
+    template <typename... Args>
+    static void Debug(Args &&...message)
+    {
+        writeLog(
+            Log::LogLevel::Debug,
+            std::cout,
+            boost::stacktrace::stacktrace()[0],
+            std::forward<Args>(message)...
+        );
+    }
+    template <typename... Args>
+    static void Error(Args &&...message)
+    {
+        writeLog(Log::LogLevel::Error, std::cerr, std::forward<Args>(message)...);
+    }
 
-        template <typename... Args>
-        static void Debug(Args &&...message)
-        {
-            writeLog(Log::LogLevel::Debug, std::cout, boost::stacktrace::stacktrace()[0], std::forward<Args>(message)...);
-        }
-        template <typename... Args>
-        static void Error(Args &&...message)
-        {
-            writeLog(Log::LogLevel::Error, std::cerr, std::forward<Args>(message)...);
-        }
-
-    }; // end Log
-}
+};  // end Log
+}  // namespace qmpc

--- a/src/ComputationContainer/Logging/Logger.hpp
+++ b/src/ComputationContainer/Logging/Logger.hpp
@@ -4,6 +4,7 @@
 #include <boost/stacktrace.hpp>
 #include <ctime>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <variant>
 

--- a/src/ComputationContainer/Math/Math.cpp
+++ b/src/ComputationContainer/Math/Math.cpp
@@ -1,4 +1,5 @@
 #include "Math.hpp"
+
 #include "LogHeader/Logger.hpp"
 #include "Logging/Logger.hpp"
 namespace qmpc::Math

--- a/src/ComputationContainer/Math/Math.hpp
+++ b/src/ComputationContainer/Math/Math.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include <string>
+#include <algorithm>
 #include <initializer_list>
 #include <iostream>
+#include <string>
 #include <vector>
-#include <algorithm>
 
 #include "Share/Share.hpp"
 

--- a/src/ComputationContainer/Model/ModelBase.cpp
+++ b/src/ComputationContainer/Model/ModelBase.cpp
@@ -1,9 +1,8 @@
 #include "ModelBase.hpp"
 
 #include "Client/ComputationToDbGate/Client.hpp"
-#include "nlohmann/json.hpp"
-
 #include "LogHeader/Logger.hpp"
+#include "nlohmann/json.hpp"
 
 namespace qmpc::Model
 {

--- a/src/ComputationContainer/Model/ModelBase.hpp
+++ b/src/ComputationContainer/Model/ModelBase.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <vector>
 #include <string>
-#include "Share/Share.hpp"
-#include "Client/ComputationToDbGate/ValueTable.hpp"
-#include "Client/ComputationToDbGate/Client.hpp"
-#include "Job/JobStatus.hpp"
+#include <vector>
 
+#include "Client/ComputationToDbGate/Client.hpp"
+#include "Client/ComputationToDbGate/ValueTable.hpp"
+#include "Job/JobStatus.hpp"
+#include "Share/Share.hpp"
 #include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
 
 namespace qmpc::Model

--- a/src/ComputationContainer/Model/ModelManager.hpp
+++ b/src/ComputationContainer/Model/ModelManager.hpp
@@ -1,18 +1,16 @@
 #pragma once
 
-#include <vector>
 #include <memory>
-
-#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
-#include "external/Proto/common_types/common_types.pb.h"
-
-#include "Model/ModelBase.hpp"
-#include "Model/Models/LinearRegression.hpp"
-#include "Model/Models/LogisticRegression.hpp"
-#include "Model/Models/DecisionTree.hpp"
-#include "Model/Models/SID3Model.hpp"
+#include <vector>
 
 #include "LogHeader/Logger.hpp"
+#include "Model/ModelBase.hpp"
+#include "Model/Models/DecisionTree.hpp"
+#include "Model/Models/LinearRegression.hpp"
+#include "Model/Models/LogisticRegression.hpp"
+#include "Model/Models/SID3Model.hpp"
+#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
+#include "external/Proto/common_types/common_types.pb.h"
 
 namespace qmpc::Model
 {

--- a/src/ComputationContainer/Model/Models/DecisionTree.hpp
+++ b/src/ComputationContainer/Model/Models/DecisionTree.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "nlohmann/json.hpp"
-#include "Model/ModelBase.hpp"
 #include "Client/ComputationToDbGate/Client.hpp"
 #include "ConfigParse/ConfigParse.hpp"
-#include "Share/Compare.hpp"
 #include "Math/Math.hpp"
+#include "Model/ModelBase.hpp"
+#include "Share/Compare.hpp"
+#include "nlohmann/json.hpp"
 
 namespace qmpc::Model
 {

--- a/src/ComputationContainer/Model/Models/LinearRegression.hpp
+++ b/src/ComputationContainer/Model/Models/LinearRegression.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Model/ModelBase.hpp"
 #include "Client/ComputationToDbGate/Client.hpp"
 #include "ConfigParse/ConfigParse.hpp"
+#include "Model/ModelBase.hpp"
 
 namespace qmpc::Model
 {

--- a/src/ComputationContainer/Model/Models/LogisticRegression.hpp
+++ b/src/ComputationContainer/Model/Models/LogisticRegression.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
+#include "Client/ComputationToDbGate/Client.hpp"
+#include "ConfigParse/ConfigParse.hpp"
+#include "Math/Math.hpp"
 #include "Model/ModelBase.hpp"
 #include "Model/Models/LinearRegression.hpp"
-
-#include "ConfigParse/ConfigParse.hpp"
-#include "Share/Networking.hpp"
 #include "Server/ComputationToComputationContainer/Server.hpp"
-#include "Client/ComputationToDbGate/Client.hpp"
-#include "Math/Math.hpp"
+#include "Share/Networking.hpp"
 
 namespace qmpc::Model
 {

--- a/src/ComputationContainer/Model/Models/SID3Model.hpp
+++ b/src/ComputationContainer/Model/Models/SID3Model.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Model/ModelBase.hpp"
 #include "Client/ComputationToDbGate/Client.hpp"
 #include "ConfigParse/ConfigParse.hpp"
 #include "GBDT/SID3.hpp"
+#include "Model/ModelBase.hpp"
 
 namespace qmpc::Model
 {

--- a/src/ComputationContainer/ObjectiveFunction/CrossEntropyError.hpp
+++ b/src/ComputationContainer/ObjectiveFunction/CrossEntropyError.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include "Share/Share.hpp"
-#include "ObjectiveFunctionInterface.hpp"
-#include "Logging/Logger.hpp"
 #include <random>
+
+#include "Logging/Logger.hpp"
+#include "ObjectiveFunctionInterface.hpp"
+#include "Share/Share.hpp"
 namespace qmpc::ObjectiveFunction
 {
 /*

--- a/src/ComputationContainer/ObjectiveFunction/ObjectiveFunctionInterface.hpp
+++ b/src/ComputationContainer/ObjectiveFunction/ObjectiveFunctionInterface.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+
 #include "Share/Share.hpp"
 
 namespace qmpc::ObjectiveFunction

--- a/src/ComputationContainer/Optimizer/Adam.hpp
+++ b/src/ComputationContainer/Optimizer/Adam.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <vector>
 #include <iostream>
-#include "Share/Share.hpp"
+#include <vector>
+
 #include "OptInterface.hpp"
+#include "Share/Share.hpp"
 
 namespace qmpc::Optimizer
 {

--- a/src/ComputationContainer/Optimizer/GradientDescent.hpp
+++ b/src/ComputationContainer/Optimizer/GradientDescent.hpp
@@ -1,9 +1,10 @@
 #pragma once
-#include <vector>
-#include <memory>
 #include <iostream>
-#include "Share/Share.hpp"
+#include <memory>
+#include <vector>
+
 #include "OptInterface.hpp"
+#include "Share/Share.hpp"
 namespace qmpc::Optimizer
 {
 /*

--- a/src/ComputationContainer/Optimizer/Momentum.hpp
+++ b/src/ComputationContainer/Optimizer/Momentum.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <vector>
 #include <iostream>
-#include "Share/Share.hpp"
+#include <vector>
+
 #include "OptInterface.hpp"
+#include "Share/Share.hpp"
 
 namespace qmpc::Optimizer
 {

--- a/src/ComputationContainer/Optimizer/SGD.hpp
+++ b/src/ComputationContainer/Optimizer/SGD.hpp
@@ -1,9 +1,10 @@
 #pragma once
-#include <vector>
-#include <memory>
 #include <iostream>
-#include "Share/Share.hpp"
+#include <memory>
+#include <vector>
+
 #include "OptInterface.hpp"
+#include "Share/Share.hpp"
 namespace qmpc::Optimizer
 {
 

--- a/src/ComputationContainer/Optimizer/optimizer.hpp
+++ b/src/ComputationContainer/Optimizer/optimizer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Optimizer/GradientDescent.hpp"
-#include "Optimizer/SGD.hpp"
-#include "Optimizer/Momentum.hpp"
 #include "Optimizer/Adam.hpp"
+#include "Optimizer/GradientDescent.hpp"
+#include "Optimizer/Momentum.hpp"
+#include "Optimizer/SGD.hpp"

--- a/src/ComputationContainer/PrimeField/PrimeField.hpp
+++ b/src/ComputationContainer/PrimeField/PrimeField.hpp
@@ -1,8 +1,9 @@
 #pragma once
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/operators.hpp>
-#include <type_traits>
 #include <exception>
+#include <type_traits>
+
 #include "Logging/Logger.hpp"
 namespace qmpc
 {

--- a/src/ComputationContainer/Random/Csprng.cpp
+++ b/src/ComputationContainer/Random/Csprng.cpp
@@ -1,4 +1,5 @@
 #include "Random/Csprng.hpp"
+
 #include "LogHeader/Logger.hpp"
 #include "Logging/Logger.hpp"
 // randombytes_buf_deterministic の内部はChaCha20

--- a/src/ComputationContainer/Random/Csprng.hpp
+++ b/src/ComputationContainer/Random/Csprng.hpp
@@ -1,40 +1,37 @@
 #ifndef CSPRNG_H_
 #define CSPRNG_H_
 
-#include <unistd.h>
-#include <sys/syscall.h>
 #include <linux/random.h>
-
 #include <sodium.h>
 #include <sys/random.h>
-
-#include <chrono>
-#include <thread>
-#include <iostream>
+#include <sys/syscall.h>
+#include <unistd.h>
 
 #include <bitset>
-#include <string>
-
+#include <chrono>
+#include <iostream>
 #include <sstream>
+#include <string>
+#include <thread>
 #include <vector>
 
 namespace Utility
 {
-    class CSPRNG
-    {
-        bool entropyCheck();
-        CSPRNG &operator=(const CSPRNG &rhs); // 代入演算子。代入を想定しないので禁止。
-        CSPRNG(const CSPRNG &rhs);            // コピーコンストラクタ。コピーを想定しないので禁止。
-    public:
-        CSPRNG(){};
-        ~CSPRNG(){};
+class CSPRNG
+{
+    bool entropyCheck();
+    CSPRNG &operator=(const CSPRNG &rhs);  // 代入演算子。代入を想定しないので禁止。
+    CSPRNG(const CSPRNG &rhs);  // コピーコンストラクタ。コピーを想定しないので禁止。
+public:
+    CSPRNG(){};
+    ~CSPRNG(){};
 
-        // size is the byte size of random (ex. 128bit -> size is 16)
-        // byteSizeが256bit以下だと/dev/urandomを使用
-        void GetRand(unsigned char *buf, unsigned int byteSize);
-        long long int GetRandLL();
-        std::vector<long long int> GetRandLLVec(unsigned int size);
-    };
-} // namespace Utility
+    // size is the byte size of random (ex. 128bit -> size is 16)
+    // byteSizeが256bit以下だと/dev/urandomを使用
+    void GetRand(unsigned char *buf, unsigned int byteSize);
+    long long int GetRandLL();
+    std::vector<long long int> GetRandLLVec(unsigned int size);
+};
+}  // namespace Utility
 
 #endif

--- a/src/ComputationContainer/Random/Random.cpp
+++ b/src/ComputationContainer/Random/Random.cpp
@@ -1,8 +1,9 @@
 #include "Random.hpp"
 
 #include <linux/random.h>
-#include <unistd.h>
 #include <sys/syscall.h>
+#include <unistd.h>
+
 #include "Random/Csprng.hpp"
 
 unsigned long long RandGenerator::generateRand()

--- a/src/ComputationContainer/Random/Random.hpp
+++ b/src/ComputationContainer/Random/Random.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+
 #include "FixedPoint/FixedPoint.hpp"
 #include "PrimeField/PrimeField.hpp"
 

--- a/src/ComputationContainer/Server/ComputationToComputationContainer/Server.cpp
+++ b/src/ComputationContainer/Server/ComputationToComputationContainer/Server.cpp
@@ -1,8 +1,8 @@
 #include "Server.hpp"
 
 #include "ConfigParse/ConfigParse.hpp"
-#include "Share/AddressId.hpp"
 #include "LogHeader/Logger.hpp"
+#include "Share/AddressId.hpp"
 
 namespace qmpc::ComputationToComputation
 {

--- a/src/ComputationContainer/Server/ComputationToComputationContainer/Server.hpp
+++ b/src/ComputationContainer/Server/ComputationToComputationContainer/Server.hpp
@@ -1,27 +1,27 @@
 #pragma once
 
-#include <iostream>
-#include <string>
-#include <unordered_map>
-#include <mutex>
-#include <condition_variable>
-#include <sstream>  // 文字列分割を実装する際に用いる
-#include <map>
-#include <vector>
-#include <tuple>
-
-#include "unistd.h"
-#include "Client/Helper/Helper.hpp"
-#include "external/Proto/ComputationToComputationContainer/computation_to_computation.grpc.pb.h"
 #include <grpc/grpc.h>
+#include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
-#include <grpcpp/security/server_credentials.h>
-#include "Client/ComputationToComputationContainer/Client.hpp"
 
+#include <condition_variable>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <sstream>  // 文字列分割を実装する際に用いる
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "Client/ComputationToComputationContainer/Client.hpp"
+#include "Client/Helper/Helper.hpp"
 #include "LogHeader/Logger.hpp"
 #include "Logging/Logger.hpp"
+#include "external/Proto/ComputationToComputationContainer/computation_to_computation.grpc.pb.h"
+#include "unistd.h"
 namespace qmpc::ComputationToComputation
 {
 class Server final : public computationtocomputation::ComputationToComputation::Service

--- a/src/ComputationContainer/Server/ComputationToComputationContainerForJob/Server.cpp
+++ b/src/ComputationContainer/Server/ComputationToComputationContainerForJob/Server.cpp
@@ -4,11 +4,10 @@
 #include <tuple>
 
 #include "ConfigParse/ConfigParse.hpp"
-#include "Job/JobParameter.hpp"
-#include "Share/AddressId.hpp"
 #include "Job/JobManager.hpp"
-
+#include "Job/JobParameter.hpp"
 #include "LogHeader/Logger.hpp"
+#include "Share/AddressId.hpp"
 
 namespace qmpc::ComputationToComputationForJob
 {

--- a/src/ComputationContainer/Server/ComputationToComputationContainerForJob/Server.hpp
+++ b/src/ComputationContainer/Server/ComputationToComputationContainerForJob/Server.hpp
@@ -1,22 +1,23 @@
 #pragma once
 
-#include <iostream>
-#include <string>
-#include <mutex>
-#include <condition_variable>
-#include <sstream>  // 文字列分割を実装する際に用いる
-#include <map>
-#include <vector>
-#include <tuple>
-
-#include "unistd.h"
-#include "Client/Helper/Helper.hpp"
-#include "external/Proto/ComputationToComputationContainerForJob/computation_to_computation_for_job.grpc.pb.h"
 #include <grpc/grpc.h>
+#include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
-#include <grpcpp/security/server_credentials.h>
+
+#include <condition_variable>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <sstream>  // 文字列分割を実装する際に用いる
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "Client/Helper/Helper.hpp"
+#include "external/Proto/ComputationToComputationContainerForJob/computation_to_computation_for_job.grpc.pb.h"
+#include "unistd.h"
 
 namespace qmpc::ComputationToComputationForJob
 {

--- a/src/ComputationContainer/Server/ManageToComputationContainer/Server.cpp
+++ b/src/ComputationContainer/Server/ManageToComputationContainer/Server.cpp
@@ -1,20 +1,18 @@
 #include "Server.hpp"
 
-#include <thread>
 #include <deque>
 #include <iostream>
 #include <string>
+#include <thread>
 
-#include "unistd.h"
-
-#include "Job/JobManager.hpp"
-#include "Model/ModelManager.hpp"
 #include "Client/ComputationToDbGate/Client.hpp"
-#include "Share/Share.hpp"
 #include "ConfigParse/ConfigParse.hpp"
-#include "Server/ComputationToComputationContainerForJob/Server.hpp"
-
+#include "Job/JobManager.hpp"
 #include "LogHeader/Logger.hpp"
+#include "Model/ModelManager.hpp"
+#include "Server/ComputationToComputationContainerForJob/Server.hpp"
+#include "Share/Share.hpp"
+#include "unistd.h"
 
 namespace qmpc::ManageToComputation
 {

--- a/src/ComputationContainer/Server/ManageToComputationContainer/Server.hpp
+++ b/src/ComputationContainer/Server/ManageToComputationContainer/Server.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
 #include <grpc/grpc.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
+
+#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
 
 namespace qmpc::ManageToComputation
 {

--- a/src/ComputationContainer/Share/Compare.cpp
+++ b/src/ComputationContainer/Share/Compare.cpp
@@ -1,5 +1,6 @@
 
 #include "Compare.hpp"
+
 #include "ConfigParse/ConfigParse.hpp"
 #include "LogHeader/Logger.hpp"
 

--- a/src/ComputationContainer/Share/Compare.hpp
+++ b/src/ComputationContainer/Share/Compare.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "FixedPoint/FixedPoint.hpp"
-#include "PrimeField/PrimeField.hpp"
 #include "ConfigParse/ConfigParse.hpp"
+#include "FixedPoint/FixedPoint.hpp"
 #include "Networking.hpp"
+#include "PrimeField/PrimeField.hpp"
 #include "Share.hpp"
 namespace qmpc::Share
 {

--- a/src/ComputationContainer/Share/Matrix.cpp
+++ b/src/ComputationContainer/Share/Matrix.cpp
@@ -1,8 +1,9 @@
 #include "Matrix.hpp"
+
 #include <Eigen/LU>
 
-#include "Networking.hpp"
 #include "Logging/Logger.hpp"
+#include "Networking.hpp"
 namespace qmpc::Share
 {
 /************** utils **************/

--- a/src/ComputationContainer/Share/Matrix.hpp
+++ b/src/ComputationContainer/Share/Matrix.hpp
@@ -1,7 +1,8 @@
 #pragma once
-#include <vector>
-#include "Share.hpp"
 #include <Eigen/Core>
+#include <vector>
+
+#include "Share.hpp"
 
 // 自作クラスでEigenの行列を扱うための各種宣言
 // 参考1: https://eigen.tuxfamily.org/dox/TopicCustomizing_CustomScalar.html

--- a/src/ComputationContainer/Share/Networking.hpp
+++ b/src/ComputationContainer/Share/Networking.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
-#include "ConfigParse/ConfigParse.hpp"
-#include "Server/ComputationToComputationContainer/Server.hpp"
-#include "FixedPoint/FixedPoint.hpp"
-#include "PrimeField/PrimeField.hpp"
 #include <boost/multiprecision/cpp_int.hpp>
 #include <iterator>
 #include <thread>
 #include <vector>
+
 #include "AddressId.hpp"
+#include "ConfigParse/ConfigParse.hpp"
+#include "FixedPoint/FixedPoint.hpp"
+#include "PrimeField/PrimeField.hpp"
+#include "Server/ComputationToComputationContainer/Server.hpp"
 namespace qmpc::Share
 {
 template <typename T>
@@ -120,7 +121,7 @@ auto recons(const T &share)
     std::vector<Result> ret(length);
     for (int pt_id = 1; pt_id <= conf->n_parties; pt_id++)
     {
-        std::vector<qmpc::Share::AddressId> ids_list(length); // 複数シェアのidリスト
+        std::vector<qmpc::Share::AddressId> ids_list(length);  // 複数シェアのidリスト
         for (unsigned int i = 0; i < length; i++)
         {
             ids_list[i] = share[i].getId();

--- a/src/ComputationContainer/Share/Share.hpp
+++ b/src/ComputationContainer/Share/Share.hpp
@@ -1,16 +1,17 @@
 #pragma once
 
-#include <cmath>
-#include "ConfigParse/ConfigParse.hpp"
-#include "Random/Random.hpp"
-#include "Networking.hpp"
-#include <boost/operators.hpp>
 #include <atomic>
-#include <tuple>
+#include <boost/operators.hpp>
+#include <cmath>
 #include <string>
+#include <tuple>
+
 #include "AddressId.hpp"
-#include "TripleHandler/TripleHandler.hpp"
+#include "ConfigParse/ConfigParse.hpp"
 #include "Logging/Logger.hpp"
+#include "Networking.hpp"
+#include "Random/Random.hpp"
+#include "TripleHandler/TripleHandler.hpp"
 namespace qmpc::Share
 {
 template <typename SV>

--- a/src/ComputationContainer/Test/Benchmark/ComputationBenchmark/ComputationBenchmark.cpp
+++ b/src/ComputationContainer/Test/Benchmark/ComputationBenchmark/ComputationBenchmark.cpp
@@ -1,7 +1,8 @@
 #include "ComputationBenchmark.hpp"
+
+#include "LogHeader/Logger.hpp"
 #include "external/com_github_grpc_grpc/src/proto/grpc/health/v1/health.grpc.pb.h"
 #include "gtest/gtest.h"
-#include "LogHeader/Logger.hpp"
 
 // 25分経過するとプログラムを終了させる
 void timekeep()

--- a/src/ComputationContainer/Test/Benchmark/ComputationBenchmark/ComputationBenchmark.hpp
+++ b/src/ComputationContainer/Test/Benchmark/ComputationBenchmark/ComputationBenchmark.hpp
@@ -2,10 +2,10 @@
 #include <iostream>
 #include <string>
 #include <thread>
-#include "unistd.h"
 
 #include "Server/ComputationToComputationContainer/Server.hpp"
-#include "Test/Benchmark/ShareCompBenchmark.hpp"
 #include "Test/Benchmark/ShareBenchmark.hpp"
+#include "Test/Benchmark/ShareCompBenchmark.hpp"
+#include "unistd.h"
 
 int main(int argc, char **argv);

--- a/src/ComputationContainer/Test/Benchmark/ShareBenchmark.hpp
+++ b/src/ComputationContainer/Test/Benchmark/ShareBenchmark.hpp
@@ -1,16 +1,17 @@
 #pragma once
-#include "gtest/gtest.h"
+#include <algorithm>
 #include <iostream>
+#include <random>
 #include <string>
 #include <thread>
-#include "unistd.h"
-#include "Share/Share.hpp"
-#include "Share/Compare.hpp"
+
+#include "Benchmark.hpp"
 #include "Random/Random.hpp"
 #include "Server/ComputationToComputationContainer/Server.hpp"
-#include <algorithm>
-#include <random>
-#include "Benchmark.hpp"
+#include "Share/Compare.hpp"
+#include "Share/Share.hpp"
+#include "gtest/gtest.h"
+#include "unistd.h"
 
 TEST(ShareBenchmark, AddBetweenShares)
 {

--- a/src/ComputationContainer/Test/Benchmark/ShareCompBenchmark.hpp
+++ b/src/ComputationContainer/Test/Benchmark/ShareCompBenchmark.hpp
@@ -4,15 +4,16 @@
  */
 
 #pragma once
-#include "gtest/gtest.h"
 #include <iostream>
 #include <string>
 #include <thread>
-#include "unistd.h"
-#include "Share/Share.hpp"
-#include "Share/Compare.hpp"
-#include "Server/ComputationToComputationContainer/Server.hpp"
+
 #include "Benchmark.hpp"
+#include "Server/ComputationToComputationContainer/Server.hpp"
+#include "Share/Compare.hpp"
+#include "Share/Share.hpp"
+#include "gtest/gtest.h"
+#include "unistd.h"
 
 TEST(ShareCompBenchmark, AddBetweenShareComps)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/AnyToDbGateTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/AnyToDbGateTest.hpp
@@ -1,16 +1,13 @@
 #pragma once
 
-#include "gtest/gtest.h"
-
-#include <vector>
 #include <string>
-
-#include "nlohmann/json.hpp"
+#include <vector>
 
 #include "Client/AnyToDb/Client.hpp"
 #include "Client/AnyToDb/N1QL.hpp"
-
 #include "LogHeader/Logger.hpp"
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
 
 // N1QLのによるクエリ文字列
 const auto insert_query_string = std::string(

--- a/src/ComputationContainer/Test/IntegrationTest/ComputationTest/ComputationTest.cpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ComputationTest/ComputationTest.cpp
@@ -1,9 +1,9 @@
 #include "ComputationTest.hpp"
+
 #include "ConfigParse/ConfigParse.hpp"
+#include "LogHeader/Logger.hpp"
 #include "external/com_github_grpc_grpc/src/proto/grpc/health/v1/health.grpc.pb.h"
 #include "gtest/gtest.h"
-
-#include "LogHeader/Logger.hpp"
 
 // 25分経過するとプログラムを終了させる
 void timekeep()

--- a/src/ComputationContainer/Test/IntegrationTest/ComputationTest/ComputationTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ComputationTest/ComputationTest.hpp
@@ -2,22 +2,24 @@
 #include <iostream>
 #include <string>
 #include <thread>
-#include "unistd.h"
 
 #include "ConfigParse/ConfigParse.hpp"
 #include "Server/ComputationToComputationContainer/Server.hpp"
 #include "Server/ManageToComputationContainer/Server.hpp"
-#include "Test/IntegrationTest/ShareCompTest.hpp"  // これを1番最初に実行しないとIncrementIdで落ちる
-#include "Test/IntegrationTest/ShareTest.hpp"
+#include "unistd.h"
+// clang-format off
+#include "Test/IntegrationTest/ShareCompTest.hpp"
+// clang-format on
+#include "Test/IntegrationTest/AnyToDbGateTest.hpp"
+#include "Test/IntegrationTest/ComputationToDbGateTest.hpp"
+#include "Test/IntegrationTest/GBDTTest.hpp"
 #include "Test/IntegrationTest/MathTest.hpp"
 #include "Test/IntegrationTest/MatrixTest.hpp"
 #include "Test/IntegrationTest/MeshCodeTest.hpp"
 #include "Test/IntegrationTest/ModelTest.hpp"
 #include "Test/IntegrationTest/OptimizeTest.hpp"
-#include "Test/IntegrationTest/GBDTTest.hpp"
 #include "Test/IntegrationTest/ReadTripleFromBtsTest.hpp"
+#include "Test/IntegrationTest/ShareTest.hpp"
 #include "Test/IntegrationTest/ValueTableTest.hpp"
-#include "Test/IntegrationTest/ComputationToDbGateTest.hpp"
-#include "Test/IntegrationTest/AnyToDbGateTest.hpp"
 
 int main(int argc, char **argv);

--- a/src/ComputationContainer/Test/IntegrationTest/ComputationToDbGateTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ComputationToDbGateTest.hpp
@@ -1,8 +1,8 @@
-#include "gtest/gtest.h"
-#include "nlohmann/json.hpp"
-#include "Client/ComputationToDbGate/Client.hpp"
 #include "Client/AnyToDb/Client.hpp"
 #include "Client/AnyToDb/N1QL.hpp"
+#include "Client/ComputationToDbGate/Client.hpp"
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
 
 TEST(ComputationToDbGateTest, PieceIdTest)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/GBDTTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/GBDTTest.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <vector>
 #include <iomanip>
-#include "gtest/gtest.h"
+#include <vector>
+
+#include "GBDT/SGBM.hpp"
 #include "GBDT/SID3.hpp"
 #include "GBDT/SID3Regression.hpp"
-#include "GBDT/SGBM.hpp"
-
 #include "LogHeader/Logger.hpp"
+#include "gtest/gtest.h"
 
 auto bitVecCreater = [](const std::vector<std::vector<int>> &data)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/MathTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/MathTest.hpp
@@ -1,11 +1,11 @@
 #pragma once
-#include <vector>
-#include <random>
-#include "gtest/gtest.h"
-#include "Math/Math.hpp"
 #include <cmath>
+#include <random>
+#include <vector>
 
 #include "LogHeader/Logger.hpp"
+#include "Math/Math.hpp"
+#include "gtest/gtest.h"
 
 TEST(MathTest, Smean)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/MatrixTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/MatrixTest.hpp
@@ -2,10 +2,10 @@
 #include <iostream>
 #include <list>
 #include <random>
-#include "gtest/gtest.h"
-#include "Share/Matrix.hpp"
 
 #include "LogHeader/Logger.hpp"
+#include "Share/Matrix.hpp"
+#include "gtest/gtest.h"
 
 std::random_device rnd;
 std::mt19937_64 mt(rnd());

--- a/src/ComputationContainer/Test/IntegrationTest/MeshCodeTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/MeshCodeTest.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <iostream>
 #include <chrono>
+#include <iostream>
 #include <string>
-#include "gtest/gtest.h"
-#include "Math/Math.hpp"
-#include "Share/Share.hpp"
-#include "Server/ComputationToComputationContainer/Server.hpp"
-#include "Job/Jobs/MeshCodeJob.hpp"
 
+#include "Job/Jobs/MeshCodeJob.hpp"
 #include "LogHeader/Logger.hpp"
+#include "Math/Math.hpp"
+#include "Server/ComputationToComputationContainer/Server.hpp"
+#include "Share/Share.hpp"
+#include "gtest/gtest.h"
 
 TEST(MeshCodeTest, BulkMeshCode)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/ModelTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ModelTest.hpp
@@ -1,13 +1,14 @@
 #pragma once
 #include <vector>
-#include "gtest/gtest.h"
-#include "Share/Share.hpp"
+
+#include "Job/Jobs/LogisticRegressionJob.hpp"
+#include "Model/Models/DecisionTree.hpp"
 #include "Model/Models/LinearRegression.hpp"
 #include "Model/Models/LogisticRegression.hpp"
-#include "Model/Models/DecisionTree.hpp"
-#include "Job/Jobs/LogisticRegressionJob.hpp"
-#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
 #include "Optimizer/GradientDescent.hpp"
+#include "Share/Share.hpp"
+#include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
+#include "gtest/gtest.h"
 
 TEST(ModelTest, LinearRegressionTest)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/OptimizeTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/OptimizeTest.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <vector>
 #include <iomanip>
-#include "gtest/gtest.h"
-#include "Optimizer/optimizer.hpp"
-#include "ObjectiveFunction/ObjectiveFunctionInterface.hpp"
+#include <vector>
 
 #include "LogHeader/Logger.hpp"
+#include "ObjectiveFunction/ObjectiveFunctionInterface.hpp"
+#include "Optimizer/optimizer.hpp"
+#include "gtest/gtest.h"
 
 TEST(OptimizeTest, GradientDescent)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/ReadTripleFromBtsTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ReadTripleFromBtsTest.hpp
@@ -1,8 +1,7 @@
+#include "Client/ComputationToBts/Client.hpp"
+#include "LogHeader/Logger.hpp"
 #include "gtest/gtest.h"
 #include "nlohmann/json.hpp"
-#include "Client/ComputationToBts/Client.hpp"
-
-#include "LogHeader/Logger.hpp"
 
 void readTriplesTest(const unsigned int jobIdMax, const unsigned int amount)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
@@ -1,14 +1,14 @@
 #pragma once
-#include "gtest/gtest.h"
 #include <iostream>
 #include <string>
 #include <thread>
-#include "unistd.h"
-#include "Share/Share.hpp"
-#include "Share/Compare.hpp"
-#include "Server/ComputationToComputationContainer/Server.hpp"
 
 #include "LogHeader/Logger.hpp"
+#include "Server/ComputationToComputationContainer/Server.hpp"
+#include "Share/Compare.hpp"
+#include "Share/Share.hpp"
+#include "gtest/gtest.h"
+#include "unistd.h"
 
 TEST(ShareCompTest, IncrementShareCompId)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
@@ -1,17 +1,17 @@
 #pragma once
-#include "gtest/gtest.h"
+#include <algorithm>
 #include <iostream>
+#include <random>
 #include <string>
 #include <thread>
-#include "unistd.h"
-#include "Share/Share.hpp"
-#include "Share/Compare.hpp"
-#include "Random/Random.hpp"
-#include "Server/ComputationToComputationContainer/Server.hpp"
-#include <algorithm>
-#include <random>
 
 #include "LogHeader/Logger.hpp"
+#include "Random/Random.hpp"
+#include "Server/ComputationToComputationContainer/Server.hpp"
+#include "Share/Compare.hpp"
+#include "Share/Share.hpp"
+#include "gtest/gtest.h"
+#include "unistd.h"
 
 TEST(ShareTest, IncrementShareId)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/ValueTableTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ValueTableTest.hpp
@@ -1,9 +1,8 @@
-#include "gtest/gtest.h"
-
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "Client/ComputationToDbGate/ValueTable.hpp"
+#include "gtest/gtest.h"
 
 /****************** Test用の各データ ******************/
 const std::vector<std::vector<std::string>> table_data1{{"101", "1", "2"}, {"102", "3", "4"}};

--- a/src/ComputationContainer/Test/UnitTest/CsprngTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/CsprngTest.cpp
@@ -1,14 +1,14 @@
-#include "gtest/gtest.h"
-#include "Random/Csprng.hpp"
-
 #include <stdlib.h>
+
 #include <set>
 
 #include "LogHeader/Logger.hpp"
+#include "Random/Csprng.hpp"
+#include "gtest/gtest.h"
 
 TEST(CsprngTest, GetRand)
 {
-    const unsigned int byteSize = 8; // 8byte = 64bit
+    const unsigned int byteSize = 8;  // 8byte = 64bit
 
     unsigned char *rnd = new unsigned char[byteSize];
 
@@ -57,7 +57,7 @@ TEST(CsprngTest, HowUse)
 {
     Utility::CSPRNG rng = Utility::CSPRNG();
 
-    const unsigned int byteSize = 8; // 8byte = 64bit
+    const unsigned int byteSize = 8;  // 8byte = 64bit
     const unsigned int bitSize = byteSize * 8;
 
     unsigned char *rnd = new unsigned char[byteSize];

--- a/src/ComputationContainer/Test/UnitTest/CtoC_test.cpp
+++ b/src/ComputationContainer/Test/UnitTest/CtoC_test.cpp
@@ -1,19 +1,20 @@
-#include "gtest/gtest.h"
-#include <string>
-#include <vector>
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 #include <unistd.h>
-#include <thread>
-#include "external/Proto/ComputationToComputationContainer/computation_to_computation.grpc.pb.h"
-#include "Server/ComputationToComputationContainer/Server.hpp"
-#include "ConfigParse/ConfigParse.hpp"
-#include "Share/AddressId.hpp"
 
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ConfigParse/ConfigParse.hpp"
 #include "LogHeader/Logger.hpp"
+#include "Server/ComputationToComputationContainer/Server.hpp"
+#include "Share/AddressId.hpp"
+#include "external/Proto/ComputationToComputationContainer/computation_to_computation.grpc.pb.h"
+#include "gtest/gtest.h"
 
 void runServer(std::string endpoint)
 {

--- a/src/ComputationContainer/Test/UnitTest/FixedPointTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/FixedPointTest.cpp
@@ -1,140 +1,140 @@
-#include "gtest/gtest.h"
 #include "FixedPoint/FixedPoint.hpp"
+#include "gtest/gtest.h"
 
 TEST(FixedPointTest, Add)
 {
-    FixedPoint a("3.0");    // operand1
-    FixedPoint b("0.141");  // operand2
-    FixedPoint c("-0.141"); // operand3
+    FixedPoint a("3.0");     // operand1
+    FixedPoint b("0.141");   // operand2
+    FixedPoint c("-0.141");  // operand3
 
-    FixedPoint res1 = a + b;  // result
-    FixedPoint cor1("3.141"); // correct
+    FixedPoint res1 = a + b;   // result
+    FixedPoint cor1("3.141");  // correct
     EXPECT_EQ(res1, cor1);
 
-    FixedPoint res2 = a + c;  // result
-    FixedPoint cor2("2.859"); // correct
+    FixedPoint res2 = a + c;   // result
+    FixedPoint cor2("2.859");  // correct
     EXPECT_EQ(res2, cor2);
 }
 
 TEST(FixedPointTest, AddAssign)
 {
-    FixedPoint a1("3.0");   // operand1
-    FixedPoint a2("3.0");   // operand1
-    FixedPoint b("0.141");  // operand2
-    FixedPoint c("-0.141"); // operand3
+    FixedPoint a1("3.0");    // operand1
+    FixedPoint a2("3.0");    // operand1
+    FixedPoint b("0.141");   // operand2
+    FixedPoint c("-0.141");  // operand3
 
     a1 += b;
-    FixedPoint cor1("3.141"); // correct
+    FixedPoint cor1("3.141");  // correct
     EXPECT_EQ(a1, cor1);
 
     a2 += c;
-    FixedPoint cor2("2.859"); // correct
+    FixedPoint cor2("2.859");  // correct
     EXPECT_EQ(a2, cor2);
 }
 
 TEST(FixedPointTest, Sub)
 {
-    FixedPoint a("3.141");  // operand1
-    FixedPoint b("0.141");  // operand2
-    FixedPoint c("-0.141"); // operand3
+    FixedPoint a("3.141");   // operand1
+    FixedPoint b("0.141");   // operand2
+    FixedPoint c("-0.141");  // operand3
 
-    FixedPoint res1 = a - b; // result
-    FixedPoint cor1("3.0");  // correct
+    FixedPoint res1 = a - b;  // result
+    FixedPoint cor1("3.0");   // correct
     EXPECT_EQ(res1, cor1);
 
-    FixedPoint res2 = a - c;  // result
-    FixedPoint cor2("3.282"); // correct
+    FixedPoint res2 = a - c;   // result
+    FixedPoint cor2("3.282");  // correct
     EXPECT_EQ(res2, cor2);
 }
 
 TEST(FixedPointTest, SubAssign)
 {
-    FixedPoint a1("3.141"); // operand1
-    FixedPoint a2("3.141"); // operand1
-    FixedPoint b("0.141");  // operand2
-    FixedPoint c("-0.141"); // operand3
+    FixedPoint a1("3.141");  // operand1
+    FixedPoint a2("3.141");  // operand1
+    FixedPoint b("0.141");   // operand2
+    FixedPoint c("-0.141");  // operand3
 
     a1 -= b;
-    FixedPoint cor1("3.0"); // correct
+    FixedPoint cor1("3.0");  // correct
     EXPECT_EQ(a1, cor1);
 
     a2 -= c;
-    FixedPoint cor2("3.282"); // correct
+    FixedPoint cor2("3.282");  // correct
     EXPECT_EQ(a2, cor2);
 }
 
 TEST(FixedPointTest, Mul)
 {
-    FixedPoint a("10.0"); // operand1
-    FixedPoint b("0.1");  // operand2
-    FixedPoint c("-0.1"); // operand3
+    FixedPoint a("10.0");  // operand1
+    FixedPoint b("0.1");   // operand2
+    FixedPoint c("-0.1");  // operand3
 
-    FixedPoint res1 = a * b; // result
-    FixedPoint cor1("1.0");  // correct
+    FixedPoint res1 = a * b;  // result
+    FixedPoint cor1("1.0");   // correct
     EXPECT_EQ(res1, cor1);
 
-    FixedPoint res2 = a * c; // result
-    FixedPoint cor2("-1.0"); // correct
+    FixedPoint res2 = a * c;  // result
+    FixedPoint cor2("-1.0");  // correct
     EXPECT_EQ(res2, cor2);
 }
 
 TEST(FixedPointTest, MulAssign)
 {
-    FixedPoint a1("10.0"); // operand1
-    FixedPoint a2("10.0"); // operand1
-    FixedPoint b("0.1");   // operand2
-    FixedPoint c("-0.1");  // operand3
+    FixedPoint a1("10.0");  // operand1
+    FixedPoint a2("10.0");  // operand1
+    FixedPoint b("0.1");    // operand2
+    FixedPoint c("-0.1");   // operand3
 
-    a1 *= b;                // result
-    FixedPoint cor1("1.0"); // correct
+    a1 *= b;                 // result
+    FixedPoint cor1("1.0");  // correct
     EXPECT_EQ(a1, cor1);
 
-    a2 *= c;                 // result
-    FixedPoint cor2("-1.0"); // correct
+    a2 *= c;                  // result
+    FixedPoint cor2("-1.0");  // correct
     EXPECT_EQ(a2, cor2);
 }
 
 TEST(FixedPointTest, Div)
 {
-    FixedPoint a("10.0"); // operand1
-    FixedPoint b("0.1");  // operand2
-    FixedPoint c("-0.1"); // operand3
+    FixedPoint a("10.0");  // operand1
+    FixedPoint b("0.1");   // operand2
+    FixedPoint c("-0.1");  // operand3
 
-    FixedPoint res1 = a / b;  // result
-    FixedPoint cor1("100.0"); // correct
+    FixedPoint res1 = a / b;   // result
+    FixedPoint cor1("100.0");  // correct
     EXPECT_EQ(res1, cor1);
 
-    FixedPoint res2 = a / c;   // result
-    FixedPoint cor2("-100.0"); // correct
+    FixedPoint res2 = a / c;    // result
+    FixedPoint cor2("-100.0");  // correct
     EXPECT_EQ(res2, cor2);
 }
 
 TEST(FixedPointTest, DivAssign)
 {
-    FixedPoint a1("10.0"); // operand1
-    FixedPoint a2("10.0"); // operand1
-    FixedPoint b("0.1");   // operand2
-    FixedPoint c("-0.1");  // operand3
+    FixedPoint a1("10.0");  // operand1
+    FixedPoint a2("10.0");  // operand1
+    FixedPoint b("0.1");    // operand2
+    FixedPoint c("-0.1");   // operand3
 
-    a1 /= b;                  // result
-    FixedPoint cor1("100.0"); // correct
+    a1 /= b;                   // result
+    FixedPoint cor1("100.0");  // correct
     EXPECT_EQ(a1, cor1);
 
-    a2 /= c;                   // result
-    FixedPoint cor2("-100.0"); // correct
+    a2 /= c;                    // result
+    FixedPoint cor2("-100.0");  // correct
     EXPECT_EQ(a2, cor2);
 }
 
 TEST(FixedPointTest, LT)
 {
-    FixedPoint a("1.23"); // operand1
-    FixedPoint b("1.45"); // operand2
+    FixedPoint a("1.23");  // operand1
+    FixedPoint b("1.45");  // operand2
     EXPECT_TRUE(a < b);
     EXPECT_FALSE(b < a);
     EXPECT_FALSE(a < a);
 
-    FixedPoint c("-1.23"); // operand3
-    FixedPoint d("-1.45"); // operand4
+    FixedPoint c("-1.23");  // operand3
+    FixedPoint d("-1.45");  // operand4
     EXPECT_FALSE(c < d);
     EXPECT_TRUE(d < c);
     EXPECT_FALSE(c < c);
@@ -142,14 +142,14 @@ TEST(FixedPointTest, LT)
 
 TEST(FixedPointTest, LTE)
 {
-    FixedPoint a("1.23"); // operand1
-    FixedPoint b("1.45"); // operand2
+    FixedPoint a("1.23");  // operand1
+    FixedPoint b("1.45");  // operand2
     EXPECT_TRUE(a <= b);
     EXPECT_FALSE(b <= a);
     EXPECT_TRUE(a <= a);
 
-    FixedPoint c("-1.23"); // operand3
-    FixedPoint d("-1.45"); // operand4
+    FixedPoint c("-1.23");  // operand3
+    FixedPoint d("-1.45");  // operand4
     EXPECT_FALSE(c <= d);
     EXPECT_TRUE(d <= c);
     EXPECT_TRUE(c <= c);
@@ -157,14 +157,14 @@ TEST(FixedPointTest, LTE)
 
 TEST(FixedPointTest, GT)
 {
-    FixedPoint a("1.23"); // operand1
-    FixedPoint b("1.45"); // operand2
+    FixedPoint a("1.23");  // operand1
+    FixedPoint b("1.45");  // operand2
     EXPECT_FALSE(a > b);
     EXPECT_TRUE(b > a);
     EXPECT_FALSE(a > a);
 
-    FixedPoint c("-1.23"); // operand3
-    FixedPoint d("-1.45"); // operand4
+    FixedPoint c("-1.23");  // operand3
+    FixedPoint d("-1.45");  // operand4
     EXPECT_TRUE(c > d);
     EXPECT_FALSE(d > c);
     EXPECT_FALSE(c > c);
@@ -172,14 +172,14 @@ TEST(FixedPointTest, GT)
 
 TEST(FixedPointTest, GTE)
 {
-    FixedPoint a("1.23"); // operand1
-    FixedPoint b("1.45"); // operand2
+    FixedPoint a("1.23");  // operand1
+    FixedPoint b("1.45");  // operand2
     EXPECT_FALSE(a >= b);
     EXPECT_TRUE(b >= a);
     EXPECT_TRUE(a >= a);
 
-    FixedPoint c("-1.23"); // operand3
-    FixedPoint d("-1.45"); // operand4
+    FixedPoint c("-1.23");  // operand3
+    FixedPoint d("-1.45");  // operand4
     EXPECT_TRUE(c >= d);
     EXPECT_FALSE(d >= c);
     EXPECT_TRUE(c >= c);
@@ -187,24 +187,24 @@ TEST(FixedPointTest, GTE)
 
 TEST(FixedPointTest, Equation)
 {
-    FixedPoint a("1.45"); // operand1
-    FixedPoint b("1.23"); // operand2
+    FixedPoint a("1.45");  // operand1
+    FixedPoint b("1.23");  // operand2
     EXPECT_TRUE(a == a);
     EXPECT_FALSE(a == b);
 
-    FixedPoint c("-1.45"); // operand3
-    FixedPoint d("-1.23"); // operand4
+    FixedPoint c("-1.45");  // operand3
+    FixedPoint d("-1.23");  // operand4
     EXPECT_TRUE(c == c);
     EXPECT_FALSE(c == d);
 }
 
 TEST(FixedPointTest, getVal)
 {
-    FixedPoint a("1.45"); // operand
+    FixedPoint a("1.45");  // operand
     EXPECT_EQ(a.getStrVal(), "1.45000000000000000000");
     EXPECT_EQ(a.getDoubleVal(), 1.45);
 
-    FixedPoint b("-1.45"); // operand
+    FixedPoint b("-1.45");  // operand
     EXPECT_EQ(b.getStrVal(), "-1.45000000000000000000");
     EXPECT_EQ(b.getDoubleVal(), -1.45);
 }
@@ -241,7 +241,8 @@ TEST(FixedPointTest, Decrement)
 TEST(FixedPointTest, Max)
 {
     namespace mp = boost::multiprecision;
-    mp::checked_int256_t ma = std::numeric_limits<mp::checked_int256_t>::max() / FixedPoint::getShift();
+    mp::checked_int256_t ma =
+        std::numeric_limits<mp::checked_int256_t>::max() / FixedPoint::getShift();
     FixedPoint a{ma};
     EXPECT_EQ(a, FixedPoint(ma));
 }
@@ -272,10 +273,10 @@ TEST(FixedPointTest, Div0)
     }
     catch (std::exception e)
     {
-        EXPECT_TRUE(true); // succeed
+        EXPECT_TRUE(true);  // succeed
         return;
     }
-    EXPECT_TRUE(false); // failed
+    EXPECT_TRUE(false);  // failed
 }
 
 TEST(FixedPointTest, Abs)

--- a/src/ComputationContainer/Test/UnitTest/LogTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/LogTest.cpp
@@ -1,7 +1,8 @@
+#include <vector>
+
+#include "Logging/Logger.hpp"
 #include "gtest/gtest.h"
 #include "gtest/internal/gtest-port.h"
-#include "Logging/Logger.hpp"
-#include <vector>
 template <typename Stream, typename Func>
 std::vector<std::string> consoleDebug(Stream &&s, Func &&f)
 {
@@ -22,13 +23,11 @@ std::vector<std::string> consoleDebug(Stream &&s, Func &&f)
 }
 TEST(LogTest, InfoTest)
 {
-
     int a = 5;
     double b = 3.4;
     std::string message = "info log";
 
-    auto testVec = consoleDebug(std::cout, [=]()
-                                { qmpc::Log::Info(message, a, b); });
+    auto testVec = consoleDebug(std::cout, [=]() { qmpc::Log::Info(message, a, b); });
     EXPECT_EQ("INFO", testVec[1]);
     EXPECT_EQ("info log", testVec[2]);
     EXPECT_EQ("5", testVec[3]);
@@ -38,8 +37,7 @@ TEST(LogTest, InfoTest)
 TEST(LogTest, DebugTest)
 {
     std::string message = "debug log";
-    auto testVec = consoleDebug(std::cout, [=]()
-                                { qmpc::Log::Debug(message); });
+    auto testVec = consoleDebug(std::cout, [=]() { qmpc::Log::Debug(message); });
 
     EXPECT_EQ("DEBUG", testVec[1]);
     EXPECT_EQ("debug log\n", testVec[3]);
@@ -48,15 +46,11 @@ TEST(LogTest, DebugTest)
 TEST(LogTest, ErrorTest)
 {
     std::string message = "error log";
-    auto testVec = consoleDebug(std::cerr, [message]()
-                                { qmpc::Log::Error(message); });
+    auto testVec = consoleDebug(std::cerr, [message]() { qmpc::Log::Error(message); });
     EXPECT_EQ("ERROR", testVec[1]);
     EXPECT_EQ("error log\n", testVec[2]);
 }
-void f()
-{
-    qmpc::Log::throw_with_trace(std::runtime_error("runtime error"));
-}
+void f() { qmpc::Log::throw_with_trace(std::runtime_error("runtime error")); }
 TEST(LogTest, exceptionTest)
 {
     try
@@ -65,8 +59,10 @@ TEST(LogTest, exceptionTest)
     }
     catch (const std::exception &e)
     {
-        auto testVec = consoleDebug(std::cerr, [&e]()
-                                    { qmpc::Log::Error(*boost::get_error_info<qmpc::Log::traced>(e), e.what()); });
+        auto testVec = consoleDebug(
+            std::cerr,
+            [&e]() { qmpc::Log::Error(*boost::get_error_info<qmpc::Log::traced>(e), e.what()); }
+        );
 
         EXPECT_EQ("ERROR", testVec[1]);
         EXPECT_EQ("runtime error\n", testVec[3]);

--- a/src/ComputationContainer/Test/UnitTest/MathTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/MathTest.cpp
@@ -1,10 +1,8 @@
-#include "gtest/gtest.h"
-
 #include <vector>
 
-#include "Math/Math.hpp"
-
 #include "LogHeader/Logger.hpp"
+#include "Math/Math.hpp"
+#include "gtest/gtest.h"
 
 TEST(MathTest, MeanBetweenShares)
 {

--- a/src/ComputationContainer/Test/UnitTest/PrimeFieldTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/PrimeFieldTest.cpp
@@ -1,15 +1,13 @@
-#include "gtest/gtest.h"
 #include <iostream>
-#include "PrimeField/PrimeField.hpp"
-#include "gtest/gtest.h"
 
 #include "PrimeField/PrimeField.hpp"
+#include "gtest/gtest.h"
 
 constexpr boost::multiprecision::uint128_t p = 18446744073709551557ull;
 constexpr boost::multiprecision::uint128_t x = 10000000;
-constexpr boost::multiprecision::uint128_t x_minus = 18446744073699551557ull; // x_minus = p-x
+constexpr boost::multiprecision::uint128_t x_minus = 18446744073699551557ull;  // x_minus = p-x
 constexpr boost::multiprecision::uint128_t y = 20000000;
-constexpr boost::multiprecision::uint128_t y_inv = 11710276295512354770ull; // y_inv = y^-1
+constexpr boost::multiprecision::uint128_t y_inv = 11710276295512354770ull;  // y_inv = y^-1
 
 // コンストラクタのチェック
 // メンバ変数に正しい値が入っているかテスト
@@ -222,13 +220,11 @@ TEST(PrimeFieldTest, OverMul)
 // modを超えた値での初期化でエラーするかテスト
 TEST(PrimeFieldTest, InitOverValue)
 {
-    EXPECT_ANY_THROW([]()
-                     { PrimeField a{PrimeField::p + 1}; }());
+    EXPECT_ANY_THROW([]() { PrimeField a{PrimeField::p + 1}; }());
 }
 
 // 負の値での初期化でエラーするかテスト
 TEST(PrimeFieldTest, InitMinusValue)
 {
-    EXPECT_ANY_THROW([]()
-                     { PrimeField a{-1}; }());
+    EXPECT_ANY_THROW([]() { PrimeField a{-1}; }());
 }

--- a/src/ComputationContainer/Test/UnitTest/RandomTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/RandomTest.cpp
@@ -1,10 +1,10 @@
-#include "gtest/gtest.h"
-
+#include <iostream>
 #include <type_traits>
-#include "Random/Random.hpp"
+
 #include "FixedPoint/FixedPoint.hpp"
 #include "PrimeField/PrimeField.hpp"
-#include <iostream>
+#include "Random/Random.hpp"
+#include "gtest/gtest.h"
 TEST(RandomTest, getRandTypeTest)
 {
     auto instance = RandGenerator::getInstance();

--- a/src/ComputationContainer/Test/UnitTest/ShareTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/ShareTest.cpp
@@ -1,7 +1,6 @@
-#include "gtest/gtest.h"
-
-#include "Share/Share.hpp"
 #include "LogHeader/Logger.hpp"
+#include "Share/Share.hpp"
+#include "gtest/gtest.h"
 
 TEST(ShareTest, GetValue)
 {

--- a/src/ComputationContainer/Test/UnitTest/TransactionQueueTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/TransactionQueueTest.cpp
@@ -1,8 +1,9 @@
-#include "gtest/gtest.h"
-#include "TransactionQueue/TransactionQueue.hpp"
+#include <atomic>
 #include <thread>
 #include <vector>
-#include <atomic>
+
+#include "TransactionQueue/TransactionQueue.hpp"
+#include "gtest/gtest.h"
 
 const long long SIZE = 5000;
 
@@ -64,21 +65,25 @@ TEST(TransactionQueTest, AsyncSinglePushSinglePopTest)
 {
     qmpc::Utils::TransactionQueue<long long> q;
     // 順にpushさせる
-    std::thread th1([&]()
-                    {
-                        for (long long i = 0; i < SIZE; i++)
-                        {
-                            q.push(i);
-                        }
-                    });
+    std::thread th1(
+        [&]()
+        {
+            for (long long i = 0; i < SIZE; i++)
+            {
+                q.push(i);
+            }
+        }
+    );
     // 順にpopさせる
-    std::thread th2([&]()
-                    {
-                        for (long long i = 0; i < SIZE; i++)
-                        {
-                            EXPECT_EQ(q.pop(), i);
-                        }
-                    });
+    std::thread th2(
+        [&]()
+        {
+            for (long long i = 0; i < SIZE; i++)
+            {
+                EXPECT_EQ(q.pop(), i);
+            }
+        }
+    );
     // pushとpopを複数threadで非同期に行っている
     th1.join();
     th2.join();
@@ -101,26 +106,28 @@ TEST(TransactionQueTest, AsyncMultiPushSinglePopTest)
     // pushさせる物の順は[0, SIZE)の順列を並び替えた物と同値
     for (long long i = 0; i < num_thread; i++)
     {
-        threads_push.push_back(std::thread([&, i]()
-                                           {
-                                               for (long long j = 0; j < SIZE / num_thread; j++)
-                                               {
-                                                   q.push((SIZE / num_thread) * i + j);
-                                               }
-                                           }));
+        threads_push.push_back(std::thread(
+            [&, i]()
+            {
+                for (long long j = 0; j < SIZE / num_thread; j++)
+                {
+                    q.push((SIZE / num_thread) * i + j);
+                }
+            }
+        ));
     }
 
     // SIZE全部出てくるかテスト
     // 順繰りに出てくるわけではないので注意
     for (long long i = 0; i < SIZE; i++)
     {
-        long long id = q.pop(); // 一つ一つpopする
-        check[id]++;            // 値が何回popされたか見る
+        long long id = q.pop();  // 一つ一つpopする
+        check[id]++;             // 値が何回popされたか見る
     }
 
     for (long long i = 0; i < SIZE; i++)
     {
-        EXPECT_EQ(check[i], 1); // 一回だけpopされたのならok
+        EXPECT_EQ(check[i], 1);  // 一回だけpopされたのならok
     }
 
     // 一応
@@ -154,14 +161,16 @@ TEST(TransactionQueTest, AsyncSinglePushMultiPopTest)
     std::vector<std::thread> threads_pop;
     for (long long i = 0; i < num_thread; i++)
     {
-        threads_pop.push_back(std::thread([&]()
-                                          {
-                                              for (long long j = 0; j < SIZE / num_thread; j++)
-                                              {
-                                                  long long id = q.pop(); // 一つ一つpopする
-                                                  check[id]++;            // 値が何回popされたか見る
-                                              }
-                                          }));
+        threads_pop.push_back(std::thread(
+            [&]()
+            {
+                for (long long j = 0; j < SIZE / num_thread; j++)
+                {
+                    long long id = q.pop();  // 一つ一つpopする
+                    check[id]++;             // 値が何回popされたか見る
+                }
+            }
+        ));
     }
 
     // 全部終わるまで待機
@@ -172,7 +181,7 @@ TEST(TransactionQueTest, AsyncSinglePushMultiPopTest)
 
     for (long long i = 0; i < SIZE; i++)
     {
-        EXPECT_EQ(check[i], 1); // 全部一回popされたならok
+        EXPECT_EQ(check[i], 1);  // 全部一回popされたならok
     }
 }
 
@@ -194,13 +203,15 @@ TEST(TransactionQueTest, AsyncMultiPushMultiPopTest)
     // pushさせる物の順は[0, SIZE)の順列を並び替えた物と同値
     for (long long i = 0; i < num_thread; i++)
     {
-        threads_push.push_back(std::thread([&, i]()
-                                           {
-                                               for (long long j = 0; j < SIZE / num_thread; j++)
-                                               {
-                                                   q.push((SIZE / num_thread) * i + j);
-                                               }
-                                           }));
+        threads_push.push_back(std::thread(
+            [&, i]()
+            {
+                for (long long j = 0; j < SIZE / num_thread; j++)
+                {
+                    q.push((SIZE / num_thread) * i + j);
+                }
+            }
+        ));
     }
 
     // SIZE個全部出てくるかnum_thread個のthreadでテスト
@@ -208,14 +219,16 @@ TEST(TransactionQueTest, AsyncMultiPushMultiPopTest)
     // 尚，popさせた順は[0, SIZE)を昇順に並び替えた配列と同値
     for (long long i = 0; i < num_thread; i++)
     {
-        threads_pop.push_back(std::thread([&]()
-                                          {
-                                              for (long long j = 0; j < SIZE / num_thread; j++)
-                                              {
-                                                  long long id = q.pop(); // 一つ一つpopする
-                                                  check[id]++;            // 値が何回popされたか見る
-                                              }
-                                          }));
+        threads_pop.push_back(std::thread(
+            [&]()
+            {
+                for (long long j = 0; j < SIZE / num_thread; j++)
+                {
+                    long long id = q.pop();  // 一つ一つpopする
+                    check[id]++;             // 値が何回popされたか見る
+                }
+            }
+        ));
     }
 
     // 全部終わるまで待機
@@ -230,7 +243,7 @@ TEST(TransactionQueTest, AsyncMultiPushMultiPopTest)
 
     for (long long i = 0; i < SIZE; i++)
     {
-        EXPECT_EQ(check[i], 1); // 全部一回popされたならok
+        EXPECT_EQ(check[i], 1);  // 全部一回popされたならok
     }
 }
 
@@ -246,21 +259,25 @@ TEST(TransactionQueTest, AsyncSinglePushSinglePopMoreSIZETest)
     qmpc::Utils::TransactionQueue<long long> q;
 
     // 順にpushさせる
-    std::thread th1([&]()
-                    {
-                        for (long long i = 0; i < RESIZE; i++)
-                        {
-                            q.push(i);
-                        }
-                    });
+    std::thread th1(
+        [&]()
+        {
+            for (long long i = 0; i < RESIZE; i++)
+            {
+                q.push(i);
+            }
+        }
+    );
     // 順にpopさせる
-    std::thread th2([&]()
-                    {
-                        for (long long i = 0; i < RESIZE; i++)
-                        {
-                            EXPECT_EQ(q.pop(), i);
-                        }
-                    });
+    std::thread th2(
+        [&]()
+        {
+            for (long long i = 0; i < RESIZE; i++)
+            {
+                EXPECT_EQ(q.pop(), i);
+            }
+        }
+    );
     // pushとpopを複数threadで非同期に行っている
     th1.join();
     th2.join();
@@ -284,25 +301,29 @@ TEST(TransactionQueTest, AsyncMultiPushSinglePopMoreSIZETest)
     // pushさせる物の順は[0, RESIZE)の順列を並び替えた物と同値
     for (long long i = 0; i < num_thread; i++)
     {
-        threads_push.push_back(std::thread([&, i]()
-                                           {
-                                               for (long long j = 0; j < RESIZE / num_thread; j++)
-                                               {
-                                                   q.push((RESIZE / num_thread) * i + j);
-                                               }
-                                           }));
+        threads_push.push_back(std::thread(
+            [&, i]()
+            {
+                for (long long j = 0; j < RESIZE / num_thread; j++)
+                {
+                    q.push((RESIZE / num_thread) * i + j);
+                }
+            }
+        ));
     }
 
     // RESIZE全部出てくるかテスト
     // 順繰りに出てくるわけではないので注意
-    std::thread thread_pop([&]()
-                           {
-                               for (long long i = 0; i < RESIZE; i++)
-                               {
-                                   long long id = q.pop(); // 一つ一つpopする
-                                   check[id]++;            // 値が何回popされたか見る
-                               }
-                           });
+    std::thread thread_pop(
+        [&]()
+        {
+            for (long long i = 0; i < RESIZE; i++)
+            {
+                long long id = q.pop();  // 一つ一つpopする
+                check[id]++;             // 値が何回popされたか見る
+            }
+        }
+    );
 
     // 全部終わるまで待機
     for (auto &th : threads_push)
@@ -314,7 +335,7 @@ TEST(TransactionQueTest, AsyncMultiPushSinglePopMoreSIZETest)
 
     for (long long i = 0; i < RESIZE; i++)
     {
-        EXPECT_EQ(check[i], 1); // 全部一回popされたならok
+        EXPECT_EQ(check[i], 1);  // 全部一回popされたならok
     }
 }
 
@@ -333,27 +354,31 @@ TEST(TransactionQueTest, AsyncSinglePushMultiPopMoreSIZETest)
     }
 
     // 順にpushさせる
-    std::thread thread_push([&]()
-                            {
-                                for (long long i = 0; i < RESIZE; i++)
-                                {
-                                    q.push(i);
-                                }
-                            });
+    std::thread thread_push(
+        [&]()
+        {
+            for (long long i = 0; i < RESIZE; i++)
+            {
+                q.push(i);
+            }
+        }
+    );
 
     // RESIZE個全部出てくるかnum_thread個のthreadでテスト
     // 各threadで順繰りに取れるわけではないので注意
     // 尚，popさせた順は[0, RESIZE)を昇順に並び替えた配列と同値
     for (long long i = 0; i < num_thread; i++)
     {
-        threads_pop.push_back(std::thread([&]()
-                                          {
-                                              for (long long j = 0; j < RESIZE / num_thread; j++)
-                                              {
-                                                  long long id = q.pop(); // 一つ一つpopする
-                                                  check[id]++;            // 値が何回popされたか見る
-                                              }
-                                          }));
+        threads_pop.push_back(std::thread(
+            [&]()
+            {
+                for (long long j = 0; j < RESIZE / num_thread; j++)
+                {
+                    long long id = q.pop();  // 一つ一つpopする
+                    check[id]++;             // 値が何回popされたか見る
+                }
+            }
+        ));
     }
 
     // 全部終わるまで待機
@@ -365,7 +390,7 @@ TEST(TransactionQueTest, AsyncSinglePushMultiPopMoreSIZETest)
 
     for (long long i = 0; i < RESIZE; i++)
     {
-        EXPECT_EQ(check[i], 1); // 全部一回popされたならok
+        EXPECT_EQ(check[i], 1);  // 全部一回popされたならok
     }
 }
 
@@ -388,13 +413,15 @@ TEST(TransactionQueTest, AsyncMultiPushMultiPopMoreSIZETest)
     // pushさせる物の順は[0, RESIZE)の順列を並び替えた物と同値
     for (long long i = 0; i < num_thread; i++)
     {
-        threads_push.push_back(std::thread([&, i]()
-                                           {
-                                               for (long long j = 0; j < RESIZE / num_thread; j++)
-                                               {
-                                                   q.push((RESIZE / num_thread) * i + j);
-                                               }
-                                           }));
+        threads_push.push_back(std::thread(
+            [&, i]()
+            {
+                for (long long j = 0; j < RESIZE / num_thread; j++)
+                {
+                    q.push((RESIZE / num_thread) * i + j);
+                }
+            }
+        ));
     }
 
     // RESIZE個全部出てくるかnum_thread個のthreadでテスト
@@ -402,14 +429,16 @@ TEST(TransactionQueTest, AsyncMultiPushMultiPopMoreSIZETest)
     // 尚，popさせた順は[0, RESIZE)を昇順に並び替えた配列と同値
     for (long long i = 0; i < num_thread; i++)
     {
-        threads_pop.push_back(std::thread([&]()
-                                          {
-                                              for (long long j = 0; j < RESIZE / num_thread; j++)
-                                              {
-                                                  long long id = q.pop(); // 一つ一つpopする
-                                                  check[id]++;            // 値が何回popされたか見る
-                                              }
-                                          }));
+        threads_pop.push_back(std::thread(
+            [&]()
+            {
+                for (long long j = 0; j < RESIZE / num_thread; j++)
+                {
+                    long long id = q.pop();  // 一つ一つpopする
+                    check[id]++;             // 値が何回popされたか見る
+                }
+            }
+        ));
     }
 
     // 全部終わるまで待機
@@ -424,6 +453,6 @@ TEST(TransactionQueTest, AsyncMultiPushMultiPopMoreSIZETest)
 
     for (long long i = 0; i < RESIZE; i++)
     {
-        EXPECT_EQ(check[i], 1); // 全部一回popされたならok
+        EXPECT_EQ(check[i], 1);  // 全部一回popされたならok
     }
 }

--- a/src/ComputationContainer/TransactionQueue/TransactionQueue.hpp
+++ b/src/ComputationContainer/TransactionQueue/TransactionQueue.hpp
@@ -1,49 +1,41 @@
 #pragma once
+#include <condition_variable>
 #include <mutex>
 #include <queue>
-#include <condition_variable>
 
 namespace qmpc::Utils
 {
-    template <typename T>
-    class TransactionQueue
-    {
-        std::mutex mtx;
-        std::condition_variable q_empty, q_max;
-        std::queue<T> q;
-        inline static size_t max_size = 5000;
+template <typename T>
+class TransactionQueue
+{
+    std::mutex mtx;
+    std::condition_variable q_empty, q_max;
+    std::queue<T> q;
+    inline static size_t max_size = 5000;
 
-    public:
-        static void setMax(size_t q_size)
-        {
-            max_size = q_size;
-        }
-        T pop()
-        {
-            std::unique_lock lk(mtx);
-            q_empty.wait(lk, [&]()
-                         { return !q.empty(); });
-            auto ret = q.front();
-            q.pop();
-            q_max.notify_all();
-            return ret;
-        }
-        void push(const T &triple)
-        {
-            std::unique_lock lk(mtx);
-            q_max.wait(lk, [&]()
-                       { return q.size() < TransactionQueue::max_size; });
-            q.push(triple);
-            q_empty.notify_all();
-        }
-        size_t size() const
-        {
-            return q.size();
-        }
-        bool empty() noexcept
-        {
-            std::lock_guard lk(mtx);
-            return q.empty();
-        }
-    };
-}
+public:
+    static void setMax(size_t q_size) { max_size = q_size; }
+    T pop()
+    {
+        std::unique_lock lk(mtx);
+        q_empty.wait(lk, [&]() { return !q.empty(); });
+        auto ret = q.front();
+        q.pop();
+        q_max.notify_all();
+        return ret;
+    }
+    void push(const T &triple)
+    {
+        std::unique_lock lk(mtx);
+        q_max.wait(lk, [&]() { return q.size() < TransactionQueue::max_size; });
+        q.push(triple);
+        q_empty.notify_all();
+    }
+    size_t size() const { return q.size(); }
+    bool empty() noexcept
+    {
+        std::lock_guard lk(mtx);
+        return q.empty();
+    }
+};
+}  // namespace qmpc::Utils

--- a/src/ComputationContainer/TripleHandler/TripleHandler.hpp
+++ b/src/ComputationContainer/TripleHandler/TripleHandler.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <queue>
+#include <tuple>
+
+#include "Client/ComputationToBts/Client.hpp"
 #include "FixedPoint/FixedPoint.hpp"
 #include "PrimeField/PrimeField.hpp"
-#include "Client/ComputationToBts/Client.hpp"
 #include "Share/AddressId.hpp"
-
-#include <tuple>
-#include <queue>
 
 namespace qmpc::TripleHandler
 {


### PR DESCRIPTION
# Summary
Enable SortIncludes option of clang-format.
The part that depends on the include order was excluded from sorting by annotation.

# Purpose
Enable sorting of include order by clang-format without affecting QuickMPC build operation.

# Contents
- Enable SortIncludes
- Annotate include statements that you do not want to be reordered to be excluded from sorting
- Add missing header include identified by sorting

# Testing Methods Performed
The following three tests were conducted at `QuickMPC/Test/` and confirmed successful.
```console
make test t=./ComputationContainer/ p=small
make test t=./ComputationContainer/ p=medium
make test t=./ComputationContainer/ p=benchmark
```