### PR TITLE
Update LTZ parmeter

### DIFF
--- a/src/ComputationContainer/FixedPoint/FixedPoint.hpp
+++ b/src/ComputationContainer/FixedPoint/FixedPoint.hpp
@@ -103,7 +103,18 @@ public:
             ret = std::numeric_limits<D>::max();
         }
         ret /= shift;
-        return ret.str(20, std::ios_base::fixed);
+        return ret.str(0, std::ios_base::fixed);
+    }
+    T getRoundValue() const
+    {
+        D ret{this->getVal<D>()};
+        if (boost::math::isinf(ret))
+        {
+            ret = std::numeric_limits<D>::max();
+        }
+        ret /= shift;
+        ret = mp::round(ret);
+        return static_cast<T>(ret);
     }
     double getDoubleVal() const
     {

--- a/src/ComputationContainer/FixedPoint/FixedPoint.hpp
+++ b/src/ComputationContainer/FixedPoint/FixedPoint.hpp
@@ -116,6 +116,18 @@ public:
         ret = mp::round(ret);
         return static_cast<T>(ret);
     }
+
+    D getSqrtValue() const
+    {
+        D ret{this->getVal<D>()};
+        if (boost::math::isinf(ret))
+        {
+            ret = std::numeric_limits<D>::max();
+        }
+        ret /= shift;
+        ret = mp::sqrt(ret);
+        return ret;
+    }
     double getDoubleVal() const
     {
         auto ret{this->getVal<double>()};

--- a/src/ComputationContainer/FixedPoint/FixedPoint.hpp
+++ b/src/ComputationContainer/FixedPoint/FixedPoint.hpp
@@ -103,7 +103,7 @@ public:
             ret = std::numeric_limits<D>::max();
         }
         ret /= shift;
-        return ret.str(0, std::ios_base::fixed);
+        return ret.str(20, std::ios_base::fixed);
     }
     T getRoundValue() const
     {

--- a/src/ComputationContainer/Share/Compare.cpp
+++ b/src/ComputationContainer/Share/Compare.cpp
@@ -55,8 +55,10 @@ bool operator<(const Share<FixedPoint> &left, const Share<FixedPoint> &right)
 // Docs/faster-comparison-operators.md
 bool operator==(const Share<FixedPoint> &left, const Share<FixedPoint> &right)
 {
-    auto x_ret = (left < right);
-    auto y_ret = (right < left);
+    // |x-y|<ep <=> (x-y<ep)&(y-x<ep)
+    auto epsilon = 0.0001;
+    auto x_ret = (left < right + epsilon);
+    auto y_ret = (right < left + epsilon);
     auto ret = (FixedPoint(1) - x_ret) * (FixedPoint(1) - y_ret);
 
     if (ret.getDoubleVal() > 0.95)

--- a/src/ComputationContainer/Share/Compare.cpp
+++ b/src/ComputationContainer/Share/Compare.cpp
@@ -187,7 +187,7 @@ bool operator==(const Share<FixedPoint> &left, const FixedPoint &right)
 Share<FixedPoint> LTZ(const Share<FixedPoint> &s)
 {
     // Experimented and adjusted.
-    int m = 32;
+    int m = 28;
     int k = 48;
 
     // s に 2^m をかけて整数化を試みる

--- a/src/ComputationContainer/Share/Compare.cpp
+++ b/src/ComputationContainer/Share/Compare.cpp
@@ -55,8 +55,6 @@ bool operator<(const Share<FixedPoint> &left, const Share<FixedPoint> &right)
 // Docs/faster-comparison-operators.md
 bool operator==(const Share<FixedPoint> &left, const Share<FixedPoint> &right)
 {
-    // |x-y|<ep <=> (x-y<ep)&(y-x<ep)
-    auto epsilon = 0.0001;
     auto x_ret = (left < right);
     auto y_ret = (right < left);
     auto ret = (FixedPoint(1) - x_ret) * (FixedPoint(1) - y_ret);

--- a/src/ComputationContainer/Share/Compare.cpp
+++ b/src/ComputationContainer/Share/Compare.cpp
@@ -184,7 +184,8 @@ bool operator==(const Share<FixedPoint> &left, const FixedPoint &right)
 // Docs/faster-comparison-operators.md
 Share<FixedPoint> LTZ(const Share<FixedPoint> &s)
 {
-    int m = 16;
+    // Experimented and adjusted.
+    int m = 32;
     int k = 48;
 
     // s に 2^m をかけて整数化を試みる

--- a/src/ComputationContainer/Share/Compare.cpp
+++ b/src/ComputationContainer/Share/Compare.cpp
@@ -57,8 +57,8 @@ bool operator==(const Share<FixedPoint> &left, const Share<FixedPoint> &right)
 {
     // |x-y|<ep <=> (x-y<ep)&(y-x<ep)
     auto epsilon = 0.0001;
-    auto x_ret = (left < right + epsilon);
-    auto y_ret = (right < left + epsilon);
+    auto x_ret = (left < right);
+    auto y_ret = (right < left);
     auto ret = (FixedPoint(1) - x_ret) * (FixedPoint(1) - y_ret);
 
     if (ret.getDoubleVal() > 0.95)

--- a/src/ComputationContainer/Share/Compare.cpp
+++ b/src/ComputationContainer/Share/Compare.cpp
@@ -185,7 +185,7 @@ bool operator==(const Share<FixedPoint> &left, const FixedPoint &right)
 Share<FixedPoint> LTZ(const Share<FixedPoint> &s)
 {
     // Experimented and adjusted.
-    int m = 28;
+    int m = 20;
     int k = 48;
 
     // s に 2^m をかけて整数化を試みる

--- a/src/ComputationContainer/Share/Compare.cpp
+++ b/src/ComputationContainer/Share/Compare.cpp
@@ -187,17 +187,18 @@ Share<FixedPoint> LTZ(const Share<FixedPoint> &s)
     int m = 16;
     int k = 48;
 
-    Share<FixedPoint> x = s * FixedPoint(1LL << m);  // s に 2^m をかけて整数化を試みる
-    Share<FixedPoint> y = FixedPoint(1LL << k) + x;
+    // s に 2^m をかけて整数化を試みる
+    Share<FixedPoint> x = s * FixedPoint(std::to_string(1LL << m));
+    Share<FixedPoint> y = FixedPoint(std::to_string(1LL << k)) + x;
     Share<FixedPoint> z = getLSBShare(y);
     y = (y - z) * FixedPoint(0.5);
     for (int i = 1; i < k; ++i)
     {
         Share<FixedPoint> b = getLSBShare(y);
-        z += (b * FixedPoint(1LL << i));
+        z += (b * FixedPoint(std::to_string(1LL << i)));
         y = (y - b) * FixedPoint(0.5);
     }
-    return (z - x) / FixedPoint(1LL << k);
+    return (z - x) / FixedPoint(std::to_string(1LL << k));
 }
 
 // 以下、サブプロトコル

--- a/src/ComputationContainer/Share/Compare.cpp
+++ b/src/ComputationContainer/Share/Compare.cpp
@@ -185,19 +185,19 @@ bool operator==(const Share<FixedPoint> &left, const FixedPoint &right)
 Share<FixedPoint> LTZ(const Share<FixedPoint> &s)
 {
     int m = 16;
-    int k = 32;
+    int k = 48;
 
-    Share<FixedPoint> x = s * FixedPoint(std::pow(2, m));  // s に 2^m をかけて整数化を試みる
-    Share<FixedPoint> y = FixedPoint(std::pow(2, k)) + x;
+    Share<FixedPoint> x = s * FixedPoint(1LL << m);  // s に 2^m をかけて整数化を試みる
+    Share<FixedPoint> y = FixedPoint(1LL << k) + x;
     Share<FixedPoint> z = getLSBShare(y);
     y = (y - z) * FixedPoint(0.5);
     for (int i = 1; i < k; ++i)
     {
         Share<FixedPoint> b = getLSBShare(y);
-        z += (b * FixedPoint(std::pow(2, i)));
+        z += (b * FixedPoint(1LL << i));
         y = (y - b) * FixedPoint(0.5);
     }
-    return (z - x) / FixedPoint(std::pow(2, k));
+    return (z - x) / FixedPoint(1LL << k);
 }
 
 // 以下、サブプロトコル

--- a/src/ComputationContainer/Share/Share.hpp
+++ b/src/ComputationContainer/Share/Share.hpp
@@ -445,7 +445,7 @@ Share<T> getRandBitShare()
         T square_r_rec = recons(square_r);
         if (square_r_rec.getDoubleVal() != 0.0)
         {
-            T r_dash = T(std::sqrt(square_r_rec.getDoubleVal()));
+            T r_dash = T(square_r_rec.getSqrtValue());
             T inv_r_dash = T(1.0) / r_dash;
             Share<T> r0 = Share(T(0.5) * (inv_r_dash * r + T(1.0)));
             return r0;
@@ -467,7 +467,7 @@ std::vector<Share<T>> getRandBitShare(int n)
     {
         if (square_r_rec[i].getDoubleVal() != 0.0)
         {
-            T r_dash = T(std::sqrt(square_r_rec[i].getDoubleVal()));
+            T r_dash = T(square_r_rec[i].getSqrtValue());
             T inv_r_dash = T(1.0) / r_dash;
             Share<T> r0 = Share(T(0.5) * (inv_r_dash * r[i] + T(1.0)));
             ret.emplace_back(r0);

--- a/src/ComputationContainer/Share/Share.hpp
+++ b/src/ComputationContainer/Share/Share.hpp
@@ -490,7 +490,7 @@ Share<T> getLSBShare(const Share<T> &y)
     Share<T> t = y + r0 + T(2) * r_dash;
     open(t);
     T c = recons(t);
-    c = T(std::round(c.getDoubleVal())) % T(2);
+    c = T(c.getRoundValue()) % T(2);
     Share<T> b = c + r0 - T(2) * c * r0;
     return b;
 }
@@ -507,7 +507,7 @@ std::vector<Share<T>> getLSBShare(const std::vector<Share<T>> &y)
     b.reserve(y.size());
     for (int j = 0; j < static_cast<int>(c.size()); ++j)
     {
-        c[j] = T(std::round(c[j].getDoubleVal())) % T(2);
+        c[j] = T(c[j].getRoundValue()) % T(2);
         b.emplace_back(c[j] + r0[j] - T(2) * c[j] * r0[j]);
     }
 

--- a/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
@@ -528,6 +528,29 @@ TEST(ShareCompTest, EqualityTest)
     EXPECT_EQ(ret.getVal(), 0);
 }
 
+TEST(ShareTest, EqualityEpsilonTest)
+{
+    Config *conf = Config::getInstance();
+    int n_parties = conf->n_parties;
+
+    // m,k is LTZ parameters
+    int m = 32;
+    int k = 48;
+    for (int _ = 0; _ < 10; ++_)
+    {
+        auto val1 = RandGenerator::getInstance()->getRand<long long>(2, (1LL << k) - 1);
+        auto val2 = val1 - 1;
+
+        auto val_d1 = static_cast<double>(val1) / (1LL << m) / n_parties;
+        auto val_d2 = static_cast<double>(val2) / (1LL << m) / n_parties;
+
+        auto s1 = Share(FixedPoint(std::to_string(val_d1)));
+        auto s2 = Share(FixedPoint(std::to_string(val_d2)));
+
+        EXPECT_EQ(s1 == s2, false);
+    }
+}
+
 //一括open,reconsテスト
 TEST(ShareCompTest, ShareCompReconsBulk)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
@@ -547,8 +547,8 @@ TEST(ShareTest, EqualityEpsilonTest)
         std::cerr << val_d1 << " == " << val_d2 << " : " << (val_d1 == val_d2) << std::endl;
         std::cerr << "\t" << std::abs(val_d1 - val_d2) << std::endl;
 
-        auto s1 = Share(FixedPoint(std::to_string(val_d1)));
-        auto s2 = Share(FixedPoint(std::to_string(val_d2)));
+        auto s1 = Share(FixedPoint((boost::format("%.10f") % val_d1).str()));
+        auto s2 = Share(FixedPoint((boost::format("%.10f") % val_d2).str()));
 
         EXPECT_EQ(s1 == s2, false);
     }

--- a/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
@@ -528,32 +528,6 @@ TEST(ShareCompTest, EqualityTest)
     EXPECT_EQ(ret.getVal(), 0);
 }
 
-TEST(ShareTest, EqualityEpsilonTest)
-{
-    Config *conf = Config::getInstance();
-    int n_parties = conf->n_parties;
-
-    // m,k is LTZ parameters
-    int m = 32 - 3;
-    int k = 48;
-    for (int _ = 0; _ < 10; ++_)
-    {
-        auto val1 = RandGenerator::getInstance()->getRand<long long>(2, (1LL << k) - 1);
-        auto val2 = val1 - 10;
-
-        auto val_d1 = static_cast<double>(val1) / (1LL << m) / n_parties;
-        auto val_d2 = static_cast<double>(val2) / (1LL << m) / n_parties;
-
-        std::cerr << val_d1 << " == " << val_d2 << " : " << (val_d1 == val_d2) << std::endl;
-        std::cerr << "\t" << std::abs(val_d1 - val_d2) << std::endl;
-
-        auto s1 = Share(FixedPoint((boost::format("%.10f") % val_d1).str()));
-        auto s2 = Share(FixedPoint((boost::format("%.10f") % val_d2).str()));
-
-        EXPECT_EQ(s1 == s2, false);
-    }
-}
-
 //一括open,reconsテスト
 TEST(ShareCompTest, ShareCompReconsBulk)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
@@ -534,15 +534,18 @@ TEST(ShareTest, EqualityEpsilonTest)
     int n_parties = conf->n_parties;
 
     // m,k is LTZ parameters
-    int m = 32;
+    int m = 32 - 3;
     int k = 48;
     for (int _ = 0; _ < 10; ++_)
     {
         auto val1 = RandGenerator::getInstance()->getRand<long long>(2, (1LL << k) - 1);
-        auto val2 = val1 - 1;
+        auto val2 = val1 - 10;
 
         auto val_d1 = static_cast<double>(val1) / (1LL << m) / n_parties;
         auto val_d2 = static_cast<double>(val2) / (1LL << m) / n_parties;
+
+        std::cerr << val_d1 << " == " << val_d2 << " : " << (val_d1 == val_d2) << std::endl;
+        std::cerr << "\t" << std::abs(val_d1 - val_d2) << std::endl;
 
         auto s1 = Share(FixedPoint(std::to_string(val_d1)));
         auto s2 = Share(FixedPoint(std::to_string(val_d2)));

--- a/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
@@ -718,6 +718,36 @@ TEST(ShareTest, ComparisonOperation)
     EXPECT_TRUE(d >= c);
 }
 
+TEST(ShareTest, EqualityEpsilonRandomTest)
+{
+    Config *conf = Config::getInstance();
+    int n_parties = conf->n_parties;
+
+    // m,k is LTZ parameters
+    int m = 28;
+    int k = 48;
+    std::vector<std::pair<long long, long long>> random_range{
+        {1, 10},                            // small case
+        {1LL << (k - 1), (1LL << k) - 2}};  // large case
+    for (const auto &[lower, upper] : test_pair)
+    {
+        for (int _ = 0; _ < 10; ++_)
+        {
+            auto val1 = RandGenerator::getInstance()->getRand<long long>(lower, upper);
+            auto val2 = val1 + 1;
+
+            auto val_d1 = static_cast<double>(val1) / (1LL << (m - 2)) / n_parties;
+            auto val_d2 = static_cast<double>(val2) / (1LL << (m - 2)) / n_parties;
+
+            auto s1 = Share(FixedPoint((boost::format("%.10f") % val_d1).str()));
+            auto s2 = Share(FixedPoint((boost::format("%.10f") % val_d2).str()));
+
+            EXPECT_TRUE(s1 == s1);
+            EXPECT_FALSE(s1 == s2);
+        }
+    }
+}
+
 // ランダムな値で比較演算のテストを実行
 TEST(ShareTest, RandomComparisonOperation)
 {

--- a/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
@@ -729,7 +729,7 @@ TEST(ShareTest, EqualityEpsilonRandomTest)
     std::vector<std::pair<long long, long long>> random_range{
         {1, 10},                            // small case
         {1LL << (k - 1), (1LL << k) - 2}};  // large case
-    for (const auto &[lower, upper] : test_pair)
+    for (const auto &[lower, upper] : random_range)
     {
         for (int _ = 0; _ < 10; ++_)
         {

--- a/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
@@ -724,11 +724,11 @@ TEST(ShareTest, EqualityEpsilonRandomTest)
     int n_parties = conf->n_parties;
 
     // m,k is LTZ parameters
-    int m = 28;
+    int m = 20;
     int k = 48;
     std::vector<std::pair<long long, long long>> random_range{
-        {1, 10},                            // small case
-        {1LL << (k - 1), (1LL << k) - 2}};  // large case
+        {1, 10},                             // small case
+        {1LL << (k - 1), (1LL << k) - 20}};  // large case
     for (const auto &[lower, upper] : random_range)
     {
         for (int _ = 0; _ < 10; ++_)
@@ -736,8 +736,8 @@ TEST(ShareTest, EqualityEpsilonRandomTest)
             auto val1 = RandGenerator::getInstance()->getRand<long long>(lower, upper);
             auto val2 = val1 + 1;
 
-            auto val_d1 = static_cast<double>(val1) / (1LL << (m - 2)) / n_parties;
-            auto val_d2 = static_cast<double>(val2) / (1LL << (m - 2)) / n_parties;
+            auto val_d1 = static_cast<double>(val1) / (1LL << (m - 3)) / n_parties;
+            auto val_d2 = static_cast<double>(val2) / (1LL << (m - 3)) / n_parties;
 
             auto s1 = Share(FixedPoint((boost::format("%.10f") % val_d1).str()));
             auto s2 = Share(FixedPoint((boost::format("%.10f") % val_d2).str()));

--- a/src/ComputationContainer/Test/UnitTest/FixedPointTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/FixedPointTest.cpp
@@ -201,11 +201,16 @@ TEST(FixedPointTest, Equation)
 TEST(FixedPointTest, getVal)
 {
     FixedPoint a("1.45");  // operand
-    EXPECT_EQ(a.getStrVal(), "1.45000000000000000000");
+    EXPECT_EQ(
+        a.getStrVal(), "1.4500000000000000000000000000000000000000000000000000000000000000000000000"
+    );
     EXPECT_EQ(a.getDoubleVal(), 1.45);
 
     FixedPoint b("-1.45");  // operand
-    EXPECT_EQ(b.getStrVal(), "-1.45000000000000000000");
+    EXPECT_EQ(
+        b.getStrVal(),
+        "-1.4500000000000000000000000000000000000000000000000000000000000000000000000"
+    );
     EXPECT_EQ(b.getDoubleVal(), -1.45);
 }
 

--- a/src/ComputationContainer/Test/UnitTest/FixedPointTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/FixedPointTest.cpp
@@ -201,16 +201,11 @@ TEST(FixedPointTest, Equation)
 TEST(FixedPointTest, getVal)
 {
     FixedPoint a("1.45");  // operand
-    EXPECT_EQ(
-        a.getStrVal(), "1.4500000000000000000000000000000000000000000000000000000000000000000000000"
-    );
+    EXPECT_EQ(a.getStrVal(), "1.45000000000000000000");
     EXPECT_EQ(a.getDoubleVal(), 1.45);
 
     FixedPoint b("-1.45");  // operand
-    EXPECT_EQ(
-        b.getStrVal(),
-        "-1.4500000000000000000000000000000000000000000000000000000000000000000000000"
-    );
+    EXPECT_EQ(b.getStrVal(), "-1.45000000000000000000");
     EXPECT_EQ(b.getDoubleVal(), -1.45);
 }
 


### PR DESCRIPTION
# Summary
Update LTZ parmeter

# Purpose
Allow larger values to be used to avoid ID collisions

# Contents
- Update LTZ parmeter k (32 -> 48), m (16 -> 20)
- Fix 2^x value on LTZ
- Fix getRoundValue

# Testing Methods Performed
- CI
- medium test
- 1000 rows horizontal join using mail address ID

# Etc
## collision probability
Assuming 1 million data, at least less than 1%. [calculation](https://www.wolframalpha.com/input?i2d=true&i=1-Divide%5B1%2CPower%5B%5C%2840%29Power%5B2%2C46%5D%5C%2841%29%2C%5C%2840%29Power%5B10%2C6%5D%5C%2841%29%5D%5D*%5C%2840%29Divide%5B%5C%2840%29Power%5B2%2C46%5D%5C%2841%29%21%2C%5C%2840%29Power%5B2%2C46%5D-Power%5B10%2C6%5D%5C%2841%29%21%5D%5C%2841%29&lang=ja)

## speed
Since it should be linear with respect to k, it can be estimated to be 1.5 times. But it was faster than I expected.
Larger sizes may produce different results, but this is time consuming and will be omitted here.
k is LTZ parameter. H is table row size.
||H=5|H=10|H=100|
|-|-|-|-|
|k=32|9.77s|10.86s|45.41s|
|k=48|10.50s|11.73s|51.76s|
