### PR TITLE
Use symbolic link to run clang-format

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -137,7 +137,7 @@ login-bts:
 
 ROOT_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 SOURCES := $(shell find $(ROOT_DIR) -type d -name '.cache' -prune -o -type f \( -name *.cpp -o -type f -name *.hpp \) -print)
-CLANG_FORMAT = clang-format-14 --verbose --style=file:$(ROOT_DIR)/.clang-format
+CLANG_FORMAT = clang-format --verbose --style=file:$(ROOT_DIR)/.clang-format
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
# Summary

Use symbolic link to run clang-format

# Purpose

There is no need to use specific version of command

# Contents

Use symbolic link to run clang-format

# Testing Methods Performed

- env: Ubuntu 22.04
- run `make check` in `src` directory