### PR TITLE
Fix issue that caused SIGSEGV when handling exceptions

### DIFF
--- a/src/ComputationContainer/Job/JobBase.hpp
+++ b/src/ComputationContainer/Job/JobBase.hpp
@@ -130,12 +130,32 @@ public:
         catch (const std::runtime_error &e)
         {
             spdlog::error("{}", static_cast<int>(statusManager.getStatus()));
-            qmpc::Log::Error(*boost::get_error_info<qmpc::Log::traced>(e), e.what(), "Job Error");
+            qmpc::Log::Error(e.what(), "Job Error");
+
+            auto error_info = boost::get_error_info<qmpc::Log::traced>(e);
+            if (error_info)
+            {
+                qmpc::Log::Error(*error_info);
+            }
+            else
+            {
+                qmpc::Log::Error("thrown exception has no stack trace information");
+            }
         }
         catch (const std::exception &e)
         {
             spdlog::error("unexpected Error");
-            qmpc::Log::Error(*boost::get_error_info<qmpc::Log::traced>(e), e.what(), "Job Error");
+            qmpc::Log::Error(e.what(), "Job Error");
+
+            auto *error_info = boost::get_error_info<qmpc::Log::traced>(e);
+            if (error_info)
+            {
+                qmpc::Log::Error(*error_info);
+            }
+            else
+            {
+                qmpc::Log::Error("thrown exception has no stack trace information");
+            }
         }
         return static_cast<int>(statusManager.getStatus());
     }


### PR DESCRIPTION
# Summary

Check if pointer is valid on exception handling

# Purpose

- Fix #17 

# Contents

- e7c7a0a35bd96b1d00672f8acd906cc3ac738984

# Testing Methods Performed

- patch
  ```diff
  diff --git a/src/ComputationContainer/Job/Jobs/CorrelJob.hpp b/src/ComputationContainer/Job/Jobs/CorrelJob.hpp
  index 574435ad..cc59e147 100644
  --- a/src/ComputationContainer/Job/Jobs/CorrelJob.hpp
  +++ b/src/ComputationContainer/Job/Jobs/CorrelJob.hpp
  @@ -18,6 +18,9 @@ public:
           const std::vector<std::list<int>> &arg
       )
       {
  +        std::vector<int> vec;
  +        std::cerr << vec.at(1) << std::endl;
  +
           std::list<std::vector<Share>> cols;
           int n = table.size();
           int m = table[0].size();
  ```
- result
  ```
  computation_container1  | [2022-08-23 10:35:48.671] [info] method id is: 4
  computation_container1  | [2022-08-23 10:35:49.033] [error] unexpected Error
  computation_container1  | 2022-08-23 10:35:49+0000|ERROR|vector::_M_range_check: __n (which is 1) >= this->size() (which is 0)|Job Error
  computation_container1  | 2022-08-23 10:35:49+0000|ERROR|thrown exception has no stack trace information
  ```