### PR TITLE
Add wrapper scripts for Computation Container

### DIFF
--- a/src/ComputationContainer/Dockerfile
+++ b/src/ComputationContainer/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && \
     curl \
     iputils-ping \
     net-tools \
-    dnsutils
+    dnsutils \
+    gdb
 
 # Install cmake
 RUN wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.sh && \
@@ -55,6 +56,9 @@ RUN cd / && wget https://github.com/gabime/spdlog/archive/refs/tags/v1.9.2.tar.g
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.14 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
+
+# Create directory to save core dump file
+RUN mkdir -p /tmp/cores
 
 FROM base as src
 # 開発環境のフォーマッタを統一
@@ -92,11 +96,14 @@ FROM alpine:3.16.2 as dep-runner
 RUN apk update && \
     apk add curl && \
     apk add --no-cache bash && \
+    apk add gdb && \
     # CVE-2022-0778 対策
     # 公式イメージの upgrade がされていないため
     apk upgrade
 RUN true
 COPY --from=builder /QuickMPC/computation_container /QuickMPC/bazel-bin/computation_container
+RUN true
+COPY --from=builder /QuickMPC/Scripts /QuickMPC/Scripts
 RUN true
 COPY --from=builder /usr/local/lib /usr/local/lib
 RUN true
@@ -107,6 +114,8 @@ RUN true
 COPY --from=builder /lib64 /lib64
 RUN true
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.14 /ko-app/grpc-health-probe /bin/grpc_health_probe
+# Create directory to save core dump file
+RUN mkdir -p /tmp/cores
 WORKDIR /QuickMPC
 
 FROM builder_debug as small
@@ -124,6 +133,9 @@ FROM alpine:latest as large-runner
 RUN apk update && apk add curl
 RUN true
 COPY --from=builder /QuickMPC/bazel-bin/computation_container /QuickMPC/bazel-bin/computation_container
+RUN true
+COPY --from=builder /QuickMPC/Scripts /QuickMPC/Scripts
+RUN true
 # テスト用バイナリ
 COPY --from=builder /QuickMPC/bazel-bin/computation_container_test /QuickMPC/bazel-bin/computation_container_test
 RUN true
@@ -134,4 +146,6 @@ RUN true
 COPY --from=builder /lib/x86_64-linux-gnu /lib/x86_64-linux-gnu
 RUN true
 COPY --from=builder /lib64 /lib64
+# Create directory to save core dump file
+RUN mkdir -p /tmp/cores
 WORKDIR /QuickMPC

--- a/src/ComputationContainer/README.md
+++ b/src/ComputationContainer/README.md
@@ -44,3 +44,24 @@ make rm # docker-compose rm -fs
 ```bash
 make down # docker-compose down
 ```
+
+### How to start Computation Container
+
+#### Host side settings
+
+This is an optional instruction.  
+If it is skipped, logging stack trace will be skipped when Comutation Container is killed with signal.
+
+Set core dump file destination using shell script.
+
+```bash
+./Scripts/host_core_setting.sh  # needs permission to write /proc/sys/kernel/core_pattern
+```
+
+#### Start Computation Container inside a container
+
+Launch Computation Container executable using shell script.
+
+```bash
+/QuickMPC/Scripts/wrapped_run.sh /QuickMPC/bazel-bin/computation_container
+```

--- a/src/ComputationContainer/Scripts/data/core_pattern.txt
+++ b/src/ComputationContainer/Scripts/data/core_pattern.txt
@@ -1,0 +1,1 @@
+/tmp/cores/core_%E_%s_%t

--- a/src/ComputationContainer/Scripts/data/gdb_print_stacktrace_cmd.txt
+++ b/src/ComputationContainer/Scripts/data/gdb_print_stacktrace_cmd.txt
@@ -1,0 +1,3 @@
+backtrace full
+info threads
+thread apply all backtrace full

--- a/src/ComputationContainer/Scripts/host_core_setting.sh
+++ b/src/ComputationContainer/Scripts/host_core_setting.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+CORE_PATTERN_FILE="${SCRIPT_DIR}/data/core_pattern.txt"
+
+# core file size limit setting
+# `-c` option is undefined in POSIX shell, so this script use `bash`
+ulimit -c unlimited
+
+# core file name setting
+CORE_FILE=$(cat "${CORE_PATTERN_FILE}")
+echo "${CORE_FILE}" > /proc/sys/kernel/core_pattern

--- a/src/ComputationContainer/Scripts/wrapped_run.sh
+++ b/src/ComputationContainer/Scripts/wrapped_run.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KERNEL_CORE_PATTERN_FILE="/proc/sys/kernel/core_pattern"
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+CORE_PATTERN_FILE="${SCRIPT_DIR}/data/core_pattern.txt"
+GDB_CMD_FILE="${SCRIPT_DIR}/data/gdb_print_stacktrace_cmd.txt"
+
+set +e
+CORE_PATTERN_CHECK="$(grep "^$(tr -d '\n' < "${CORE_PATTERN_FILE}")$" "${KERNEL_CORE_PATTERN_FILE}")"
+set -e
+
+if [ -z "${CORE_PATTERN_CHECK}" ]
+then
+  echo "WARNING: ${KERNEL_CORE_PATTERN_FILE} does not match what QuickMPC expects."
+  echo "WARNING: Please run ${SCRIPT_DIR}/host_core_setting.sh on host machine."
+fi
+
+if [ $# -le 0 ]
+then
+  echo "Usage: $0 [env_setting]... [executable_file]"
+  echo "Example: $0 LD_PRELOAD=./bazel-bin/libexception_handler.so ./bazel-bin/computation_container"
+  exit 1
+fi
+
+# run
+set +e
+env "${@:1:$(($#-1))}" "${@: -1}"
+
+STATUS=$?
+set -e
+
+if [ $STATUS -eq 0 ]
+then
+  exit 0
+fi
+
+# core pattern check
+if [ -z "${CORE_PATTERN_CHECK}" ]
+then
+  echo "WARNING: ${KERNEL_CORE_PATTERN_FILE} does not match what QuickMPC expects."
+  echo "WARNING: core file analyzing is skipped."
+  exit $STATUS
+fi
+
+# find executable file
+executable_file=""
+
+for arg in "$@"
+do
+  if [[ -x "$arg" ]]
+  then
+    executable_file="$arg"
+  fi
+done
+
+# find latest core file
+core_file=$(find /tmp/cores/ -maxdepth 1 -type f -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1,NR==3 {print $2}' | head -1)
+
+if [ $STATUS -ne 0 ]
+then
+  gdb "${executable_file}" "${core_file}" -x "${GDB_CMD_FILE}" -batch -quiet
+fi
+
+exit $STATUS

--- a/src/ComputationContainer/Scripts/wrapped_run.sh
+++ b/src/ComputationContainer/Scripts/wrapped_run.sh
@@ -21,7 +21,7 @@ fi
 if [ $# -le 0 ]
 then
   echo "Usage: $0 [env_setting]... [executable_file]"
-  echo "Example: $0 LD_PRELOAD=./bazel-bin/libexception_handler.so ./bazel-bin/computation_container"
+  echo "Example: $0 ./bazel-bin/computation_container"
   exit 1
 fi
 


### PR DESCRIPTION
# Summary

- Partially handle unexpected error on CC

# Purpose

- When an unexpected error (ex. SIGSEGV) was occured in CC,  
  there are few debug information.
- This patch will solve this issue partially.

# Contents

- Add wrapper script for lauching CC
- Add core dump file setting script for maintainer
  - This patch is checked that it works in Linux environment

# Testing Methods Performed

- run SIGSEGV code
  ```diff
  diff --git a/src/ComputationContainer/Job/JobBase.hpp b/src/ComputationContainer/Job/JobBase.hpp
  index 2b6cc5c4..373de8c4 100644
  --- a/src/ComputationContainer/Job/JobBase.hpp
  +++ b/src/ComputationContainer/Job/JobBase.hpp
  @@ -166,6 +166,11 @@ public:
           {
               auto [share_table, schemas] = readDb();
               validate_cols(schemas, arg);
  +            if (schemas.size())
  +            {
  +                int *ptr = nullptr;
  +                *ptr = 1;
  +            }
               auto result = static_cast<T *>(this)->compute(share_table, schemas, arg);
               writeDb(result);
           }
  ```
- Use wrapper script
  ```diff
  diff --git a/Test/docker-compose.yml b/Test/docker-compose.yml
  index 836c98d9..bd868add 100644
  --- a/Test/docker-compose.yml
  +++ b/Test/docker-compose.yml
  @@ -32,7 +32,7 @@ services:
       depends_on:
         dev_bts:
           condition: service_healthy
  -    command: ["/bin/bash", "-c", "printenv && ./computation_container"]
  +    command: ["/bin/bash", "-c", "printenv && ./Scripts/wrapped_run.sh ./computation_container"]
       healthcheck:
         test: [
             "CMD-SHELL",
  @@ -73,7 +73,7 @@ services:
       networks:
         shared-network:
           ipv4_address: 10.0.2.20
  -    command: ["/bin/bash", "-c", "printenv && ./computation_container"]
  +    command: ["/bin/bash", "-c", "printenv && ./Scripts/wrapped_run.sh ./computation_container"]
       healthcheck:
         test: [
             "CMD-SHELL",
  @@ -114,7 +114,7 @@ services:
       networks:
         shared-network:
           ipv4_address: 10.0.3.20
  -    command: ["/bin/bash", "-c", "printenv && ./computation_container"]
  +    command: ["/bin/bash", "-c", "printenv && ./Scripts/wrapped_run.sh ./computation_container"]
       healthcheck:
         test: [
             "CMD-SHELL",
  ```
- check log with `docker logs computation_container1`
- check that core dump file can be copied with `docker cp computation_container1:/tmp/cores /`