### PR TITLE
[CI] Add `--load` option when building image with buildx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Build CC image
         run: |
-          docker buildx build ../../ --file Dockerfile --target dep-runner --tag ghcr.io/${{ github.repository_owner }}/quickmpc-cc:s${{ steps.date.outputs.date }}
-          docker buildx build ../../ --file Dockerfile --target dep-runner --tag ghcr.io/${{ github.repository_owner }}/quickmpc-cc:stable
+          docker buildx build ../../ --file Dockerfile --target dep-runner --tag ghcr.io/${{ github.repository_owner }}/quickmpc-cc:s${{ steps.date.outputs.date }} --load
+          docker buildx build ../../ --file Dockerfile --target dep-runner --tag ghcr.io/${{ github.repository_owner }}/quickmpc-cc:stable                          --load
         working-directory: ./src/ComputationContainer/
 
       - name: Run Trivy vulnerability scanner for CC
@@ -62,8 +62,8 @@ jobs:
 
       - name: Build MC image
         run: |
-          docker buildx build ../../ --file Dockerfile --target dep-runner --tag ghcr.io/${{ github.repository_owner }}/quickmpc-mc:s${{ steps.date.outputs.date }}
-          docker buildx build ../../ --file Dockerfile --target dep-runner --tag ghcr.io/${{ github.repository_owner }}/quickmpc-mc:stable
+          docker buildx build ../../ --file Dockerfile --target dep-runner --tag ghcr.io/${{ github.repository_owner }}/quickmpc-mc:s${{ steps.date.outputs.date }} --load
+          docker buildx build ../../ --file Dockerfile --target dep-runner --tag ghcr.io/${{ github.repository_owner }}/quickmpc-mc:stable                          --load
         working-directory: ./src/ManageContainer/
 
       - name: Run Trivy vulnerability scanner for MC


### PR DESCRIPTION
# Summary

- related
  - https://github.com/acompany-develop/QuickMPC/pull/68
  - https://github.com/acompany-develop/QuickMPC/pull/67
- fix missing option
  - https://github.com/acompany-develop/QuickMPC/actions/runs/3458228061/jobs/5772438108#step:6:3544
    ```
    WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
    ``` 

# Purpose

- CI failed issue
  - https://github.com/acompany-develop/QuickMPC/actions/runs/3458228061/jobs/5772438108

# Contents

130b1e6657ffbc76e37835cb757e5f1185aeae3a Add `--load` option

# Testing Methods Performed

- run command at local
- check trivy