### PR TITLE
Add aging test to libClient benchmark

### DIFF
--- a/Test/LibClient/src/benchmark/test_linear.py
+++ b/Test/LibClient/src/benchmark/test_linear.py
@@ -7,6 +7,12 @@ from utils import get_result, qmpc
 from benchmark.data import iris, penguins, titanic
 from benchmark.metrics import MetricsOutputer
 
+# types: (iterate_num, train_size)
+test_parameters = [
+    (10, 15),
+    (10, 30)
+]
+
 
 def linear_sklearn(train_x, train_y, test_x):
     """ sklearnの線形回帰 """
@@ -68,77 +74,68 @@ def linear_qmpc(train_x, train_y, test_x):
 
 
 @pytest.mark.parametrize(
-    ("train_size"),
-    [
-        (15), (30)
-    ]
+    ("iterate_num", "train_size"), test_parameters
 )
-def test_linear_titanic(train_size):
-    # 現実時間で学習を終わらせるためサイズを小さくする
-    train_x, train_y, test_x, test_y, _, _ = titanic()
-    train_x = train_x[:train_size]
-    train_y = train_y[:train_size]
-
-    # trainデータで学習してtestデータでの推測値を得る
-    pred_y_qmpc = linear_qmpc(train_x, train_y, test_x)
-    pred_y_sklearn = linear_sklearn(train_x, train_y, test_x)
-
-    # 指標を出力
+def test_linear_titanic(iterate_num: int, train_size: int):
     mo = MetricsOutputer("regression")
-    mo.append("sklean", test_y, pred_y_sklearn)
-    mo.append("QuickMPC", test_y, pred_y_qmpc)
+    for _ in range(iterate_num):
+        # 現実時間で学習を終わらせるためサイズを小さくする
+        train_x, train_y, test_x, test_y, _, _ = titanic()
+        train_x = train_x[:train_size]
+        train_y = train_y[:train_size]
+
+        # trainデータで学習してtestデータでの推測値を得る
+        pred_y_qmpc = linear_qmpc(train_x, train_y, test_x)
+        pred_y_sklearn = linear_sklearn(train_x, train_y, test_x)
+
+        mo.append("sklean", test_y, pred_y_sklearn)
+        mo.append("QuickMPC", test_y, pred_y_qmpc)
     mo.output()
 
 
 @pytest.mark.parametrize(
-    ("train_size"),
-    [
-        (15), (30)
-    ]
+    ("iterate_num", "train_size"), test_parameters
 )
-def test_linear_iris(train_size):
-    # 現実時間で学習を終わらせるためサイズを小さくする
-    train_x, train_y_list, test_x, test_y_list, _, _ = iris()
-    train_x = train_x[:train_size]
-    train_y_list = train_y_list[:train_size]
-
+def test_linear_iris(iterate_num: int, train_size: int):
     mo = MetricsOutputer("regression")
-    labels = ["setosa", "versicolor", "virginica"]
+    for _ in range(iterate_num):
+        # 現実時間で学習を終わらせるためサイズを小さくする
+        train_x, train_y_list, test_x, test_y_list, _, _ = iris()
+        train_x = train_x[:train_size]
+        train_y_list = train_y_list[:train_size]
 
-    # trainデータで学習してtestデータでの推測値を得る
-    for label, train_y, test_y in \
-            zip(labels, train_y_list.transpose(), test_y_list.transpose()):
-        pred_y_qmpc = linear_qmpc(train_x, train_y, test_x)
-        pred_y_sklearn = linear_sklearn(train_x, train_y, test_x)
+        labels = ["setosa", "versicolor", "virginica"]
 
-        mo.append(f"[{label}] sklean", test_y, pred_y_sklearn)
-        mo.append(f"[{label}] QuickMPC", test_y, pred_y_qmpc)
+        # trainデータで学習してtestデータでの推測値を得る
+        for label, train_y, test_y in \
+                zip(labels, train_y_list.transpose(), test_y_list.transpose()):
+            pred_y_qmpc = linear_qmpc(train_x, train_y, test_x)
+            pred_y_sklearn = linear_sklearn(train_x, train_y, test_x)
 
+            mo.append(f"[{label}] sklean", test_y, pred_y_sklearn)
+            mo.append(f"[{label}] QuickMPC", test_y, pred_y_qmpc)
     mo.output()
 
 
 @pytest.mark.parametrize(
-    ("train_size"),
-    [
-        (15), (30)
-    ]
+    ("iterate_num", "train_size"), test_parameters
 )
-def test_linear_penguins(train_size):
-    # 現実時間で学習を終わらせるためサイズを小さくする
-    train_x, train_y_list, test_x, test_y_list, _, _ = penguins()
-    train_x = train_x[:train_size]
-    train_y_list = train_y_list[:train_size]
-
+def test_linear_penguins(iterate_num: int, train_size: int):
     mo = MetricsOutputer("regression")
-    labels = ['Adelie', 'Chinstrap', 'Gentoo']
+    for _ in range(iterate_num):
+        # 現実時間で学習を終わらせるためサイズを小さくする
+        train_x, train_y_list, test_x, test_y_list, _, _ = penguins()
+        train_x = train_x[:train_size]
+        train_y_list = train_y_list[:train_size]
 
-    # trainデータで学習してtestデータでの推測値を得る
-    for label, train_y, test_y in \
-            zip(labels, train_y_list.transpose(), test_y_list.transpose()):
-        pred_y_qmpc = linear_qmpc(train_x, train_y, test_x)
-        pred_y_sklearn = linear_sklearn(train_x, train_y, test_x)
+        labels = ['Adelie', 'Chinstrap', 'Gentoo']
 
-        mo.append(f"[{label}] sklean", test_y, pred_y_sklearn)
-        mo.append(f"[{label}] QuickMPC", test_y, pred_y_qmpc)
+        # trainデータで学習してtestデータでの推測値を得る
+        for label, train_y, test_y in \
+                zip(labels, train_y_list.transpose(), test_y_list.transpose()):
+            pred_y_qmpc = linear_qmpc(train_x, train_y, test_x)
+            pred_y_sklearn = linear_sklearn(train_x, train_y, test_x)
 
+            mo.append(f"[{label}] sklean", test_y, pred_y_sklearn)
+            mo.append(f"[{label}] QuickMPC", test_y, pred_y_qmpc)
     mo.output()

--- a/Test/LibClient/src/benchmark/test_linear.py
+++ b/Test/LibClient/src/benchmark/test_linear.py
@@ -36,11 +36,11 @@ def linear_qmpc(train_x, train_y, test_x):
 
     # データをシェア化し送信(schema,idは適当)
     res_train_x = qmpc.send_share(train_x_include_id, schema_x)
-    assert(res_train_x["is_ok"])
+    assert (res_train_x["is_ok"])
     res_train_y = qmpc.send_share(train_y_include_id, ["id", "y"])
-    assert(res_train_y["is_ok"])
+    assert (res_train_y["is_ok"])
     res_test_x = qmpc.send_share(test_x_include_id, schema_x)
-    assert(res_test_x["is_ok"])
+    assert (res_test_x["is_ok"])
     id_train_x = res_train_x["data_id"]
     id_train_y = res_train_y["data_id"]
     id_test_x = res_test_x["data_id"]
@@ -48,15 +48,17 @@ def linear_qmpc(train_x, train_y, test_x):
     # 線形回帰学習
     table_train = [[id_train_x, id_train_y], [0], [1, 1]]
     inp_train = [[i for i in range(2, column_size+1)], [column_size+1]]
-    res_train = get_result(qmpc.linear_regression(table_train, inp_train), limit=40)
-    assert(res_train["is_ok"])
+    res_train = get_result(qmpc.linear_regression(
+        table_train, inp_train), limit=40)
+    assert (res_train["is_ok"])
     model_param_job_uuid: str = res_train["job_uuid"]
 
     # 線形回帰推論
     table_pred = [[id_test_x], [], [1]]
     inp_pred = [i for i in range(2, column_size+1)]
-    res_pred = get_result(qmpc.linear_regression_predict(model_param_job_uuid, table_pred, inp_pred), limit=40)
-    assert(res_pred["is_ok"])
+    res_pred = get_result(qmpc.linear_regression_predict(
+        model_param_job_uuid, table_pred, inp_pred), limit=40)
+    assert (res_pred["is_ok"])
 
     # 冪等性のために消しておく
     qmpc.delete_share([id_train_x, id_train_y, id_test_x])

--- a/Test/LibClient/src/benchmark/test_logistic.py
+++ b/Test/LibClient/src/benchmark/test_logistic.py
@@ -7,6 +7,12 @@ from utils import get_result, qmpc
 from benchmark.data import iris, penguins, titanic
 from benchmark.metrics import MetricsOutputer
 
+# types: (iterate_num, train_size)
+test_parameters = [
+    (10, 5),
+    (10, 10)
+]
+
 
 def logistic_sklearn(train_x, train_y, test_x):
     """ sklearnのロジスティック回帰 """
@@ -69,77 +75,69 @@ def logistic_qmpc(train_x, train_y, test_x):
 
 
 @pytest.mark.parametrize(
-    ("train_size"),
-    [
-        (5), (10)
-    ]
+    ("iterate_num", "train_size"), test_parameters
 )
-def test_logistic_titanic(train_size):
-    # 現実時間で学習を終わらせるためサイズを小さくする
-    train_x, train_y, test_x, test_y, _, _ = titanic()
-    train_x = train_x[:train_size]
-    train_y = train_y[:train_size]
-
-    # trainデータで学習してtestデータでの推測値を得る
-    pred_y_qmpc = logistic_qmpc(train_x, train_y, test_x)
-    pred_y_sklearn = logistic_sklearn(train_x, train_y, test_x)
-
-    # 指標を出力
+def test_logistic_titanic(iterate_num: int, train_size: int):
     mo = MetricsOutputer("classification")
-    mo.append("sklean", test_y, pred_y_sklearn)
-    mo.append("QuickMPC", test_y, pred_y_qmpc)
+    for _ in range(iterate_num):
+        # 現実時間で学習を終わらせるためサイズを小さくする
+        train_x, train_y, test_x, test_y, _, _ = titanic()
+        train_x = train_x[:train_size]
+        train_y = train_y[:train_size]
+
+        # trainデータで学習してtestデータでの推測値を得る
+        pred_y_qmpc = logistic_qmpc(train_x, train_y, test_x)
+        pred_y_sklearn = logistic_sklearn(train_x, train_y, test_x)
+
+        mo.append("sklean", test_y, pred_y_sklearn)
+        mo.append("QuickMPC", test_y, pred_y_qmpc)
     mo.output()
 
 
 @pytest.mark.parametrize(
-    ("train_size"),
-    [
-        (5), (10)
-    ]
+    ("iterate_num", "train_size"), test_parameters
 )
-def test_logistic_iris(train_size):
-    # 現実時間で学習を終わらせるためサイズを小さくする
-    train_x, train_y_list, test_x, test_y_list, _, _ = iris()
-    train_x = train_x[:train_size]
-    train_y_list = train_y_list[:train_size]
-
+def test_logistic_iris(iterate_num: int, train_size: int):
     mo = MetricsOutputer("classification")
-    labels = ["setosa", "versicolor", "virginica"]
+    for _ in range(iterate_num):
+        # 現実時間で学習を終わらせるためサイズを小さくする
+        train_x, train_y_list, test_x, test_y_list, _, _ = iris()
+        train_x = train_x[:train_size]
+        train_y_list = train_y_list[:train_size]
 
-    # trainデータで学習してtestデータでの推測値を得る
-    for label, train_y, test_y in \
-            zip(labels, train_y_list.transpose(), test_y_list.transpose()):
-        pred_y_qmpc = logistic_qmpc(train_x, train_y, test_x)
-        pred_y_sklearn = logistic_sklearn(train_x, train_y, test_x)
+        labels = ["setosa", "versicolor", "virginica"]
 
-        mo.append(f"[{label}] sklean", test_y, pred_y_sklearn)
-        mo.append(f"[{label}] QuickMPC", test_y, pred_y_qmpc)
+        # trainデータで学習してtestデータでの推測値を得る
+        for label, train_y, test_y in \
+                zip(labels, train_y_list.transpose(), test_y_list.transpose()):
+            pred_y_qmpc = logistic_qmpc(train_x, train_y, test_x)
+            pred_y_sklearn = logistic_sklearn(train_x, train_y, test_x)
+
+            mo.append(f"[{label}] sklean", test_y, pred_y_sklearn)
+            mo.append(f"[{label}] QuickMPC", test_y, pred_y_qmpc)
 
     mo.output()
 
 
 @pytest.mark.parametrize(
-    ("train_size"),
-    [
-        (5), (10)
-    ]
+    ("iterate_num", "train_size"), test_parameters
 )
-def test_logistic_penguins(train_size):
-    # 現実時間で学習を終わらせるためサイズを小さくする
-    train_x, train_y_list, test_x, test_y_list, _, _ = penguins()
-    train_x = train_x[:train_size]
-    train_y_list = train_y_list[:train_size]
-
+def test_logistic_penguins(iterate_num: int, train_size: int):
     mo = MetricsOutputer("classification")
-    labels = ['Adelie', 'Chinstrap', 'Gentoo']
+    for _ in range(iterate_num):
+        # 現実時間で学習を終わらせるためサイズを小さくする
+        train_x, train_y_list, test_x, test_y_list, _, _ = penguins()
+        train_x = train_x[:train_size]
+        train_y_list = train_y_list[:train_size]
 
-    # trainデータで学習してtestデータでの推測値を得る
-    for label, train_y, test_y in \
-            zip(labels, train_y_list.transpose(), test_y_list.transpose()):
-        pred_y_qmpc = logistic_qmpc(train_x, train_y, test_x)
-        pred_y_sklearn = logistic_sklearn(train_x, train_y, test_x)
+        labels = ['Adelie', 'Chinstrap', 'Gentoo']
 
-        mo.append(f"[{label}] sklean", test_y, pred_y_sklearn)
-        mo.append(f"[{label}] QuickMPC", test_y, pred_y_qmpc)
+        # trainデータで学習してtestデータでの推測値を得る
+        for label, train_y, test_y in \
+                zip(labels, train_y_list.transpose(), test_y_list.transpose()):
+            pred_y_qmpc = logistic_qmpc(train_x, train_y, test_x)
+            pred_y_sklearn = logistic_sklearn(train_x, train_y, test_x)
 
+            mo.append(f"[{label}] sklean", test_y, pred_y_sklearn)
+            mo.append(f"[{label}] QuickMPC", test_y, pred_y_qmpc)
     mo.output()

--- a/Test/LibClient/src/benchmark/test_logistic.py
+++ b/Test/LibClient/src/benchmark/test_logistic.py
@@ -36,11 +36,11 @@ def logistic_qmpc(train_x, train_y, test_x):
 
     # データをシェア化し送信(schema,idは適当)
     res_train_x = qmpc.send_share(train_x_include_id, schema_x)
-    assert(res_train_x["is_ok"])
+    assert (res_train_x["is_ok"])
     res_train_y = qmpc.send_share(train_y_include_id, ["id", "y"])
-    assert(res_train_y["is_ok"])
+    assert (res_train_y["is_ok"])
     res_test_x = qmpc.send_share(test_x_include_id, schema_x)
-    assert(res_test_x["is_ok"])
+    assert (res_test_x["is_ok"])
     id_train_x = res_train_x["data_id"]
     id_train_y = res_train_y["data_id"]
     id_test_x = res_test_x["data_id"]
@@ -49,14 +49,15 @@ def logistic_qmpc(train_x, train_y, test_x):
     table_train = [[id_train_x, id_train_y], [0], [1, 1]]
     inp_train = [[i for i in range(2, column_size+1)], [column_size+1]]
     res_train = get_result(qmpc.logistic_regression(table_train, inp_train))
-    assert(res_train["is_ok"])
+    assert (res_train["is_ok"])
     model_param_job_uuid: str = res_train["job_uuid"]
 
     # ロジスティック回帰推論
     table_pred = [[id_test_x], [], [1]]
     inp_pred = [i for i in range(2, column_size+1)]
-    res_pred = get_result(qmpc.logistic_regression_predict(model_param_job_uuid, table_pred, inp_pred))
-    assert(res_pred["is_ok"])
+    res_pred = get_result(qmpc.logistic_regression_predict(
+        model_param_job_uuid, table_pred, inp_pred))
+    assert (res_pred["is_ok"])
 
     # 冪等性のために消しておく
     qmpc.delete_share([id_train_x, id_train_y, id_test_x])

--- a/Test/LibClient/src/benchmark/test_sid3.py
+++ b/Test/LibClient/src/benchmark/test_sid3.py
@@ -32,11 +32,11 @@ def sid3_qmpc(train_x, train_y, test_x, schema_x, schema_y):
 
     # データをシェア化し送信(idsは適当)
     res_train_x = qmpc.send_share(train_x_include_id, ["id#0"] + schema_x)
-    assert(res_train_x["is_ok"])
+    assert (res_train_x["is_ok"])
     res_train_y = qmpc.send_share(train_y_include_id, ["id#0"] + schema_y)
-    assert(res_train_y["is_ok"])
+    assert (res_train_y["is_ok"])
     res_test_x = qmpc.send_share(test_x_include_id, ["id#0"] + schema_x)
-    assert(res_test_x["is_ok"])
+    assert (res_test_x["is_ok"])
     id_train_x = res_train_x["data_id"]
     id_train_y = res_train_y["data_id"]
     id_test_x = res_test_x["data_id"]
@@ -46,14 +46,15 @@ def sid3_qmpc(train_x, train_y, test_x, schema_x, schema_y):
     inp_train = [[i for i in range(2, column_size + 1)],
                  [column_size + 1 + i for i in range(len(train_y[0]))]]
     res_train = get_result(qmpc.decision_tree(table_train, inp_train))
-    assert(res_train["is_ok"])
+    assert (res_train["is_ok"])
     model_param_job_uuid: str = res_train["job_uuid"]
 
     # SID3推論
     table_pred = [[id_test_x], [], [1]]
     inp_pred = [i for i in range(2, column_size + 1)]
-    res_pred = get_result(qmpc.sid3_tree_predict(model_param_job_uuid, table_pred, inp_pred))
-    assert(res_pred["is_ok"])
+    res_pred = get_result(qmpc.sid3_tree_predict(
+        model_param_job_uuid, table_pred, inp_pred))
+    assert (res_pred["is_ok"])
 
     # 冪等性のために消しておく
     qmpc.delete_share([id_train_x, id_train_y, id_test_x])

--- a/Test/LibClient/src/benchmark/test_sid3.py
+++ b/Test/LibClient/src/benchmark/test_sid3.py
@@ -6,6 +6,12 @@ from utils import get_result, qmpc
 from benchmark.data import iris, penguins, titanic
 from benchmark.metrics import MetricsOutputer
 
+# types: (iterate_num, train_size)
+test_parameters = [
+    (10, 5),
+    (10, 10)
+]
+
 
 def id3_sklearn(train_x, train_y, test_x):
     """ ID3 """
@@ -71,66 +77,57 @@ def convert(test_y):
 
 
 @pytest.mark.parametrize(
-    ("train_size"),
-    [
-        (5), (10)
-    ]
+    ("iterate_num", "train_size"), test_parameters
 )
-def test_sid3_titanic(train_size):
-    # 現実時間で学習を終わらせるためサイズを小さくする
-    train_x, train_y, test_x, test_y, schema_x, schema_y = titanic(
-        is_bitvector=True)
-    train_x = train_x[:train_size]
-    train_y = train_y[:train_size]
-
-    # trainデータで学習してtestデータでの推測値を得る
-    pred_y_qmpc = sid3_qmpc(train_x, train_y, test_x, schema_x, schema_y)
-
-    # 指標を出力
+def test_sid3_titanic(iterate_num: int, train_size: int):
     mo = MetricsOutputer("classification")
-    mo.append("QuickMPC", convert(test_y), pred_y_qmpc)
+    for _ in range(iterate_num):
+        # 現実時間で学習を終わらせるためサイズを小さくする
+        train_x, train_y, test_x, test_y, schema_x, schema_y = titanic(
+            is_bitvector=True)
+        train_x = train_x[:train_size]
+        train_y = train_y[:train_size]
+
+        # trainデータで学習してtestデータでの推測値を得る
+        pred_y_qmpc = sid3_qmpc(train_x, train_y, test_x, schema_x, schema_y)
+
+        mo.append("QuickMPC", convert(test_y), pred_y_qmpc)
     mo.output()
 
 
 @pytest.mark.parametrize(
-    ("train_size"),
-    [
-        (5), (10)
-    ]
+    ("iterate_num", "train_size"), test_parameters
 )
-def test_sid3_iris(train_size):
-    # 現実時間で学習を終わらせるためサイズを小さくする
-    train_x, train_y, test_x, test_y, schema_x, schema_y = iris(
-        is_bitvector=True)
-    train_x = train_x[:train_size]
-    train_y = train_y[:train_size]
-
-    # trainデータで学習してtestデータでの推測値を得る
-    pred_y_qmpc = sid3_qmpc(train_x, train_y, test_x, schema_x, schema_y)
-
-    # 指標を出力
+def test_sid3_iris(iterate_num: int, train_size: int):
     mo = MetricsOutputer("classification")
-    mo.append("QuickMPC", convert(test_y), pred_y_qmpc)
+    for _ in range(iterate_num):
+        # 現実時間で学習を終わらせるためサイズを小さくする
+        train_x, train_y, test_x, test_y, schema_x, schema_y = iris(
+            is_bitvector=True)
+        train_x = train_x[:train_size]
+        train_y = train_y[:train_size]
+
+        # trainデータで学習してtestデータでの推測値を得る
+        pred_y_qmpc = sid3_qmpc(train_x, train_y, test_x, schema_x, schema_y)
+
+        mo.append("QuickMPC", convert(test_y), pred_y_qmpc)
     mo.output()
 
 
 @pytest.mark.parametrize(
-    ("train_size"),
-    [
-        (5), (10)
-    ]
+    ("iterate_num", "train_size"), test_parameters
 )
-def test_sid3_penguins(train_size):
-    # 現実時間で学習を終わらせるためサイズを小さくする
-    train_x, train_y, test_x, test_y, schema_x, schema_y = penguins(
-        is_bitvector=True)
-    train_x = train_x[:train_size]
-    train_y = train_y[:train_size]
-
-    # trainデータで学習してtestデータでの推測値を得る
-    pred_y_qmpc = sid3_qmpc(train_x, train_y, test_x, schema_x, schema_y)
-
-    # 指標を出力
+def test_sid3_penguins(iterate_num: int, train_size: int):
     mo = MetricsOutputer("classification")
-    mo.append("QuickMPC", convert(test_y), pred_y_qmpc)
+    for _ in range(iterate_num):
+        # 現実時間で学習を終わらせるためサイズを小さくする
+        train_x, train_y, test_x, test_y, schema_x, schema_y = penguins(
+            is_bitvector=True)
+        train_x = train_x[:train_size]
+        train_y = train_y[:train_size]
+
+        # trainデータで学習してtestデータでの推測値を得る
+        pred_y_qmpc = sid3_qmpc(train_x, train_y, test_x, schema_x, schema_y)
+
+        mo.append("QuickMPC", convert(test_y), pred_y_qmpc)
     mo.output()

--- a/Test/LibClient/src/benchmark/test_statistics.py
+++ b/Test/LibClient/src/benchmark/test_statistics.py
@@ -25,121 +25,121 @@ def get_data_id():
     return lambda size, data_num=1: get(size, data_num)
 
 
-bench_size = [
-    (5),
-    (50),
-    (500),
+# types: (iterate_num, size)
+test_parameters = [
+    (10, 5),
+    (10, 50)
 ]
 
 
 @pytest.mark.parametrize(
-    ("size"), bench_size
+    ("iterate_num", "size"), test_parameters
 )
-def test_mean(size: int, get_data_id):
+def test_mean(iterate_num: int, size: int, get_data_id):
     data_id, secrets, schema = get_data_id(size)
     schema_size: int = len(schema)
+    for _ in range(iterate_num):
+        # table情報と列指定情報を定義して計算
+        table = [[data_id], [], [1]]
+        inp = [i+1 for i in range(schema_size)]
+        with PrintTime("mean"):
+            res = get_result(qmpc.mean(table, inp), limit=10000)
+        assert (res["is_ok"])
 
-    # table情報と列指定情報を定義して計算
-    table = [[data_id], [], [1]]
-    inp = [i+1 for i in range(schema_size)]
-    with PrintTime("mean"):
-        res = get_result(qmpc.mean(table, inp), limit=10000)
-    assert (res["is_ok"])
-
-    # 正しく計算されたか確認
-    secrets_np = np.array(secrets)
-    true_val = np.add.reduce(secrets_np) / len(secrets)
-    for x, y in zip(res["results"], true_val):
-        assert (math.isclose(x, y, abs_tol=0.1))
+        # 正しく計算されたか確認
+        secrets_np = np.array(secrets)
+        true_val = np.add.reduce(secrets_np) / len(secrets)
+        for x, y in zip(res["results"], true_val):
+            assert (math.isclose(x, y, abs_tol=0.1))
 
 
 @pytest.mark.parametrize(
-    ("size"), bench_size
+    ("iterate_num", "size"), test_parameters
 )
-def test_sum(size: int, get_data_id):
+def test_sum(iterate_num: int, size: int, get_data_id):
     data_id, secrets, schema = get_data_id(size)
     schema_size: int = len(schema)
+    for _ in range(iterate_num):
+        # table情報と列指定情報を定義して計算
+        table = [[data_id], [], [1]]
+        inp = [i+1 for i in range(schema_size)]
+        with PrintTime("sum"):
+            res = get_result(qmpc.sum(table, inp), limit=10000)
+        assert (res["is_ok"])
 
-    # table情報と列指定情報を定義して計算
-    table = [[data_id], [], [1]]
-    inp = [i+1 for i in range(schema_size)]
-    with PrintTime("sum"):
-        res = get_result(qmpc.sum(table, inp), limit=10000)
-    assert (res["is_ok"])
-
-    # 正しく計算されたか確認
-    secrets_np = np.array(secrets)
-    true_val = np.add.reduce(secrets_np)
-    for x, y in zip(res["results"], true_val):
-        assert (math.isclose(x, y, abs_tol=0.1))
+        # 正しく計算されたか確認
+        secrets_np = np.array(secrets)
+        true_val = np.add.reduce(secrets_np)
+        for x, y in zip(res["results"], true_val):
+            assert (math.isclose(x, y, abs_tol=0.1))
 
 
 @pytest.mark.parametrize(
-    ("size"), bench_size
+    ("iterate_num", "size"), test_parameters
 )
-def test_variance(size: int, get_data_id):
+def test_variance(iterate_num: int, size: int, get_data_id):
     data_id, secrets, schema = get_data_id(size)
     schema_size: int = len(schema)
+    for _ in range(iterate_num):
+        # table情報と列指定情報を定義して計算
+        table = [[data_id], [], [1]]
+        inp = [i+1 for i in range(schema_size)]
+        with PrintTime("variance"):
+            res = get_result(qmpc.variance(table, inp), limit=10000)
+        assert (res["is_ok"])
 
-    # table情報と列指定情報を定義して計算
-    table = [[data_id], [], [1]]
-    inp = [i+1 for i in range(schema_size)]
-    with PrintTime("variance"):
-        res = get_result(qmpc.variance(table, inp), limit=10000)
-    assert (res["is_ok"])
-
-    # 正しく計算されたか確認
-    secrets_np = np.array(secrets)
-    true_val = np.var(secrets_np, axis=0)
-    for x, y in zip(res["results"], true_val):
-        assert (math.isclose(x, y, abs_tol=0.1))
+        # 正しく計算されたか確認
+        secrets_np = np.array(secrets)
+        true_val = np.var(secrets_np, axis=0)
+        for x, y in zip(res["results"], true_val):
+            assert (math.isclose(x, y, abs_tol=0.1))
 
 
 @pytest.mark.parametrize(
-    ("size"), bench_size
+    ("iterate_num", "size"), test_parameters
 )
-def test_correl(size: int, get_data_id):
+def test_correl(iterate_num: int, size: int, get_data_id):
     data_id, secrets, schema = get_data_id(size)
     schema_size: int = len(schema)
+    for _ in range(iterate_num):
+        # table情報と列指定情報を定義して計算
+        table = [[data_id], [], [1]]
+        inp = ([i+1 for i in range(schema_size)], [schema_size])
+        with PrintTime("correl"):
+            res = get_result(qmpc.correl(table, inp), limit=10000)
+        assert (res["is_ok"])
 
-    # table情報と列指定情報を定義して計算
-    table = [[data_id], [], [1]]
-    inp = ([i+1 for i in range(schema_size)], [schema_size])
-    with PrintTime("correl"):
-        res = get_result(qmpc.correl(table, inp), limit=10000)
-    assert (res["is_ok"])
-
-    # 正しく計算されたか確認
-    secrets_np = np.array(secrets)
-    correl_matrix = np.corrcoef(secrets_np.transpose())
-    true_val = correl_matrix[:schema_size-1, schema_size-1].transpose()
-    for x, y in zip(res["results"][0], true_val):
-        assert (math.isclose(x, y, abs_tol=0.1))
+        # 正しく計算されたか確認
+        secrets_np = np.array(secrets)
+        correl_matrix = np.corrcoef(secrets_np.transpose())
+        true_val = correl_matrix[:schema_size-1, schema_size-1].transpose()
+        for x, y in zip(res["results"][0], true_val):
+            assert (math.isclose(x, y, abs_tol=0.1))
 
 
 @pytest.mark.parametrize(
-    ("size"), bench_size
+    ("iterate_num", "size"), test_parameters
 )
-def test_hjoin(size: int, get_data_id):
+def test_hjoin(iterate_num: int, size: int, get_data_id):
     data_id1, secrets1, schema1 = get_data_id(size, data_num=1)
     data_id2, secrets2, schema2 = get_data_id(size, data_num=2)
+    for _ in range(iterate_num):
+        # table情報を定義して計算
+        table = [[data_id1, data_id2], [2], [1, 1]]
+        with PrintTime("hjoin"):
+            res = get_result(qmpc.get_join_table(table), limit=10000)
+        assert (res["is_ok"])
 
-    # table情報を定義して計算
-    table = [[data_id1, data_id2], [2], [1, 1]]
-    with PrintTime("hjoin"):
-        res = get_result(qmpc.get_join_table(table), limit=10000)
-    assert (res["is_ok"])
+        # 正しく計算されたか確認
+        exe_schema = res["results"]["schema"]
+        assert (schema1[1:] + schema2[1:] == exe_schema)
 
-    # 正しく計算されたか確認
-    exe_schema = res["results"]["schema"]
-    assert (schema1[1:] + schema2[1:] == exe_schema)
-
-    exe_table = res["results"]["table"]
-    exe_table_sorted = sorted(exe_table)
-    true_table = []
-    for r1, r2 in zip(secrets1, secrets2):
-        true_table.append(r1[1:]+r2[1:])
-    true_table_sorted = sorted(true_table)
-    for r1, r2 in zip(true_table_sorted, exe_table_sorted):
-        for x, y in zip(r1, r2):
-            assert (math.isclose(x, y, abs_tol=0.1))
+        exe_table = res["results"]["table"]
+        exe_table_sorted = sorted(exe_table)
+        true_table = []
+        for r1, r2 in zip(secrets1, secrets2):
+            true_table.append(r1[1:]+r2[1:])
+        true_table_sorted = sorted(true_table)
+        for r1, r2 in zip(true_table_sorted, exe_table_sorted):
+            for x, y in zip(r1, r2):
+                assert (math.isclose(x, y, abs_tol=0.1))

--- a/Test/LibClient/src/benchmark/test_statistics.py
+++ b/Test/LibClient/src/benchmark/test_statistics.py
@@ -18,7 +18,7 @@ def get_data_id():
         secrets, schema = large_data(size, data_num)
         with PrintTime("send_share"):
             res = qmpc.send_share(secrets, schema)
-        assert(res["is_ok"])
+        assert (res["is_ok"])
         data_id: str = res["data_id"]
         val[(size, data_num)] = (data_id, secrets, schema)
         return val[(size, data_num)]
@@ -44,13 +44,13 @@ def test_mean(size: int, get_data_id):
     inp = [i+1 for i in range(schema_size)]
     with PrintTime("mean"):
         res = get_result(qmpc.mean(table, inp), limit=10000)
-    assert(res["is_ok"])
+    assert (res["is_ok"])
 
     # 正しく計算されたか確認
     secrets_np = np.array(secrets)
     true_val = np.add.reduce(secrets_np) / len(secrets)
     for x, y in zip(res["results"], true_val):
-        assert(math.isclose(x, y, abs_tol=0.1))
+        assert (math.isclose(x, y, abs_tol=0.1))
 
 
 @pytest.mark.parametrize(
@@ -65,13 +65,13 @@ def test_sum(size: int, get_data_id):
     inp = [i+1 for i in range(schema_size)]
     with PrintTime("sum"):
         res = get_result(qmpc.sum(table, inp), limit=10000)
-    assert(res["is_ok"])
+    assert (res["is_ok"])
 
     # 正しく計算されたか確認
     secrets_np = np.array(secrets)
     true_val = np.add.reduce(secrets_np)
     for x, y in zip(res["results"], true_val):
-        assert(math.isclose(x, y, abs_tol=0.1))
+        assert (math.isclose(x, y, abs_tol=0.1))
 
 
 @pytest.mark.parametrize(
@@ -86,13 +86,13 @@ def test_variance(size: int, get_data_id):
     inp = [i+1 for i in range(schema_size)]
     with PrintTime("variance"):
         res = get_result(qmpc.variance(table, inp), limit=10000)
-    assert(res["is_ok"])
+    assert (res["is_ok"])
 
     # 正しく計算されたか確認
     secrets_np = np.array(secrets)
     true_val = np.var(secrets_np, axis=0)
     for x, y in zip(res["results"], true_val):
-        assert(math.isclose(x, y, abs_tol=0.1))
+        assert (math.isclose(x, y, abs_tol=0.1))
 
 
 @pytest.mark.parametrize(
@@ -107,14 +107,14 @@ def test_correl(size: int, get_data_id):
     inp = ([i+1 for i in range(schema_size)], [schema_size])
     with PrintTime("correl"):
         res = get_result(qmpc.correl(table, inp), limit=10000)
-    assert(res["is_ok"])
+    assert (res["is_ok"])
 
     # 正しく計算されたか確認
     secrets_np = np.array(secrets)
     correl_matrix = np.corrcoef(secrets_np.transpose())
     true_val = correl_matrix[:schema_size-1, schema_size-1].transpose()
     for x, y in zip(res["results"][0], true_val):
-        assert(math.isclose(x, y, abs_tol=0.1))
+        assert (math.isclose(x, y, abs_tol=0.1))
 
 
 @pytest.mark.parametrize(
@@ -128,11 +128,11 @@ def test_hjoin(size: int, get_data_id):
     table = [[data_id1, data_id2], [2], [1, 1]]
     with PrintTime("hjoin"):
         res = get_result(qmpc.get_join_table(table), limit=10000)
-    assert(res["is_ok"])
+    assert (res["is_ok"])
 
     # 正しく計算されたか確認
     exe_schema = res["results"]["schema"]
-    assert(schema1[1:] + schema2[1:] == exe_schema)
+    assert (schema1[1:] + schema2[1:] == exe_schema)
 
     exe_table = res["results"]["table"]
     exe_table_sorted = sorted(exe_table)
@@ -142,4 +142,4 @@ def test_hjoin(size: int, get_data_id):
     true_table_sorted = sorted(true_table)
     for r1, r2 in zip(true_table_sorted, exe_table_sorted):
         for x, y in zip(r1, r2):
-            assert(math.isclose(x, y, abs_tol=0.1))
+            assert (math.isclose(x, y, abs_tol=0.1))


### PR DESCRIPTION
# Summary
Run the benchmark consecutively.

# Purpose
Assume actual operation.

# Contents
- add `iterate_num` to each benchmark and update to run this number of times
- add min,max,mean,median to metrics
- clean format (automatic)

# Testing Methods Performed
- make test t=LibClient p=benchmark