### PR TITLE
Remove pipenv from libClient test and benchmark

### DIFF
--- a/Test/LibClient/Dockerfile
+++ b/Test/LibClient/Dockerfile
@@ -8,9 +8,7 @@ COPY QuickMPC-libClient-py /QuickMPC-libClient-py
 # install pipenv and modules
 WORKDIR /LibClient
 RUN pip install -U pip && \
-    pip install pipenv && \
-    pipenv --python=3.7 && \
-    pipenv install --skip-lock \
+    pip install \
       pytest \
       seaborn \
       scikit-learn \

--- a/Test/docker-compose.yml
+++ b/Test/docker-compose.yml
@@ -1103,7 +1103,7 @@ services:
       - type: bind
         source: ./LibClient/src
         target: /LibClient/src
-    command: ["/bin/bash", "-c", "pipenv run pip list && pipenv run pytest src/tests -s -v -log-cli-level=DEBUG"]
+    command: ["/bin/bash", "-c", "pip list && pytest src/tests -s -v -log-cli-level=DEBUG"]
     network_mode: "host"
     depends_on:
       dev_mc1:
@@ -1126,7 +1126,7 @@ services:
       - type: bind
         source: ./LibClient/src
         target: /LibClient/src
-    command: ["/bin/bash", "-c", "pipenv run pip list && pipenv run pytest src/benchmark -s -v -log-cli-level=DEBUG"]
+    command: ["/bin/bash", "-c", "pip list && pytest src/benchmark -s -v -log-cli-level=DEBUG"]
     network_mode: "host"
     depends_on:
       dev_mc1:


### PR DESCRIPTION
# Summary
Remove pipenv

# Purpose
Fix libClient test

# Contents
- Remove pipenv from libClient Dockerfile

# Testing Methods Performed
- make test t=LibClient p=medium
- CI

# Details
The following changes were made Pipenv version 2022.10.9.
- When you create a pipenv project with a python version, the following two items are written to the Pipfile
  - python_version
  - python_full_version

ref: [Pipenv release note](https://pipenv.pypa.io/en/latest/changelog/#id4)

However, the following error occurs when trying to install the module as is.
```console
python_full_version: 'python_version' must not be present with 'python_full_version'
python_version: 'python_full_version' must not be present with 'python_version'
```
wow... Really? I don't understand... So I remove Pipenv. 