### PR TITLE
Use `std::unique_ptr` instead of `new`

### DIFF
--- a/src/ComputationContainer/Random/Csprng.cpp
+++ b/src/ComputationContainer/Random/Csprng.cpp
@@ -1,5 +1,7 @@
 #include "Random/Csprng.hpp"
 
+#include <memory>
+
 #include "Logging/Logger.hpp"
 // randombytes_buf_deterministic の内部はChaCha20
 // ((2**32[ctrが4byte長])*64[byte/block])/10**9[byte->GB] = 274GB[俗にいう256GB]
@@ -31,7 +33,7 @@ bool CSPRNG::entropyCheck()
     return true;
 };
 
-void CSPRNG::GetRand(unsigned char *buf, unsigned int byteSize)
+void CSPRNG::GetRand(unsigned char* buf, unsigned int byteSize)
 {
     if (!this->CSPRNG::entropyCheck())
     {
@@ -47,23 +49,25 @@ void CSPRNG::GetRand(unsigned char *buf, unsigned int byteSize)
     }
     else
     {
-        unsigned char *seed = new unsigned char[randombytes_SEEDBYTES];
-        syscall(SYS_getrandom, seed, randombytes_SEEDBYTES, 1);
-        randombytes_buf_deterministic(buf, byteSize, seed);
+        std::unique_ptr<unsigned char[]> seed =
+            std::make_unique<unsigned char[]>(randombytes_SEEDBYTES);
+        syscall(SYS_getrandom, seed.get(), randombytes_SEEDBYTES, 1);
+        randombytes_buf_deterministic(buf, byteSize, seed.get());
     }
 };
 
 long long int CSPRNG::GetRandLL()
 {
-    constexpr unsigned int LL_SIZE = sizeof(long long int);  // 8byte = 64bit
+    constexpr std::size_t LL_SIZE = sizeof(long long int);  // 8byte = 64bit
 
-    unsigned char *rnd = new unsigned char[LL_SIZE];
+    // std::make_shared<unsigned char[]> is available in C++20
+    std::unique_ptr<unsigned char[]> rnd = std::make_unique<unsigned char[]>(LL_SIZE);
     // 64bit乱数[unsigned char*]生成
-    this->CSPRNG::GetRand(rnd, LL_SIZE);
+    this->CSPRNG::GetRand(rnd.get(), LL_SIZE);
 
     // unsiged char* -> str(bin)
     std::stringstream str;
-    for (unsigned int i = 0; i < LL_SIZE; i++)
+    for (std::size_t i = 0; i < LL_SIZE; i++)
     {
         str << std::bitset<LL_SIZE>(rnd[i]);
     }
@@ -77,12 +81,13 @@ std::vector<long long int> CSPRNG::GetRandLLVec(unsigned int size)
 {
     std::vector<long long int> randLLVec = {};
 
-    constexpr unsigned int LL_SIZE = sizeof(long long int);  // 8byte
-    const unsigned int byteSize = size * LL_SIZE;            // size * 8[byte/llsize]
+    constexpr std::size_t LL_SIZE = sizeof(long long int);  // 8byte
+    const std::size_t byteSize = size * LL_SIZE;            // size * 8[byte/llsize]
 
-    unsigned char *rnd = new unsigned char[byteSize];
+    // std::make_shared<unsigned char[]> is available in C++20
+    std::unique_ptr<unsigned char[]> rnd = std::make_unique<unsigned char[]>(byteSize);
     // 64bit乱数[unsigned char*]生成
-    this->CSPRNG::GetRand(rnd, byteSize);
+    this->CSPRNG::GetRand(rnd.get(), byteSize);
 
     // unsiged char* -> str(bin)
     for (unsigned int i = 0; i < byteSize; i += LL_SIZE)

--- a/src/ComputationContainer/Random/Csprng.cpp
+++ b/src/ComputationContainer/Random/Csprng.cpp
@@ -76,7 +76,7 @@ long long int CSPRNG::GetRandLL()
     return rndVal;
 };
 
-std::vector<long long int> CSPRNG::GetRandLLVec(std::size_t size)
+std::vector<long long int> CSPRNG::GetRandLLVec(const std::size_t size)
 {
     std::vector<long long int> randLLVec = {};
 

--- a/src/ComputationContainer/Random/Csprng.cpp
+++ b/src/ComputationContainer/Random/Csprng.cpp
@@ -33,7 +33,7 @@ bool CSPRNG::entropyCheck()
     return true;
 };
 
-void CSPRNG::GetRand(unsigned char* buf, unsigned int byteSize)
+void CSPRNG::GetRand(unsigned char* buf, std::size_t byteSize)
 {
     if (!this->CSPRNG::entropyCheck())
     {
@@ -77,7 +77,7 @@ long long int CSPRNG::GetRandLL()
     return rndVal;
 };
 
-std::vector<long long int> CSPRNG::GetRandLLVec(unsigned int size)
+std::vector<long long int> CSPRNG::GetRandLLVec(std::size_t size)
 {
     std::vector<long long int> randLLVec = {};
 
@@ -90,10 +90,10 @@ std::vector<long long int> CSPRNG::GetRandLLVec(unsigned int size)
     this->CSPRNG::GetRand(rnd.get(), byteSize);
 
     // unsiged char* -> str(bin)
-    for (unsigned int i = 0; i < byteSize; i += LL_SIZE)
+    for (std::size_t i = 0; i < byteSize; i += LL_SIZE)
     {
         std::stringstream str;
-        for (unsigned int j = 0; j < LL_SIZE; j++)
+        for (std::size_t j = 0; j < LL_SIZE; j++)
         {
             str << std::bitset<LL_SIZE>(rnd[i + j]);
         }

--- a/src/ComputationContainer/Random/Csprng.hpp
+++ b/src/ComputationContainer/Random/Csprng.hpp
@@ -10,6 +10,7 @@
 #include <bitset>
 #include <chrono>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -28,7 +29,7 @@ public:
 
     // size is the byte size of random (ex. 128bit -> size is 16)
     // byteSizeが256bit以下だと/dev/urandomを使用
-    void GetRand(unsigned char *buf, std::size_t byteSize);
+    void GetRand(const std::unique_ptr<unsigned char[]>& buf, std::size_t byteSize);
     long long int GetRandLL();
     std::vector<long long int> GetRandLLVec(std::size_t size);
 };

--- a/src/ComputationContainer/Random/Csprng.hpp
+++ b/src/ComputationContainer/Random/Csprng.hpp
@@ -29,9 +29,9 @@ public:
 
     // size is the byte size of random (ex. 128bit -> size is 16)
     // byteSizeが256bit以下だと/dev/urandomを使用
-    void GetRand(const std::unique_ptr<unsigned char[]>& buf, std::size_t byteSize);
+    void GetRand(const std::unique_ptr<unsigned char[]>& buf, const std::size_t byteSize);
     long long int GetRandLL();
-    std::vector<long long int> GetRandLLVec(std::size_t size);
+    std::vector<long long int> GetRandLLVec(const std::size_t size);
 };
 }  // namespace Utility
 

--- a/src/ComputationContainer/Random/Csprng.hpp
+++ b/src/ComputationContainer/Random/Csprng.hpp
@@ -29,7 +29,7 @@ public:
 
     // size is the byte size of random (ex. 128bit -> size is 16)
     // byteSizeが256bit以下だと/dev/urandomを使用
-    void GetRand(const std::unique_ptr<unsigned char[]>& buf, const std::size_t byteSize);
+    void GetRand(const std::unique_ptr<unsigned char[]> &buf, const std::size_t byteSize);
     long long int GetRandLL();
     std::vector<long long int> GetRandLLVec(const std::size_t size);
 };

--- a/src/ComputationContainer/Random/Csprng.hpp
+++ b/src/ComputationContainer/Random/Csprng.hpp
@@ -28,9 +28,9 @@ public:
 
     // size is the byte size of random (ex. 128bit -> size is 16)
     // byteSizeが256bit以下だと/dev/urandomを使用
-    void GetRand(unsigned char *buf, unsigned int byteSize);
+    void GetRand(unsigned char *buf, std::size_t byteSize);
     long long int GetRandLL();
-    std::vector<long long int> GetRandLLVec(unsigned int size);
+    std::vector<long long int> GetRandLLVec(std::size_t size);
 };
 }  // namespace Utility
 

--- a/src/ComputationContainer/Test/UnitTest/CsprngTest.cpp
+++ b/src/ComputationContainer/Test/UnitTest/CsprngTest.cpp
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 
+#include <memory>
 #include <set>
 
 #include "Logging/Logger.hpp"
@@ -10,7 +11,7 @@ TEST(CsprngTest, GetRand)
 {
     const unsigned int byteSize = 8;  // 8byte = 64bit
 
-    unsigned char *rnd = new unsigned char[byteSize];
+    std::unique_ptr<unsigned char[]> rnd = std::make_unique<unsigned char[]>(byteSize);
 
     Utility::CSPRNG rng = Utility::CSPRNG();
     rng.GetRand(rnd, byteSize);
@@ -21,7 +22,6 @@ TEST(CsprngTest, GetRand)
         QMPC_LOG_INFO("{:d}", r);
         ASSERT_TRUE((r >= 0) && (r <= 255));
     }
-    delete[] rnd;
 }
 
 TEST(CsprngTest, GetRandLL)
@@ -60,7 +60,7 @@ TEST(CsprngTest, HowUse)
     const unsigned int byteSize = 8;  // 8byte = 64bit
     const unsigned int bitSize = byteSize * 8;
 
-    unsigned char *rnd = new unsigned char[byteSize];
+    std::unique_ptr<unsigned char[]> rnd = std::make_unique<unsigned char[]>(byteSize);
     rng.GetRand(rnd, byteSize);
 
     QMPC_LOG_INFO("変換前");
@@ -86,7 +86,6 @@ TEST(CsprngTest, HowUse)
         QMPC_LOG_INFO((unsigned int)rnd[i]);
     }
     QMPC_LOG_INFO("\n");
-    delete[] rnd;
 
     QMPC_LOG_INFO("変換");
     QMPC_LOG_INFO("[bin] unsigned char* -> string: ");


### PR DESCRIPTION
# Summary

- Use smart pointer instead of handling raw pointer

# Purpose

- prevent memory leak

# Contents

- bb708fa55bac999ac05aa6458268e0576ed25f5c Use `std::unique_ptr` instead of `new`

# Testing Methods Performed

- Run `progress_demo.py` 3~5 times with N=10,000, `valgrind --tool=massif` when launching CC
- Run CC small, medium test