### PR TITLE
Remove warning on ComputationContainer

### DIFF
--- a/src/ComputationContainer/Client/AnyToDb/Client.cpp
+++ b/src/ComputationContainer/Client/AnyToDb/Client.cpp
@@ -82,6 +82,7 @@ std::string Client::executeQuery(const std::string &query) const
         std::string res;
         for (const auto &[_, piece] : pieces)
         {
+            static_cast<void>(_);  // NOTE: unused warningを消すため
             res.append(piece);
         }
         return res;

--- a/src/ComputationContainer/ConfigParse/ConfigParse.hpp
+++ b/src/ComputationContainer/ConfigParse/ConfigParse.hpp
@@ -132,7 +132,6 @@ class Config
             {
                 return std::stoi(env_map[std::string(s)]);
             }
-            qmpc::Log::throw_with_trace(std::runtime_error(std::string(s) + " is not defined"));
         }
         else
         {
@@ -141,8 +140,8 @@ class Config
             {
                 return atoi(tmp);
             }
-            qmpc::Log::throw_with_trace(std::runtime_error(std::string(s) + " is not defined"));
         }
+        qmpc::Log::throw_with_trace(std::runtime_error(std::string(s) + " is not defined"));
     }
     std::string getEnvString(const char *s)
     {
@@ -154,7 +153,6 @@ class Config
             {
                 return env_map[std::string(s)];
             }
-            qmpc::Log::throw_with_trace(std::runtime_error(std::string(s) + " is not defined"));
         }
         else
         {
@@ -163,8 +161,8 @@ class Config
             {
                 return std::string(tmp);
             }
-            qmpc::Log::throw_with_trace(std::runtime_error(std::string(s) + " is not defined"));
         }
+        qmpc::Log::throw_with_trace(std::runtime_error(std::string(s) + " is not defined"));
     }
     Url getEnvUrl(const char *s)
     {
@@ -176,7 +174,6 @@ class Config
             {
                 return Url::Parse(env_map[std::string(s)]);
             }
-            qmpc::Log::throw_with_trace(std::runtime_error(std::string(s) + " is not defined"));
         }
         else
         {
@@ -185,8 +182,8 @@ class Config
             {
                 return Url::Parse(tmp);
             }
-            qmpc::Log::throw_with_trace(std::runtime_error(std::string(s) + " is not defined"));
         }
+        qmpc::Log::throw_with_trace(std::runtime_error(std::string(s) + " is not defined"));
     }
 
 public:

--- a/src/ComputationContainer/GBDT/SGBM.hpp
+++ b/src/ComputationContainer/GBDT/SGBM.hpp
@@ -30,13 +30,12 @@ public:
     {
     }
     /**
-    /**
      * @brief 指定した決定技アルゴリズムでブースティングを実行
      * ブースティング時のハイパーパラメータ
      * 木の数、学習率lr,最大深度max_depth,葉の最大枚数max_leaves
      *
      *
-    */
+     */
     auto boosting(size_t numIterations)
     {
         //予測結果
@@ -49,7 +48,7 @@ public:
         {
             //誤差
             std::vector<Share> diff(T.size());
-            for (int i = 0; i < T.size(); ++i)
+            for (size_t i = 0; i < T.size(); ++i)
             {
                 diff[i] = targets[i] - currentY[i];
             }
@@ -57,7 +56,7 @@ public:
             //勾配結果を取得
             auto grad = tree->grad();
             //予測値
-            for (int i = 0; i < T.size(); ++i)
+            for (size_t i = 0; i < T.size(); ++i)
             {
                 currentY[i] = currentY[i] + lr * grad[i];
             }

--- a/src/ComputationContainer/GBDT/SID3.cpp
+++ b/src/ComputationContainer/GBDT/SID3.cpp
@@ -23,7 +23,7 @@ Share SID3::majorityClass(const std::vector<std::vector<Share>> &U) const
         base_count.emplace_back(static_cast<int>(count.getDoubleVal()), index);
         index++;
     }
-    auto [max_num, max_num_index] = *max_element(base_count.begin(), base_count.end());
+    auto max_num_index = max_element(base_count.begin(), base_count.end())->second;
     // TODO:正確にShare化する必要があるが分類の場合はこのままで良い
     Share ret = qmpc::Share::getConstantShare(FixedPoint(max_num_index));
     return ret;
@@ -60,11 +60,11 @@ Share SID3::dot(const std::vector<Share> &x, const std::vector<Share> &y) const
 auto SID3::getMaxGini(const std::vector<std::vector<Share>> &U) const
 {
     auto gini_indexies = calcGini(U, R);
-    for (const auto &[gini_, index] : gini_indexies)
-    {
-        // spdlog::info("gini_ is {}",gini_);
-        // spdlog::info("index is {}",index);
-    }
+    // for (const auto &[gini_, index] : gini_indexies)
+    // {
+    //     spdlog::info("gini_ is {}",gini_);
+    //     spdlog::info("index is {}",index);
+    // }
     if (gini_indexies.empty()) return std::make_pair<double, int>(-1, -1);
     auto ret = *std::max_element(gini_indexies.begin(), gini_indexies.end());
     return ret;

--- a/src/ComputationContainer/GBDT/SID3.hpp
+++ b/src/ComputationContainer/GBDT/SID3.hpp
@@ -113,7 +113,7 @@ public:
         const std::vector<std::vector<Share>> &targets,
         const std::set<int> &R
     )
-        : T(T), S(bit_data), targets(targets), R(R), att_class(-1), y(FixedPoint(-1))
+        : T(T), S(bit_data), targets(targets), att_class(-1), R(R), y(FixedPoint(-1))
     {
         size = dataSize();
     }

--- a/src/ComputationContainer/GBDT/SID3Regression.cpp
+++ b/src/ComputationContainer/GBDT/SID3Regression.cpp
@@ -54,7 +54,7 @@ Share SID3Regression::infomationGain(const std::vector<Share> &category) const
     auto average_mask = averageVec * mask;
     auto target_mask = targets * mask;
     Share ret;
-    for (int i = 0; i < T.size(); ++i)
+    for (size_t i = 0; i < T.size(); ++i)
     {
         Share cur = target_mask[i] - average_mask[i];
         cur *= cur;
@@ -177,10 +177,10 @@ std::shared_ptr<SID3Regression> SID3Regression::createTree(
     std::tie(current->error_value, current->att_class) = current->IG();
 
     // TODO:ここではデータ数に対してうまく調整したほうが良いかも
-    if (R.empty() or (T.size() >= 3 * current->size) or (0 == current->size)) return current;
+    if (R.empty() or (T.size() >= 3u * current->size) or (0u == current->size)) return current;
     auto R_ = R;
     R_.erase(current->att_class);
-    for (int j = 0; j < S[current->att_class].size(); ++j)
+    for (size_t j = 0; j < S[current->att_class].size(); ++j)
     {
         auto T_ = T * S[current->att_class][j];
         auto child = createTree(T_, S, targets, R_);

--- a/src/ComputationContainer/GBDT/SID3Regression.hpp
+++ b/src/ComputationContainer/GBDT/SID3Regression.hpp
@@ -106,7 +106,7 @@ public:
         const std::vector<Share> &targets,
         const std::set<int> &R
     )
-        : T(T), S(S), targets(targets), R(R), att_class(-1)
+        : T(T), S(S), targets(targets), att_class(-1), R(R)
     {
         size = dataSize();
         y = dot(targets, T);

--- a/src/ComputationContainer/Logging/Logger.hpp
+++ b/src/ComputationContainer/Logging/Logger.hpp
@@ -56,7 +56,7 @@ public:
     constexpr Log(Log::LogLevel level) : level(level) {}
     //例外生成用関数
     template <class E>
-    static void throw_with_trace(const E &e)
+    [[noreturn]] static void throw_with_trace(const E &e)
     {
         throw boost::enable_error_info(e) << traced(boost::stacktrace::stacktrace());
     }

--- a/src/ComputationContainer/Optimizer/Adam.hpp
+++ b/src/ComputationContainer/Optimizer/Adam.hpp
@@ -39,7 +39,7 @@ class Adam : public qmpc::Optimizer::OptInterface
         {
             auto l1 = f.df(1, theta);
             auto l2 = l1 * l1;
-            for (int i = 0; i < size; ++i)
+            for (size_t i = 0; i < size; ++i)
             {
                 mt[i] = beta1 * mt[i] + (1 - beta1) * l1[i];
                 vt[i] = beta2 * vt[i] + (1 - beta2) * l2[i];
@@ -47,7 +47,7 @@ class Adam : public qmpc::Optimizer::OptInterface
             beta1_pow *= beta1.getDoubleVal();
             beta2_pow *= beta2.getDoubleVal();
             auto b_t = std::sqrt(1 - beta2_pow) / (1 - beta1_pow);
-            for (int i = 0; i < size; ++i)
+            for (size_t i = 0; i < size; ++i)
             {
                 theta[i] = theta[i] - alpha * mt[i] * FixedPoint(b_t) / (sqrt(vt[i]) + eps);
             }
@@ -79,7 +79,6 @@ public:
     */
     Shares optimize(int iterationNum, const interface &f, const Shares &theta) const override
     {
-        size_t sz = std::size(theta);
         return adapt(iterationNum, theta, f);
     }
 };

--- a/src/ComputationContainer/Optimizer/Momentum.hpp
+++ b/src/ComputationContainer/Optimizer/Momentum.hpp
@@ -23,8 +23,8 @@ class Momentum : public qmpc::Optimizer::OptInterface
 {
     using Share = ::Share;
     using interface = qmpc::ObjectiveFunction::ObjectiveFunctionInterface;
-    const ::FixedPoint beta;
     const ::FixedPoint alpha;
+    const ::FixedPoint beta;
     const int batch_size;
     std::vector<Share> moment(
         int iterationNum,

--- a/src/ComputationContainer/Server/Helper/Helper.hpp
+++ b/src/ComputationContainer/Server/Helper/Helper.hpp
@@ -85,7 +85,7 @@ public:
  * @param logSource ログ発行元を示す文字列（例："[Cc2CcForJob]", "[Cc2Cc]"）
  * @param endpoint エンドポイント
  */
-static void runServerCore(
+inline void runServerCore(
     grpc::ServerBuilder& builder, const std::string& logSource, const std::string& endpoint
 )
 {

--- a/src/ComputationContainer/Share/Compare.hpp
+++ b/src/ComputationContainer/Share/Compare.hpp
@@ -144,18 +144,17 @@ std::pair<Share<int>, std::vector<Share<int>>> unitvPrep()
     std::vector<AddressId> addressIds(N * N);
     std::vector<Share<int>> ret(N * N);
     Config *conf = Config::getInstance();
-    auto server = ComputationToComputation::Server::getServer();
     auto random_s = RandGenerator::getInstance()->getRandVec<long long>(1, 1 << 20, N);
     auto r = RandGenerator::getInstance()->getRand<long long>(0, N - 1);
     int n_parties = conf->n_parties;
     int pt_id = conf->party_id - 1;
-    for (int i = 0; i < N * N; ++i)
+    for (size_t i = 0; i < N * N; ++i)
     {
         addressIds[i] = e[i].getId();
     }
     if (pt_id == 0)
     {
-        for (int i = 0; i < N * N; ++i)
+        for (size_t i = 0; i < N * N; ++i)
         {
             if (i % N == i / N) e[i] = 1;
             e[i] += random_s[i % N];
@@ -165,7 +164,7 @@ std::pair<Share<int>, std::vector<Share<int>>> unitvPrep()
         send(e, (pt_id + 1) % n_parties + 1);
         auto s = receive<int>((pt_id + n_parties - 1) % n_parties + 1, addressIds);
 
-        for (int i = 0; i < N * N; ++i)
+        for (size_t i = 0; i < N * N; ++i)
         {
             ret[i] = s[i] - random_s[i % N];
         }
@@ -173,13 +172,13 @@ std::pair<Share<int>, std::vector<Share<int>>> unitvPrep()
     else
     {
         auto s = receive<int>((pt_id + n_parties - 1) % n_parties + 1, addressIds);
-        for (int i = 0; i < N * N; ++i)
+        for (size_t i = 0; i < N * N; ++i)
         {
             e[i] = s[i] + random_s[i % N];
         }
         std::rotate(e.begin(), e.begin() + r * N, e.end());
         send(e, (pt_id + 1) % n_parties + 1);
-        for (int i = 0; i < N * N; ++i)
+        for (size_t i = 0; i < N * N; ++i)
         {
             ret[i] = -random_s[i % N];
         }

--- a/src/ComputationContainer/Share/Networking.hpp
+++ b/src/ComputationContainer/Share/Networking.hpp
@@ -134,7 +134,7 @@ auto recons(const T &share)
             auto s = server->getShare(pt_id, share.getId());
             if constexpr (std::is_same_v<Result, bool>)
             {
-                ret ^= Result{std::stoi(s)};
+                ret ^= Result{s == "1"};
             }
             else if constexpr (std::is_integral_v<Result>)
             {
@@ -142,7 +142,7 @@ auto recons(const T &share)
             }
             else if constexpr (std::is_floating_point_v<Result>)
             {
-                ret += Result{std::stod(s)};
+                ret += Result{std::stof(s)};
             }
             else
             {

--- a/src/ComputationContainer/Test/Benchmark/ShareCompBenchmark.hpp
+++ b/src/ComputationContainer/Test/Benchmark/ShareCompBenchmark.hpp
@@ -198,7 +198,7 @@ TEST(ShareCompBenchmark, BStoSC)
         {
             // IntegrationTest/ShareCompTest.hpp からコピペ
             // ShareCompTest のテストケースの中から1個取ってきた
-            auto test_case = PrimeField(14055031461681146081);
+            auto test_case = PrimeField(14055031461681146081ull);
             auto a_shares = qmpc::Share::PFtoBS(test_case);
             ShareComp ans = qmpc::Share::BStoSC(a_shares);
         }
@@ -215,7 +215,7 @@ TEST(ShareCompBenchmark, PFtoBS)
         {
             // IntegrationTest/ShareCompTest.hpp からコピペ
             // ShareCompTest のテストケースの中から1個取ってきた
-            auto test_case = PrimeField(11990882371217920413);
+            auto test_case = PrimeField(11990882371217920413ull);
             auto a_shares = qmpc::Share::PFtoBS(test_case);
         }
     );

--- a/src/ComputationContainer/Test/IntegrationTest/GBDTTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/GBDTTest.hpp
@@ -12,7 +12,6 @@
 auto bitVecCreater = [](const std::vector<std::vector<int>> &data)
 {
     int col = std::size(data[0]);
-    int row = std::size(data);
 
     std::vector<std::vector<std::vector<FixedPoint>>> fixed_vec;
     for (int i = 0; i < col; ++i)
@@ -23,8 +22,9 @@ auto bitVecCreater = [](const std::vector<std::vector<int>> &data)
         {
             col_value[cur[i]] = -1;
         }
-        for (auto &[key, value] : col_value)
+        for (auto &[_, value] : col_value)
         {
+            static_cast<void>(_);  // NOTE: unused warningを消すため
             value = index++;
         }
         int value_size = std::size(col_value);
@@ -185,10 +185,10 @@ TEST(SID3RegTest, categoryError)
     auto convertToShare = [](const std::vector<std::vector<FixedPoint>> &test_data)
     {
         std::vector<std::vector<Share>> stest_data;
-        for (int i = 0; i < test_data.size(); ++i)
+        for (size_t i = 0; i < test_data.size(); ++i)
         {
             std::vector<Share> test_(test_data[i].size());
-            for (int j = 0; j < test_data[i].size(); ++j)
+            for (size_t j = 0; j < test_data[i].size(); ++j)
             {
                 test_[j] = qmpc::Share::getConstantShare(test_data[i][j]);
             }
@@ -260,7 +260,7 @@ TEST(SGBMTest, treeGradTest)
         tt += FixedPoint(1);
     }
     std::set<int> R;
-    for (int i = 0; i < x.size(); ++i)
+    for (size_t i = 0; i < x.size(); ++i)
     {
         R.insert(i);
     }
@@ -269,7 +269,7 @@ TEST(SGBMTest, treeGradTest)
     auto tree_grads = tree->grad();
     open(tree_grads);
     auto grads = recons(tree_grads);
-    for (int i = 0; i < T.size(); ++i)
+    for (size_t i = 0; i < T.size(); ++i)
     {
         spdlog::info("grad {} is {}", i, grads[i]);
     }
@@ -281,10 +281,10 @@ TEST(SGBMTest, treeGradTest)
     auto convertToShare = [](const std::vector<std::vector<FixedPoint>> &test_data)
     {
         std::vector<std::vector<Share>> stest_data;
-        for (int i = 0; i < test_data.size(); ++i)
+        for (size_t i = 0; i < test_data.size(); ++i)
         {
             std::vector<Share> test_(test_data[i].size());
-            for (int j = 0; j < test_data[i].size(); ++j)
+            for (size_t j = 0; j < test_data[i].size(); ++j)
             {
                 test_[j] = qmpc::Share::getConstantShare(test_data[i][j]);
             }
@@ -347,7 +347,7 @@ TEST(SGBMTest, GBDTRegressionTest)
         tt += FixedPoint(1);
     }
     std::set<int> R;
-    for (int i = 0; i < x.size(); ++i)
+    for (size_t i = 0; i < x.size(); ++i)
     {
         R.insert(i);
     }
@@ -355,7 +355,7 @@ TEST(SGBMTest, GBDTRegressionTest)
     auto pred = gt.boosting(20);
     open(pred);
     auto p_rec = recons(pred);
-    for (int i = 0; i < t.size(); ++i)
+    for (size_t i = 0; i < t.size(); ++i)
     {
         spdlog::info("pred is {}", p_rec[i]);
         spdlog::info("t is {}", t_rec[i]);
@@ -375,10 +375,10 @@ TEST(SGBMTest, GBDTRegressionTest)
     auto convertToShare = [](const std::vector<std::vector<FixedPoint>> &test_data)
     {
         std::vector<std::vector<Share>> stest_data;
-        for (int i = 0; i < test_data.size(); ++i)
+        for (size_t i = 0; i < test_data.size(); ++i)
         {
             std::vector<Share> test_(test_data[i].size());
-            for (int j = 0; j < test_data[i].size(); ++j)
+            for (size_t j = 0; j < test_data[i].size(); ++j)
             {
                 test_[j] = qmpc::Share::getConstantShare(test_data[i][j]);
             }
@@ -435,9 +435,9 @@ TEST(SID3Test, sid3JsonConstructorTest)
 
     std::vector<std::vector<FixedPoint>> t_ = {{1, 1, 0, 1, 0}, {0, 0, 1, 0, 0}, {0, 0, 0, 0, 1}};
     std::vector<std::vector<Share>> t(t_.size(), std::vector<Share>(t_[0].size()));
-    for (int i = 0; i < t_.size(); ++i)
+    for (size_t i = 0; i < t_.size(); ++i)
     {
-        for (int j = 0; j < t_[i].size(); ++j)
+        for (size_t j = 0; j < t_[i].size(); ++j)
         {
             t[i][j] = qmpc::Share::getConstantShare(t_[i][j]);
         }
@@ -490,9 +490,9 @@ TEST(SID3Test, sid3JsonPredictTest)
 
     std::vector<std::vector<FixedPoint>> t_ = {{1, 1, 0, 1, 0}, {0, 0, 1, 0, 0}, {0, 0, 0, 0, 1}};
     std::vector<std::vector<Share>> t(t_.size(), std::vector<Share>(t_[0].size()));
-    for (int i = 0; i < t_.size(); ++i)
+    for (size_t i = 0; i < t_.size(); ++i)
     {
-        for (int j = 0; j < t_[i].size(); ++j)
+        for (size_t j = 0; j < t_[i].size(); ++j)
         {
             t[i][j] = qmpc::Share::getConstantShare(t_[i][j]);
         }
@@ -519,10 +519,10 @@ TEST(SID3Test, sid3JsonPredictTest)
     auto convertToShare = [](const std::vector<std::vector<FixedPoint>> &test_data)
     {
         std::vector<std::vector<Share>> stest_data;
-        for (int i = 0; i < test_data.size(); ++i)
+        for (size_t i = 0; i < test_data.size(); ++i)
         {
             std::vector<Share> test_(test_data[i].size());
-            for (int j = 0; j < test_data[i].size(); ++j)
+            for (size_t j = 0; j < test_data[i].size(); ++j)
             {
                 test_[j] = qmpc::Share::getConstantShare(test_data[i][j]);
             }

--- a/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareCompTest.hpp
@@ -67,7 +67,7 @@ TEST(ShareCompTest, DivBetweenShareComps)
     a = a / b;
     open(a);
     PrimeField a_rec = recons(a);
-    EXPECT_EQ(a_rec, PrimeField(9223372036854775779));
+    EXPECT_EQ(a_rec, PrimeField(9223372036854775779ull));
 }
 
 TEST(ShareCompTest, AddBetweenShareCompAndPrimeField)
@@ -352,16 +352,16 @@ TEST(ShareCompTest, BStoSC)
     bool flag = true;  // テストが失敗した場合falseになる
     // テストケース
     PrimeField test_case[10] = {
-        PrimeField(8404635061939753279),
-        PrimeField(14055031461681146081),
-        PrimeField(4401882840069225473),
-        PrimeField(955727980728323728),
-        PrimeField(11939286497068664120),
-        PrimeField(7128445707545015008),
-        PrimeField(13165665109915604075),
-        PrimeField(2146559468229273184),
-        PrimeField(12307437278508535873),
-        PrimeField(2264793496591040620)};
+        PrimeField(8404635061939753279ull),
+        PrimeField(14055031461681146081ull),
+        PrimeField(4401882840069225473ull),
+        PrimeField(955727980728323728ull),
+        PrimeField(11939286497068664120ull),
+        PrimeField(7128445707545015008ull),
+        PrimeField(13165665109915604075ull),
+        PrimeField(2146559468229273184ull),
+        PrimeField(12307437278508535873ull),
+        PrimeField(2264793496591040620ull)};
 
     for (int i = 0; i < 10; i++)
     {
@@ -386,16 +386,16 @@ TEST(ShareCompTest, PFtoBS)
     bool flag = true;  // テストが失敗した場合falseになる
     // テストケース
     PrimeField test_case[10] = {
-        PrimeField(5801164259233537525),
-        PrimeField(11990882371217920413),
-        PrimeField(12133433930879247631),
-        PrimeField(12367114231622338330),
-        PrimeField(5019517851162398891),
-        PrimeField(4135365588412164698),
-        PrimeField(5721501916669856084),
-        PrimeField(12279116850396682003),
-        PrimeField(7702089081674672791),
-        PrimeField(1083686755848627406)};
+        PrimeField(5801164259233537525ull),
+        PrimeField(11990882371217920413ull),
+        PrimeField(12133433930879247631ull),
+        PrimeField(12367114231622338330ull),
+        PrimeField(5019517851162398891ull),
+        PrimeField(4135365588412164698ull),
+        PrimeField(5721501916669856084ull),
+        PrimeField(12279116850396682003ull),
+        PrimeField(7702089081674672791ull),
+        PrimeField(1083686755848627406ull)};
 
     for (int i = 0; i < 10; i++)
     {

--- a/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ShareTest.hpp
@@ -763,8 +763,6 @@ TEST(ShareTest, ComparisonOperation)
 
 TEST(ShareTest, ComparisonOperationBulk)
 {
-    Config *conf = Config::getInstance();
-    int n_parties = conf->n_parties;
     Share a(FixedPoint("2.0"));
     Share b(FixedPoint("3.0"));
     std::vector<Share> l{a, a, b, b};
@@ -1125,8 +1123,6 @@ TEST(StreamTest, ReconsBulk)
     }
     open(t);
     auto target = recons(t);
-    bool ng = false;
-
     for (int i = 0; i < static_cast<int>(t.size()); ++i)
     {
         EXPECT_NEAR(target[i].getDoubleVal(), expected[i].getDoubleVal(), 0.00001);
@@ -1134,13 +1130,11 @@ TEST(StreamTest, ReconsBulk)
 }
 TEST(ShareTest, GenericSendShare)
 {
-    Config *conf = Config::getInstance();
-    int n_parties = conf->n_parties;
     {
         const auto clock_start = std::chrono::system_clock::now();
         qmpc::Share::Share<bool> a{};
         open(a);
-        auto a_rec = recons(a);
+        [[maybe_unused]] auto _ = recons(a);
         const auto clock_end = std::chrono::system_clock::now();
         const auto elapsed_time_ms =
             std::chrono::duration_cast<std::chrono::microseconds>(clock_end - clock_start).count();
@@ -1150,7 +1144,7 @@ TEST(ShareTest, GenericSendShare)
         const auto clock_start = std::chrono::system_clock::now();
         qmpc::Share::Share<int> b(4);
         open(b);
-        auto b_rec = recons(b);
+        [[maybe_unused]] auto _ = recons(b);
         const auto clock_end = std::chrono::system_clock::now();
         const auto elapsed_time_ms =
             std::chrono::duration_cast<std::chrono::microseconds>(clock_end - clock_start).count();
@@ -1160,7 +1154,7 @@ TEST(ShareTest, GenericSendShare)
         const auto clock_start = std::chrono::system_clock::now();
         qmpc::Share::Share<long> c(4);
         open(c);
-        auto c_rec = recons(c);
+        [[maybe_unused]] auto _ = recons(c);
         const auto clock_end = std::chrono::system_clock::now();
         const auto elapsed_time_ms =
             std::chrono::duration_cast<std::chrono::microseconds>(clock_end - clock_start).count();
@@ -1170,7 +1164,7 @@ TEST(ShareTest, GenericSendShare)
         const auto clock_start = std::chrono::system_clock::now();
         qmpc::Share::Share<float> d{};
         open(d);
-        auto d_rec = recons(d);
+        [[maybe_unused]] auto _ = recons(d);
         const auto clock_end = std::chrono::system_clock::now();
         const auto elapsed_time_ms =
             std::chrono::duration_cast<std::chrono::microseconds>(clock_end - clock_start).count();
@@ -1180,7 +1174,7 @@ TEST(ShareTest, GenericSendShare)
         const auto clock_start = std::chrono::system_clock::now();
         qmpc::Share::Share<double> e{};
         open(e);
-        auto e_rec = recons(e);
+        [[maybe_unused]] auto _ = recons(e);
         const auto clock_end = std::chrono::system_clock::now();
         const auto elapsed_time_ms =
             std::chrono::duration_cast<std::chrono::microseconds>(clock_end - clock_start).count();
@@ -1190,7 +1184,7 @@ TEST(ShareTest, GenericSendShare)
         const auto clock_start = std::chrono::system_clock::now();
         qmpc::Share::Share<FixedPoint> f{};
         open(f);
-        auto f_rec = recons(f);
+        [[maybe_unused]] auto _ = recons(f);
         const auto clock_end = std::chrono::system_clock::now();
         const auto elapsed_time_ms =
             std::chrono::duration_cast<std::chrono::microseconds>(clock_end - clock_start).count();
@@ -1200,7 +1194,7 @@ TEST(ShareTest, GenericSendShare)
         const auto clock_start = std::chrono::system_clock::now();
         qmpc::Share::Share<PrimeField> f{};
         open(f);
-        auto f_rec = recons(f);
+        [[maybe_unused]] auto _ = recons(f);
         const auto clock_end = std::chrono::system_clock::now();
         const auto elapsed_time_ms =
             std::chrono::duration_cast<std::chrono::microseconds>(clock_end - clock_start).count();
@@ -1247,40 +1241,30 @@ TEST(ShareTest, mulIntShare)
 }
 TEST(ShareTest, boolLarge)
 {
-    Config *conf = Config::getInstance();
-    int n_parties = conf->n_parties;
     std::vector<qmpc::Share::Share<bool>> a(50000, true);
     open(a);
     auto target = recons(a);
 }
 TEST(ShareTest, IntLarge)
 {
-    Config *conf = Config::getInstance();
-    int n_parties = conf->n_parties;
     std::vector<qmpc::Share::Share<int>> a(50000, 1);
     open(a);
     auto target = recons(a);
 }
 TEST(ShareTest, floatLarge)
 {
-    Config *conf = Config::getInstance();
-    int n_parties = conf->n_parties;
     std::vector<qmpc::Share::Share<float>> a(50000, 1);
     open(a);
     auto target = recons(a);
 }
 TEST(ShareTest, doubleLarge)
 {
-    Config *conf = Config::getInstance();
-    int n_parties = conf->n_parties;
     std::vector<qmpc::Share::Share<double>> a(50000, 1);
     open(a);
     auto target = recons(a);
 }
 TEST(ShareTest, FPLarge)
 {
-    Config *conf = Config::getInstance();
-    int n_parties = conf->n_parties;
     std::vector<qmpc::Share::Share<FixedPoint>> a(50000, FixedPoint("1"));
     open(a);
     auto target = recons(a);
@@ -1387,7 +1371,7 @@ TEST(ShareTest, expandTest)
         int x = 5;  // 00000011
         auto d = qmpc::Share::expand(x, delta);
         std::vector<int> expected = {0, 0, 0, 0, 0, 0, 0, 5};
-        for (int i = 0; i < d.size(); ++i)
+        for (size_t i = 0; i < d.size(); ++i)
         {
             EXPECT_EQ(expected[i], d[i]);
         }
@@ -1396,7 +1380,7 @@ TEST(ShareTest, expandTest)
         int y = -5;
         auto d = qmpc::Share::expand(y, delta);
         std::vector<int> expected = {0, 3, 31, 31, 31, 31, 31, 27};
-        for (int i = 0; i < d.size(); ++i)
+        for (size_t i = 0; i < d.size(); ++i)
         {
             EXPECT_EQ(expected[i], d[i]);
         }


### PR DESCRIPTION
# Summary
Remove warning

# Purpose
Clean log at build time.

# Contents
- `control reaches end of non-void function`
  - use `[[noreturn]]` attribute
    <details>
    <summary>example</summary>
  
    ```C++
    // warning
    auto throw_func(){
      throw std::runtime_error(hoge);
    }
    auto func(){
      if(b){return 0;}
      throw_func();
    } // control reaches end of non-void function

    // no warning
    [[noreturn]] auto throw_func(){
      throw std::runtime_error(hoge);
    }
     auto func(){
       if(b){return 0;}
       throw_func();
     } 
    ```
    </details>
- `X defined but not used `
  - remove `static` and add `inline`
- `unused variable X`
  - remove `X` or add `[[maybe_unused]] `attribute
- `X will be initialized after `
  - sort member initializer list
- `comparison between signed and unsigned integer expressions `
  - replace `int` to `size_t`
- `integer constant is so large that it is unsigned`
  - add ull to suffix
- `"/*" within comment`
  - remove this
- `narrowing conversion of X from Y to Z`
  - replace conversion function

# Testing Methods Performed
- check build log
``` console
# bazel build //:all --config=debug
INFO: Analyzed 4 targets (167 packages loaded, 4914 targets configured).
INFO: Found 4 targets...
INFO: Elapsed time: 2486.999s, Critical Path: 243.04s
INFO: 2071 processes: 27 internal, 2044 processwrapper-sandbox.
INFO: Build completed successfully, 2071 total actions
```