### PR TITLE
Parallelize hjoin with BulkCompare

### DIFF
--- a/Test/LibClient/src/benchmark/data.py
+++ b/Test/LibClient/src/benchmark/data.py
@@ -152,7 +152,7 @@ def large_data(size: int, data_num: int):
 
     mod = 47
     data: List[List[str]] = [
-        [str(((i*size + k) % mod)/mod)for k in range(schema_size)]
+        [str(i)] + [str(((i*size + k) % mod)/mod)for k in range(schema_size-1)]
         for i in range(size)
     ]
     return qmpc.parse_csv_data([schema]+data)

--- a/src/ComputationContainer/Client/ComputationToDbGate/BUILD
+++ b/src/ComputationContainer/Client/ComputationToDbGate/BUILD
@@ -27,6 +27,7 @@ cc_library(
     deps = [
         "@nlohmann_json//:json",
         "//Share:share",
+        "//Share:compare"
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
+++ b/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
@@ -177,8 +177,8 @@ std::vector<std::pair<int, int>> intersectionSortedValueIndex(
             }
             // lessとgreaterも並列で行う
             comp_l.emplace_back(sorted_v1[i1]);
-            comp_l.emplace_back(sorted_v1[i2]);
-            comp_r.emplace_back(sorted_v1[i2]);
+            comp_l.emplace_back(sorted_v2[i2]);
+            comp_r.emplace_back(sorted_v2[i2]);
             comp_r.emplace_back(sorted_v1[i1]);
         }
 

--- a/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
+++ b/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
@@ -106,7 +106,7 @@ std::vector<std::pair<int, int>> intersectionSortedValueIndex(
     std::vector<int> lower(block_nums, -1);
     std::vector<int> upper(block_nums, len - 1);
     int iterated_num = std::log2(len) + 1;
-    for (int i = 0; i < iterated_num; ++i)
+    for (int progress_i = 0; progress_i < iterated_num; ++progress_i)
     {
         std::vector<int> mid_v(block_nums);
         for (int i = 0; i < block_nums; ++i)
@@ -126,7 +126,7 @@ std::vector<std::pair<int, int>> intersectionSortedValueIndex(
         {
             (less_eq[i] ? upper[i] : lower[i]) = mid_v[i];
         }
-        double progress = 100.0 * i / iterated_num;
+        double progress = 100.0 * progress_i / iterated_num;
         spdlog::info("[progress] hjoin: binary search (0/1): {:>5.2f} %", progress);
     }
     spdlog::info("[progress] hjoin: binary search (1/1): {:>5.2f} %", 100);

--- a/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
+++ b/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
@@ -78,7 +78,7 @@ std::vector<std::pair<int, int>> intersectionSortedValueIndex(
     const std::vector<T> &sorted_v1, const std::vector<T> &sorted_v2
 )
 {
-    // v2がソートされている必要あり
+    // v1, v2がソートされている必要あり
     spdlog::info("[progress] hjoin: core (0/1)");
 
     int size = sorted_v1.size();

--- a/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
+++ b/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
@@ -84,7 +84,7 @@ std::vector<std::pair<int, int>> intersectionSortedValueIndex(
     int size = sorted_v1.size();
     int len = sorted_v2.size();
     // ブロックサイズ(S)とブロック数(N):N:=size/S
-    // サイズO(N)のBulk比較をO(Slog(len) + S)回行う
+    // サイズO(N)のBulk比較をO(log(len) + S)回行う
     int block_size = std::min(100, size);
     int block_nums = (size + block_size - 1) / block_size;
 

--- a/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
+++ b/src/ComputationContainer/Client/ComputationToDbGate/ValueTable.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -85,7 +86,7 @@ std::vector<std::pair<int, int>> intersectionSortedValueIndex(
     // ブロックサイズ(S)とブロック数(N):N:=size/S
     // サイズO(N)のBulk比較をO(Slog(len) + S)回行う
     int block_size = std::min(100, size);
-    int block_nums = size / block_size;
+    int block_nums = (size + block_size - 1) / block_size;
 
     std::vector<int> block_it;
     std::vector<T> block_s;
@@ -104,9 +105,8 @@ std::vector<std::pair<int, int>> intersectionSortedValueIndex(
     spdlog::info("[progress] hjoin: binary search (0/1): {:>5.2f} %", 0);
     std::vector<int> lower(block_nums, -1);
     std::vector<int> upper(block_nums, len - 1);
-    auto d_max = len;
-    int iterated = 0;
-    while (d_max > 1)
+    int iterated_num = std::log2(len) + 1;
+    for (int i = 0; i < iterated_num; ++i)
     {
         std::vector<int> mid_v(block_nums);
         for (int i = 0; i < block_nums; ++i)
@@ -122,13 +122,11 @@ std::vector<std::pair<int, int>> intersectionSortedValueIndex(
         }
 
         auto less_eq = qmpc::Share::allLessEq(block_s, target);
-        d_max = 0;
         for (int i = 0; i < block_nums; ++i)
         {
             (less_eq[i] ? upper[i] : lower[i]) = mid_v[i];
-            d_max = std::max(d_max, upper[i] - lower[i]);
         }
-        double progress = 100.0 - d_max * 100.0 / len;
+        double progress = 100.0 * i / iterated_num;
         spdlog::info("[progress] hjoin: binary search (0/1): {:>5.2f} %", progress);
     }
     spdlog::info("[progress] hjoin: binary search (1/1): {:>5.2f} %", 100);
@@ -193,7 +191,7 @@ std::vector<std::pair<int, int>> intersectionSortedValueIndex(
         // [0th less, 0th greater, 1st less, 1st greater ....]
         auto comp = qmpc::Share::allLess(comp_l, comp_r);
         auto comp_it = 0;
-        auto progress = 0.0;
+        auto progress = 100.0;
         for (int i = 0; i < block_nums; ++i)
         {
             if (fin[i])


### PR DESCRIPTION
# Summary
Accelerate `intersectionSortedValueIndex`

# Purpose
Accelerate hjoin

# Contents
- Fix ID of hjoin test table
- Parallelize `intersectionSortedValueIndex` with BulkCompare
  - Step1: Split into blocks using parallel binary search
  - Step2: Parallel scanning per block

# Testing Methods Performed
- CI
- make test t=LibClient p=benchmark
- make test t=ComputationContainer p=benchmark

# Benchmark

2-patry
|(second)|N=10|N=100|N=1,000|N=10,000|N=100,000|
|-|-|-|-|-|-|
|PR ver|4|15|24|115|973|
|old ver|6|15|111|1027|9989|
