### PR TITLE
Fix FixedPoint infinity check

### DIFF
--- a/src/ComputationContainer/FixedPoint/FixedPoint.hpp
+++ b/src/ComputationContainer/FixedPoint/FixedPoint.hpp
@@ -65,7 +65,11 @@ public:
                 value = static_cast<T>(std::numeric_limits<U>::max());
             }
             else
-                value = static_cast<T>(v * shift);
+            {
+                // cast to `D` first to avoid going infinity
+                const D value_float = static_cast<D>(v);
+                value = static_cast<T>(value_float * shift);
+            }
         }
         else
             value = static_cast<T>(v * shift);

--- a/src/ComputationContainer/Test/UnitTest/FixedPointTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/FixedPointTest.cpp
@@ -287,3 +287,17 @@ TEST(FixedPointTest, Abs)
     FixedPoint b("-1.45");
     EXPECT_EQ(qmpc::Utils::abs(b), a);
 }
+
+TEST(FixedPointTest, Inf)
+{
+    try
+    {
+        FixedPoint a(1e301);
+    }
+    catch (const std::exception &e)
+    {
+        EXPECT_TRUE(false);  // failed
+        return;
+    }
+    EXPECT_TRUE(true);  // succeed
+}


### PR DESCRIPTION
# Summary

temporary fixed an issue in CC that caused calculation results going to infinity.

# Purpose

If `boost::multiprecision::cpp_int` constructor received `std::numeric_limits<double>::infinity()`,  
it called `abort` on version 1.65.1 .

# Contents

- 45557a38943175de0add1a838e950c0fc829a252 Add test case
- c57402b95a8797acc695fcd1551eaa1c44cc0281 Fix it

# Testing Methods Performed

- CC small test
- CC medium test
