### PR TITLE
Fix `make check` command to be runnable on CI

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -136,7 +136,7 @@ login-bts:
 	docker-compose -f $(BTS)/docker-compose.yml exec bts /bin/bash
 
 ROOT_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-SOURCES := $(shell git ls-tree -r develop --name-only | grep -E '.*\.(cpp|hpp)')
+SOURCES := $(shell find $(ROOT_DIR) -type d -name '.cache' -prune -o -type f \( -name *.cpp -o -type f -name *.hpp \) -print | grep -E '.*\.(cpp|hpp)')
 CLANG_FORMAT = clang-format-14 --verbose --style=file:$(ROOT_DIR)/.clang-format
 
 .PHONY: fmt

--- a/src/Makefile
+++ b/src/Makefile
@@ -136,7 +136,7 @@ login-bts:
 	docker-compose -f $(BTS)/docker-compose.yml exec bts /bin/bash
 
 ROOT_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-SOURCES := $(shell find $(ROOT_DIR) -type d -name '.cache' -prune -o -type f \( -name *.cpp -o -type f -name *.hpp \) -print | grep -E '.*\.(cpp|hpp)')
+SOURCES := $(shell find $(ROOT_DIR) -type d -name '.cache' -prune -o -type f \( -name *.cpp -o -type f -name *.hpp \) -print)
 CLANG_FORMAT = clang-format-14 --verbose --style=file:$(ROOT_DIR)/.clang-format
 
 .PHONY: fmt


### PR DESCRIPTION
# Summary

Use `find` command for gathering files on `make check`

# Purpose

- In GitHub Actions, `lint` job does not work correctly 
  - https://github.com/acompany-develop/QuickMPC/runs/7892456395#step:4:9
  - GitHub Actions cannot refer `develop` branch at present

# Contents

- Use `find` command for gathering files

# Testing Methods Performed

- local check that `make check` results is equivalent to `git ls-file ...`