### PR TITLE
Add `.clang-format` config for include orders

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -11,3 +11,4 @@ AccessModifierOffset: -4
 BreakBeforeBinaryOperators: NonAssignment
 ColumnLimit: 100
 BreakBeforeBraces: Allman
+IncludeBlocks: Preserve


### PR DESCRIPTION
# Summary

- Add configuration in .clang-format for include orders
  - `IncludeBlocks: Preserve`

# Purpose

Without added `IncludeBlocks: Preserve` config, we will get include orders that go against [Google C++ Style](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes).

## exmaple

If the source code we are editing is `example.cpp`,

- original
  ```c++
  #include "exmaple.hpp"
  
  #include <iostream>
  #include <atomic>
  
  #include <boost/uuid/uuid.hpp>
  
  #include "projects/other/header.hpp"
  ```
- `clang-format` applied with current `.clang-format`
```c++
  #include "exmaple.hpp"
  
  #include <atomic>
  #include <boost/uuid/uuid.hpp>
  #include <iostream>
  
  #include "projects/other/header.hpp"
  ```
- Following Google C++ style
  ```c++
  #include "exmaple.hpp"
  
  #include <atomic>
  #include <iostream>
  
  #include <boost/uuid/uuid.hpp>
  
  #include "projects/other/header.hpp"
  ```
  - I think that it is desired result
  - this patch will take this result

## notation

When this patch is applied, separating include blocks will require human effort.

# Contents

- c153925adb7e7236c1db43b33baf7a9ca8263826 add .clang-format config

# Testing Methods Performed

- run clang-format
