### PR TITLE
bind .clang-format inside CC container

### DIFF
--- a/src/ComputationContainer/docker-compose.yml
+++ b/src/ComputationContainer/docker-compose.yml
@@ -34,6 +34,9 @@ services:
         source: ../../.vscode
         target: /QuickMPC/.vscode
       - type: bind
+        source: ../.clang-format
+        target: /QuickMPC/.clang-format
+      - type: bind
         source: ../Db/
         target: /Db
     env_file:


### PR DESCRIPTION
# Summary

When developing CC inside container, `.clang-format` file was not mounted.  
This patch will bind `src/.clang-format` to `/QuickMPC/.clang-format` in container.

# Purpose

Improve developing experiment inside container.

# Contents

- 79ed5ec3754386c00daff2f108ea82195f8f6fb8 add configuration to mount `.clang-format` in CC's `docker-compose.yml`

# Testing Methods Performed

- Checked if `.clang-format` is mounted by `make login` after `make upd`
