### PR TITLE
Fix argument name for building DBG image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,8 @@ jobs:
 
       - name: Build DbGate image
         run: |
-          docker build ../../../ --file Dockerfile --target dep-runner --build-arg lowercase_DB_NAME=sharedb --tag ghcr.io/${{ github.repository_owner }}/quickmpc-dbg:s${{ steps.date.outputs.date }}
-          docker build ../../../ --file Dockerfile --target dep-runner --build-arg lowercase_DB_NAME=sharedb --tag ghcr.io/${{ github.repository_owner }}/quickmpc-dbg:stable
+          docker build ../../../ --file Dockerfile --target dep-runner --build-arg lowercase_DB_NAMES=sharedb --tag ghcr.io/${{ github.repository_owner }}/quickmpc-dbg:s${{ steps.date.outputs.date }}
+          docker build ../../../ --file Dockerfile --target dep-runner --build-arg lowercase_DB_NAMES=sharedb --tag ghcr.io/${{ github.repository_owner }}/quickmpc-dbg:stable
         working-directory: ./src/DbContainer/DbGate/
 
       - name: Run Trivy vulnerability scanner for DbGate


### PR DESCRIPTION
# Summary

- Fix argument when building docker image for DBG

# Purpose

- DBG use `lowercase_DB_NAMES` not `lowercase_DB_NAME` (which is used in sharedb container)

# Contents

- 8de920ab41d0516f9ca07f9321ab88687fd15617 Fix argument when building docker image for DBG

# Testing Methods Performed

- Check following CI log to know issue
  - https://github.com/acompany-develop/QuickMPC/actions/runs/3190452740/jobs/5205578994#step:5:4494
- local build and use it