### PR TITLE
Fix target branch name on GitHub Actions

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -3,9 +3,8 @@ name: Build CC, MC, DB and Run Build and Test in Each Containers
 on:
   pull_request:
     branches:
-      - develop
+      - main
       - "feature/**"
-      - "migration/**"
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Push Stable CC, MC, DB Image
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   # 安定バージョンのQMPCイメージをpush


### PR DESCRIPTION
# Summary

- Fix target branch name on GitHub Actions

# Purpose

- default branch is change to `main` from `develop`

# Contents

- Fix target branch name on GitHub Actions
- Remove unused target branch

# Testing Methods Performed

CI