### PR TITLE
Fix to be able to get stacktrace

### DIFF
--- a/src/ComputationContainer/.bazelrc
+++ b/src/ComputationContainer/.bazelrc
@@ -1,3 +1,3 @@
-build --cxxopt=-std=c++17 --cxxopt=-Wall --cxxopt=-O2 --output_filter='^//((?!(external):).)*$'  --cxxopt=-lboost_stacktrace_addr2line --cxxopt=-DBOOST_STACKTRACE_LINK --cxxopt=-DBOOST_STACKTRACE_USE_ADDR2LINE  --cxxopt=-g --cxxopt=-ldl
+build --strip=never --cxxopt=-std=c++17 --cxxopt=-Wall --cxxopt=-O2 --output_filter='^//((?!(external):).)*$' --cxxopt=-g
 
-build:debug --cxxopt=-std=c++17 --cxxopt=-Wall --cxxopt=-O2 --output_filter='^//((?!(external):).)*$' --cxxopt=-lboost_stacktrace_addr2line --cxxopt=-DDEBUG --cxxopt=-DBOOST_STACKTRACE_LINK --cxxopt=-DBOOST_STACKTRACE_USE_ADDR2LINE --cxxopt=-g --cxxopt=-ldl
+build:debug --strip=never --cxxopt=-std=c++17 --cxxopt=-Wall --cxxopt=-O2 --output_filter='^//((?!(external):).)*$' --cxxopt=-g

--- a/src/ComputationContainer/Job/BUILD
+++ b/src/ComputationContainer/Job/BUILD
@@ -12,10 +12,6 @@ cc_library(
         "@Proto//ManageToComputationContainer:manage_to_computation_cc_grpc",
         "//LogHeader:logger"
     ],
-    linkopts=["-lboost_stacktrace_addr2line"],
-    defines=["BOOST_STACKTRACE_LINK",
-        "BOOST_STACKTRACE_USE_ADDR2LINE"],
-    
     visibility = ["//visibility:public"],
 )
 

--- a/src/ComputationContainer/Logging/BUILD
+++ b/src/ComputationContainer/Logging/BUILD
@@ -3,9 +3,9 @@ cc_library(
     hdrs = [
         "Logger.hpp",
     ],
-    linkopts=["-lboost_stacktrace_addr2line"],
+    linkopts=["-lboost_stacktrace_backtrace", "-ldl", "-lbacktrace"],
     defines=["BOOST_STACKTRACE_LINK",
-        "BOOST_STACKTRACE_USE_ADDR2LINE"],
+        "BOOST_STACKTRACE_USE_BACKTRACE"],
     deps = [
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
# Summary

Fixed an issue where stack traces could not be obtained properly in CC.

# Purpose

stack trace is important information

# Contents

- Use backtrace instead of addr2line
- Add `--strip=never` option at bazel build
- Remove unnecessary code

# Testing Methods Performed

I used `qmpc::Log::Debug` in several places and confirmed that a stack trace could be obtained as follows.

- example of insertion:
  ```diff
  diff --git a/src/ComputationContainer/ConfigParse/ConfigParse.hpp b/src/ComputationContainer/ConfigParse/ConfigParse.hpp
  index 5e4647c4..3361ff3a 100644
  --- a/src/ComputationContainer/ConfigParse/ConfigParse.hpp
  +++ b/src/ComputationContainer/ConfigParse/ConfigParse.hpp
  @@ -83,6 +83,7 @@ class Config
   
       Config()
       {
  +        qmpc::Log::Debug(__FILE__, __LINE__);
           party_id = getEnvInt("PARTY_ID");
           n_parties = getEnvInt("N_PARTIES");
           sp_id = getEnvInt("SP_ID");
  ```
- log:
  ```console
  root@dae2cfbfc368:/QuickMPC# ./bazel-bin/computation_container
  2022-08-18 01:22:46+0000|DEBUG|Config::Config() at ./ConfigParse/ConfigParse.hpp:86|./ConfigParse/ConfigParse.hpp|86
  [2022-08-18 01:22:46.757] [info] 3 maps to http://computation_container3:50120 and http://computation_container3:50120
  [2022-08-18 01:22:46.757] [info] 1 maps to http://computation_container1:50120 and http://computation_container1:50120
  ...
  ```