### PR TITLE
Add healthcheck on secrets server

### DIFF
--- a/Test/docker-compose.yml
+++ b/Test/docker-compose.yml
@@ -191,7 +191,7 @@ services:
         ipv4_address: 10.0.1.31
     depends_on:
       dev_secrets-server:
-        condition: service_started
+        condition: service_healthy
 
   dev_dbgate2:
     container_name: dbgate_container2
@@ -252,7 +252,7 @@ services:
         ipv4_address: 10.0.2.31
     depends_on:
       dev_secrets-server:
-        condition: service_started
+        condition: service_healthy
 
   dev_dbgate3:
     container_name: dbgate_container3
@@ -313,7 +313,7 @@ services:
         ipv4_address: 10.0.3.31
     depends_on:
       dev_secrets-server:
-        condition: service_started
+        condition: service_healthy
 
   dev_secrets-server:
     container_name: secrets-server
@@ -425,7 +425,7 @@ services:
         ipv4_address: 10.0.1.131
     depends_on:
       src_secrets-server:
-        condition: service_started
+        condition: service_healthy
 
   src_secrets-server:
     container_name: secrets-server
@@ -693,7 +693,7 @@ services:
       - "0.0.0.0:60131:8091"
     depends_on:
       small_secrets-server:
-        condition: service_started
+        condition: service_healthy
 
   small_secrets-server:
     container_name: secrets-server

--- a/src/DbContainer/secrets-server.Dockerfile
+++ b/src/DbContainer/secrets-server.Dockerfile
@@ -15,6 +15,9 @@ ENV lowercase_DB_NAMES=${lowercase_DB_NAMES}
 
 RUN mkdir /files
 
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 \
+    CMD curl http://localhost:8000
+
 # NOTE: 秘密情報を消し去りたいとき、Imageの削除だけでなくビルドキャッシュも削除する必要がある
 # その際に`docker system prune --filter label=secrets-server`でこのImageのキャッシュだけ削除できるようにするためのもの
 LABEL secrets-server=


### PR DESCRIPTION
# Summary

Add healthcheck on secrets server

# Purpose

- Recently, CI is unstable.  This PR may fix it
  - https://github.com/acompany-develop/QuickMPC/runs/8263087085#step:4:689

# Reason

- service sharedb depends on secrets-server: `service_started`
- sharedb is going to GET data from secrets-server with no-retry
  - https://github.com/acompany-develop/QuickMPC/blob/b09ac2223b168c9ad50ed4695d1e414978cc4a85/src/DbContainer/.bashrc#L4-L15
- if secrets-server was not healthy, initialization of sharedb would be failed

# Another solution

- retry if secrets-server is not healthy
  - it is needed, but this PR is for quick-fix

# Contents

- Add healthcheck on secrets server 2643fdcde37a6e520b83f65314aa0108632903d2
- Make service to need that secrets server is healthy da9ca24febec3c756a24f50871aee36e43f29a28

# Testing Methods Performed

- re-run CI 5 times