### PR TITLE
Save error info when exception occured

### DIFF
--- a/src/ComputationContainer/Client/ComputationToDb/Client.hpp
+++ b/src/ComputationContainer/Client/ComputationToDb/Client.hpp
@@ -7,6 +7,7 @@
 
 #include "ValueTable.hpp"
 #include "external/Proto/ManageToComputationContainer/manage_to_computation.grpc.pb.h"
+#include "external/Proto/common_types/common_types.pb.h"
 #include "nlohmann/json.hpp"
 
 namespace qmpc::ComputationToDb
@@ -34,6 +35,9 @@ public:
 
     // Job の実行状態を更新する
     void updateJobStatus(const std::string &job_uuid, const int &status) const;
+
+    void saveErrorInfo(const std::string &job_uuid, const pb_common_types::JobErrorInfo &info)
+        const;
 
     // tableデータを結合して取り出す
     ValueTable readTable(const managetocomputation::JoinOrder &table);

--- a/src/ComputationContainer/Client/ComputationToDb/Client.hpp
+++ b/src/ComputationContainer/Client/ComputationToDb/Client.hpp
@@ -36,6 +36,7 @@ public:
     // Job の実行状態を更新する
     void updateJobStatus(const std::string &job_uuid, const int &status) const;
 
+    // Job 実行中に発生したエラーに関する情報を保存する
     void saveErrorInfo(const std::string &job_uuid, const pb_common_types::JobErrorInfo &info)
         const;
 

--- a/src/ComputationContainer/Job/JobBase.hpp
+++ b/src/ComputationContainer/Job/JobBase.hpp
@@ -136,10 +136,12 @@ public:
             if (error_info)
             {
                 QMPC_LOG_ERROR("{}", *error_info);
+                statusManager.error(e, *error_info);
             }
             else
             {
                 QMPC_LOG_ERROR("thrown exception has no stack trace information");
+                statusManager.error(e, std::nullopt);
             }
         }
         catch (const std::exception &e)
@@ -151,10 +153,12 @@ public:
             if (error_info)
             {
                 QMPC_LOG_ERROR("{}", *error_info);
+                statusManager.error(e, *error_info);
             }
             else
             {
                 QMPC_LOG_ERROR("thrown exception has no stack trace information");
+                statusManager.error(e, std::nullopt);
             }
         }
         return static_cast<int>(statusManager.getStatus());

--- a/src/Proto/common_types/common_types.proto
+++ b/src/Proto/common_types/common_types.proto
@@ -6,11 +6,12 @@ option go_package = "github.com/acompany-develop/QuickMPC/src/Proto/common_types
 
 enum JobStatus {
     UNKNOWN = 0;
-    PRE_JOB = 1;
-    READ_DB = 2;
-    COMPUTE = 3;
-    WRITE_DB = 4;
-    COMPLETED = 5;
+    ERROR = 1;
+    PRE_JOB = 2;
+    READ_DB = 3;
+    COMPUTE = 4;
+    WRITE_DB = 5;
+    COMPLETED = 6;
 }
 
 enum ComputationMethod {

--- a/src/Proto/common_types/common_types.proto
+++ b/src/Proto/common_types/common_types.proto
@@ -48,3 +48,17 @@ message JobProgress {
     JobStatus status = 2;
     repeated ProcedureProgress progresses = 3;
 }
+
+message Stacktrace {
+    message Frame {
+        string source_location = 1;
+        uint64 source_line = 2;
+        string function_name = 3;
+    }
+    repeated Frame frames = 1;
+}
+
+message JobErrorInfo {
+    string what = 1;
+    optional Stacktrace stacktrace = 2;
+}


### PR DESCRIPTION
# Summary

Implement saving error info in Computation Container

# Purpose

It is a part of tasks to get error info from client.

# Contents

- Change protobuf files
  - e9533f42898090e4c0f254decddb7d22ddbc13b8 Add `ERROR` status to `JobStatus`
  - 796a5638955fd7986428aec4e82a76d3bf5fa559 Add types for saving error info
- b646b4f0e49e5cf04179a490faf01d5272eef60b Implement saving error info
- b531f2e6ae3e407d5667fc13e40d45e2cfd7a2a7 Add validation for input column index

# Testing Methods Performed

- Note: implementation of integration test with libClient-py is planned by another PR.
- Use invalid column index when requesting job with libClient-py
  - Check `/Db/result/${job_uuid}/status_ERROR`
  - ```console
    dev@host:/path/to/QuickMPC/Test$ docker exec -it computation_container1 bash
    root@47e29a11d465:/QuickMPC# cat /Db/result/969302f0-6411-486d-a43e-db7c6d702c46/status_ERROR 
    {
     "what": "inp[1][2] = 7 is out of range where column range = [1, 6], schemas = [\"id\", \"attr1\", \"attr2\", \"attr3\", \"attr4\", \"attr5\"]",
     "stacktrace": {
      "frames": [
       {
        "source_location": "./Logging/Logger.hpp",
        "source_line": "58",
        "function_name": "void qmpc::Log::throw_with_trace\u003cstd::invalid_argument\u003e(std::invalid_argument const&)"
       },
       ...
      ]
     }
    }
    ```