### PR TITLE
Add gRPC interceptor on CC

### DIFF
--- a/src/ComputationContainer/Client/Helper/Helper.hpp
+++ b/src/ComputationContainer/Client/Helper/Helper.hpp
@@ -14,7 +14,7 @@
 
 #include "ConfigParse/ConfigParse.hpp"
 
-class LoggingInterceptor : public grpc::experimental::Interceptor
+class LoggingClientInterceptor : public grpc::experimental::Interceptor
 {
     std::string grpc_method_full_name;
 
@@ -23,7 +23,7 @@ class LoggingInterceptor : public grpc::experimental::Interceptor
     std::string response;
 
 public:
-    explicit LoggingInterceptor(grpc::experimental::ClientRpcInfo *info)
+    explicit LoggingClientInterceptor(grpc::experimental::ClientRpcInfo *info)
         : grpc_method_full_name(info->method())
     {
     }
@@ -74,13 +74,13 @@ public:
     }
 };
 
-class LoggingInterceptorFactory : public grpc::experimental::ClientInterceptorFactoryInterface
+class LoggingClientInterceptorFactory : public grpc::experimental::ClientInterceptorFactoryInterface
 {
 public:
     grpc::experimental::Interceptor *CreateClientInterceptor(grpc::experimental::ClientRpcInfo *info
     ) override
     {
-        return new LoggingInterceptor(info);
+        return new LoggingClientInterceptor(info);
     }
 };
 
@@ -127,7 +127,7 @@ static std::unique_ptr<typename T::Stub> createStub(
         creds = grpc::SslCredentials(grpc::SslCredentialsOptions());
     }
     std::vector<std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>> creators;
-    creators.push_back(std::make_unique<LoggingInterceptorFactory>());
+    creators.push_back(std::make_unique<LoggingClientInterceptorFactory>());
 
     auto channel =
         CreateCustomChannelWithInterceptors(target.getAddress(), creds, args, std::move(creators));

--- a/src/ComputationContainer/Client/Helper/Helper.hpp
+++ b/src/ComputationContainer/Client/Helper/Helper.hpp
@@ -14,6 +14,76 @@
 
 #include "ConfigParse/ConfigParse.hpp"
 
+class LoggingInterceptor : public grpc::experimental::Interceptor
+{
+    std::string grpc_method_full_name;
+
+    bool send_messsage_status;
+    std::string request;
+    std::string response;
+
+public:
+    explicit LoggingInterceptor(grpc::experimental::ClientRpcInfo *info)
+        : grpc_method_full_name(info->method())
+    {
+    }
+
+    void Intercept(grpc::experimental::InterceptorBatchMethods *methods) override
+    {
+        if (methods->QueryInterceptionHookPoint(
+                grpc::experimental::InterceptionHookPoints::PRE_SEND_MESSAGE
+            ))
+        {
+            spdlog::info("{} - [client] send", grpc_method_full_name);
+        }
+
+        if (methods->QueryInterceptionHookPoint(
+                grpc::experimental::InterceptionHookPoints::POST_RECV_STATUS
+            ))
+        {
+            const grpc::Status *status = methods->GetRecvStatus();
+
+            if (status == nullptr)
+            {
+                spdlog::warn("{} - [client] received, gRPC status: nullptr", grpc_method_full_name);
+            }
+            else
+            {
+                if (status->ok())
+                {
+                    spdlog::info(
+                        "{} - [client] received, gRPC status: {}",
+                        grpc_method_full_name,
+                        status->error_code()
+                    );
+                }
+                else
+                {
+                    spdlog::info(
+                        "{} - [client] received, gRPC status: {}, message: {}, details: {}",
+                        grpc_method_full_name,
+                        status->error_code(),
+                        status->error_message(),
+                        status->error_details()
+                    );
+                }
+            }
+        }
+
+        methods->Proceed();
+    }
+};
+
+class LoggingInterceptorFactory : public grpc::experimental::ClientInterceptorFactoryInterface
+{
+public:
+    grpc::experimental::Interceptor *CreateClientInterceptor(grpc::experimental::ClientRpcInfo *info
+    ) override
+    {
+        return new LoggingInterceptor(info);
+    }
+};
+
 /**
  * gRPC チャンネル生成時に渡すデフォルト設定を返す
  */
@@ -43,7 +113,7 @@ static grpc::ChannelArguments getDefaultChannelArguments(
  */
 template <typename T>
 static std::unique_ptr<typename T::Stub> createStub(
-    const Url& target, const grpc::ChannelArguments& args = getDefaultChannelArguments()
+    const Url &target, const grpc::ChannelArguments &args = getDefaultChannelArguments()
 )
 {
     // プロトコルに合わせて credentials を設定
@@ -56,8 +126,11 @@ static std::unique_ptr<typename T::Stub> createStub(
     {
         creds = grpc::SslCredentials(grpc::SslCredentialsOptions());
     }
+    std::vector<std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>> creators;
+    creators.push_back(std::make_unique<LoggingInterceptorFactory>());
 
-    auto channel = CreateCustomChannel(target.getAddress(), creds, args);
+    auto channel =
+        CreateCustomChannelWithInterceptors(target.getAddress(), creds, args, std::move(creators));
+
     return T::NewStub(channel);
-    ;
 }

--- a/src/ComputationContainer/Server/ComputationToComputationContainer/Server.cpp
+++ b/src/ComputationContainer/Server/ComputationToComputationContainer/Server.cpp
@@ -171,6 +171,6 @@ void Server::runServer(std::string endpoint)
     grpc::ServerBuilder builder;
     builder.RegisterService(server);
 
-    runServerCore(builder, "[Cc2Cc]", endpoint);
+    runServerCore(builder, "Cc2Cc", endpoint);
 }
 }  // namespace qmpc::ComputationToComputation

--- a/src/ComputationContainer/Server/ComputationToComputationContainerForJob/Server.cpp
+++ b/src/ComputationContainer/Server/ComputationToComputationContainerForJob/Server.cpp
@@ -56,6 +56,6 @@ void Server::runServer(std::string endpoint)
     grpc::ServerBuilder builder;
     builder.RegisterService(server);
 
-    runServerCore(builder, "[Cc2CcForJob]", endpoint);
+    runServerCore(builder, "Cc2CcForJob", endpoint);
 }
 }  // namespace qmpc::ComputationToComputationForJob

--- a/src/ComputationContainer/Server/Helper/Helper.hpp
+++ b/src/ComputationContainer/Server/Helper/Helper.hpp
@@ -36,7 +36,9 @@ public:
             if (status.ok())
             {
                 spdlog::info(
-                    "{} - [server] send, gRPC status: {}", grpc_method_full_name, status.error_code()
+                    "{} - [server] send, gRPC status: {}",
+                    grpc_method_full_name,
+                    status.error_code()
                 );
             }
             else
@@ -58,7 +60,7 @@ public:
 class LoggingServerInterceptorFactory : public grpc::experimental::ServerInterceptorFactoryInterface
 {
 public:
-    grpc::experimental::Interceptor *CreateServerInterceptor(grpc::experimental::ServerRpcInfo *info
+    grpc::experimental::Interceptor* CreateServerInterceptor(grpc::experimental::ServerRpcInfo* info
     ) override
     {
         return new LoggingServerInterceptor(info);
@@ -85,7 +87,6 @@ static void runServerCore(
 
     // 外部からのSSL通信はインフラレイヤーでhttpに変換するのでInsecureにする
     builder.AddListeningPort(endpoint, grpc::InsecureServerCredentials());
-
 
     std::vector<std::unique_ptr<grpc::experimental::ServerInterceptorFactoryInterface>> creators;
     creators.push_back(std::make_unique<LoggingServerInterceptorFactory>());

--- a/src/ComputationContainer/Server/Helper/Helper.hpp
+++ b/src/ComputationContainer/Server/Helper/Helper.hpp
@@ -24,9 +24,12 @@ public:
     void Intercept(grpc::experimental::InterceptorBatchMethods* methods) override
     {
         if (methods->QueryInterceptionHookPoint(
-                grpc::experimental::InterceptionHookPoints::POST_RECV_MESSAGE
+                grpc::experimental::InterceptionHookPoints::POST_RECV_INITIAL_METADATA
             ))
         {
+            // if this was hooked `POST_RECV_MESSAGE`
+            // and ServerRpcInfo::Type was `CLIENT_STREAMING`,
+            // this was going to be called multiple.
             spdlog::info("{} - [server:{}] received", grpc_method_full_name, server_name);
         }
 

--- a/src/ComputationContainer/Server/Helper/Helper.hpp
+++ b/src/ComputationContainer/Server/Helper/Helper.hpp
@@ -11,10 +11,13 @@
 class LoggingServerInterceptor : public grpc::experimental::Interceptor
 {
     std::string grpc_method_full_name;
+    std::string server_name;
 
 public:
-    explicit LoggingServerInterceptor(grpc::experimental::ServerRpcInfo* info)
-        : grpc_method_full_name(info->method())
+    explicit LoggingServerInterceptor(
+        grpc::experimental::ServerRpcInfo* info, const std::string& server_name
+    )
+        : grpc_method_full_name(info->method()), server_name(server_name)
     {
     }
 
@@ -24,7 +27,7 @@ public:
                 grpc::experimental::InterceptionHookPoints::POST_RECV_MESSAGE
             ))
         {
-            spdlog::info("{} - [server] received", grpc_method_full_name);
+            spdlog::info("{} - [server:{}] received", grpc_method_full_name, server_name);
         }
 
         if (methods->QueryInterceptionHookPoint(
@@ -36,16 +39,18 @@ public:
             if (status.ok())
             {
                 spdlog::info(
-                    "{} - [server] send, gRPC status: {}",
+                    "{} - [server:{}] send, gRPC status: {}",
                     grpc_method_full_name,
+                    server_name,
                     status.error_code()
                 );
             }
             else
             {
                 spdlog::info(
-                    "{} - [server] send, gRPC status: {}, message: {}, details: {}",
+                    "{} - [server:{}] send, gRPC status: {}, message: {}, details: {}",
                     grpc_method_full_name,
+                    server_name,
                     status.error_code(),
                     status.error_message(),
                     status.error_details()
@@ -59,11 +64,16 @@ public:
 
 class LoggingServerInterceptorFactory : public grpc::experimental::ServerInterceptorFactoryInterface
 {
+private:
+    std::string server_name;
+
 public:
+    LoggingServerInterceptorFactory(const std::string& server_name) : server_name(server_name) {}
+
     grpc::experimental::Interceptor* CreateServerInterceptor(grpc::experimental::ServerRpcInfo* info
     ) override
     {
-        return new LoggingServerInterceptor(info);
+        return new LoggingServerInterceptor(info, server_name);
     }
 };
 
@@ -89,7 +99,7 @@ static void runServerCore(
     builder.AddListeningPort(endpoint, grpc::InsecureServerCredentials());
 
     std::vector<std::unique_ptr<grpc::experimental::ServerInterceptorFactoryInterface>> creators;
-    creators.push_back(std::make_unique<LoggingServerInterceptorFactory>());
+    creators.push_back(std::make_unique<LoggingServerInterceptorFactory>(logSource));
     builder.experimental().SetInterceptorCreators(std::move(creators));
 
     std::unique_ptr<grpc::Server> listener(builder.BuildAndStart());
@@ -103,13 +113,13 @@ static void runServerCore(
     else
     {
         spdlog::info(
-            "{:<15 } grpc::DefaultHealthCheckService "
+            "[{:<15 }] grpc::DefaultHealthCheckService "
             "is not enabled on {:<30}",
             logSource,
             endpoint
         );
     }
 
-    spdlog::info("{:<15} Server listening on {:<30}", logSource, endpoint);
+    spdlog::info("[{:<15}] Server listening on {:<30}", logSource, endpoint);
     listener->Wait();
 }

--- a/src/ComputationContainer/Server/ManageToComputationContainer/Server.cpp
+++ b/src/ComputationContainer/Server/ManageToComputationContainer/Server.cpp
@@ -96,24 +96,8 @@ void runServer(std::string endpoint)
 
     grpc::ServerBuilder builder;
 
-    builder.AddListeningPort(endpoint, grpc::InsecureServerCredentials());
     builder.RegisterService(&server);
-    std::unique_ptr<grpc::Server> listener(builder.BuildAndStart());
 
-    // HealthCheckService を有効化する
-    grpc::HealthCheckServiceInterface *service = listener->GetHealthCheckService();
-    if (service != nullptr)
-    {
-        service->SetServingStatus(true);  // 登録した全てのサービスで有効化
-    }
-    else
-    {
-        spdlog::info(
-            "{:<15} grpc::DefaultHealthCheckService is not enabled on {:<30}", "[Mc2Cc]", endpoint
-        );
-    }
-
-    spdlog::info("{:<15} Server listening on {:<30}", "[Mc2Cc]", endpoint);
-    listener->Wait();
+    runServerCore(builder, "[Mc2Cc]", endpoint);
 }
 }  // namespace qmpc::ManageToComputation

--- a/src/ComputationContainer/Server/ManageToComputationContainer/Server.cpp
+++ b/src/ComputationContainer/Server/ManageToComputationContainer/Server.cpp
@@ -98,6 +98,6 @@ void runServer(std::string endpoint)
 
     builder.RegisterService(&server);
 
-    runServerCore(builder, "[Mc2Cc]", endpoint);
+    runServerCore(builder, "Mc2Cc", endpoint);
 }
 }  // namespace qmpc::ManageToComputation


### PR DESCRIPTION
# Summary

- add gRPC interceptor on CC
  - this logs following communication event only
    - received
    - send

# Purpose

- by keeping more logs, it is slightly easier to determine the cause when something went wrong

# Contents

- Use gRPC Interceptor to client and server
- Use `runServerCore` on MC2CC
- Change `runServerCore` behavior to commonize

# Testing Methods Performed

- I ran demo, and checked logs