### PR TITLE
Write error status when CC exited with code non-zero

### DIFF
--- a/src/ComputationContainer/Scripts/wrapped_run.sh
+++ b/src/ComputationContainer/Scripts/wrapped_run.sh
@@ -48,7 +48,14 @@ function core_pattern_check() {
 
 function run()
 {
-  env "${@:1:$(($#-1))}" "${@: -1}"
+  declare -r executable_file="${*: -1}"
+  if [[ ! -x "$executable_file" ]]
+  then
+    echo "ERROR: ${executable_file} is not executable file"
+    exit 1
+  fi
+
+  env "${@:1:$(($#-1))}" "${executable_file}"
 
   declare -r status=$?
 
@@ -64,21 +71,10 @@ function run()
     return 1
   fi
 
-  # find executable file
-  local executable_file=""
-
-  for arg in "$@"
-  do
-    if [[ -x "$arg" ]]
-    then
-      executable_file="$arg"
-    fi
-  done
-
   # find latest core file
   declare -r core_file=$(find /tmp/cores/ -maxdepth 1 -type f -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1,NR==3 {print $2}' | head -1)
 
-  if [[ "$core_file" == "" ]]
+  if [[ -z "${core_file}" ]]
   then
     echo 'WARNING: core file was not found'
     return 1

--- a/src/ComputationContainer/Scripts/wrapped_run.sh
+++ b/src/ComputationContainer/Scripts/wrapped_run.sh
@@ -93,8 +93,6 @@ fi
 
 core_pattern_check
 
-while true
-do
-  write_status_error
-  run "$@"
-done
+write_status_error
+run "$@"
+write_status_error

--- a/src/ComputationContainer/Scripts/wrapped_run.sh
+++ b/src/ComputationContainer/Scripts/wrapped_run.sh
@@ -81,6 +81,8 @@ function run()
   fi
 
   gdb "${executable_file}" "${core_file}" -x "${GDB_CMD_FILE}" -batch -quiet
+
+  return $status
 }
 
 
@@ -95,4 +97,7 @@ core_pattern_check
 
 write_status_error
 run "$@"
+declare -r status=$?
 write_status_error
+
+exit $status

--- a/src/ComputationContainer/Scripts/wrapped_run.sh
+++ b/src/ComputationContainer/Scripts/wrapped_run.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 
-set -euo pipefail
+set -uo pipefail
 
 KERNEL_CORE_PATTERN_FILE="/proc/sys/kernel/core_pattern"
 
-SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
 CORE_PATTERN_FILE="${SCRIPT_DIR}/data/core_pattern.txt"
 GDB_CMD_FILE="${SCRIPT_DIR}/data/gdb_print_stacktrace_cmd.txt"
 
 function core_pattern_check() {
-  set +e
   result="$(grep "^$(tr -d '\n' < "${CORE_PATTERN_FILE}")$" "${KERNEL_CORE_PATTERN_FILE}")"
-  set -e
 
   if [ -z "${result}" ]
   then
@@ -26,11 +24,9 @@ function core_pattern_check() {
 
 function run()
 {
-  set +e
   env "${@:1:$(($#-1))}" "${@: -1}"
 
   status=$?
-  set -e
 
   if [ $status -eq 0 ]
   then
@@ -79,5 +75,5 @@ core_pattern_check
 
 while true
 do
-  run
+  run "$@"
 done

--- a/src/ComputationContainer/Scripts/wrapped_run.sh
+++ b/src/ComputationContainer/Scripts/wrapped_run.sh
@@ -8,6 +8,29 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
 CORE_PATTERN_FILE="${SCRIPT_DIR}/data/core_pattern.txt"
 GDB_CMD_FILE="${SCRIPT_DIR}/data/gdb_print_stacktrace_cmd.txt"
 
+function write_status_error()
+{
+  JOB_RESULT_ROOT='/Db/result'
+  ERROR_JSON='{"what": "Unexpected error occured.  Contact your administrator."}'
+
+  for job_result_dir in "${JOB_RESULT_ROOT}"/*
+  do
+    completed_file_path="${job_result_dir}/status_COMPLETED"
+    if [[ -f "$completed_file_path" ]]
+    then
+      continue
+    fi
+
+    error_file_path="${job_result_dir}/status_ERROR"
+    if [[ -f "$error_file_path" ]]
+    then
+      continue
+    fi
+
+    echo "$ERROR_JSON" > "$error_file_path"
+  done
+}
+
 function core_pattern_check() {
   result="$(grep "^$(tr -d '\n' < "${CORE_PATTERN_FILE}")$" "${KERNEL_CORE_PATTERN_FILE}")"
 
@@ -75,5 +98,6 @@ core_pattern_check
 
 while true
 do
+  write_status_error
   run "$@"
 done

--- a/src/ComputationContainer/Scripts/wrapped_run.sh
+++ b/src/ComputationContainer/Scripts/wrapped_run.sh
@@ -8,15 +8,65 @@ SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 CORE_PATTERN_FILE="${SCRIPT_DIR}/data/core_pattern.txt"
 GDB_CMD_FILE="${SCRIPT_DIR}/data/gdb_print_stacktrace_cmd.txt"
 
-set +e
-CORE_PATTERN_CHECK="$(grep "^$(tr -d '\n' < "${CORE_PATTERN_FILE}")$" "${KERNEL_CORE_PATTERN_FILE}")"
-set -e
+function core_pattern_check() {
+  set +e
+  result="$(grep "^$(tr -d '\n' < "${CORE_PATTERN_FILE}")$" "${KERNEL_CORE_PATTERN_FILE}")"
+  set -e
 
-if [ -z "${CORE_PATTERN_CHECK}" ]
-then
-  echo "WARNING: ${KERNEL_CORE_PATTERN_FILE} does not match what QuickMPC expects."
-  echo "WARNING: Please run ${SCRIPT_DIR}/host_core_setting.sh on host machine."
-fi
+  if [ -z "${result}" ]
+  then
+    echo "WARNING: ${KERNEL_CORE_PATTERN_FILE} does not match what QuickMPC expects."
+    echo "WARNING: Please run ${SCRIPT_DIR}/host_core_setting.sh on host machine."
+
+    return 1
+  fi
+
+  return 0
+}
+
+function run()
+{
+  set +e
+  env "${@:1:$(($#-1))}" "${@: -1}"
+
+  status=$?
+  set -e
+
+  if [ $status -eq 0 ]
+  then
+    return 0
+  fi
+
+  echo "INFO: ${*: -1} exit with code: ${status}"
+
+  if ! core_pattern_check
+  then
+    return 1
+  fi
+
+  # find executable file
+  executable_file=""
+
+  for arg in "$@"
+  do
+    if [[ -x "$arg" ]]
+    then
+      executable_file="$arg"
+    fi
+  done
+
+  # find latest core file
+  core_file=$(find /tmp/cores/ -maxdepth 1 -type f -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1,NR==3 {print $2}' | head -1)
+
+  if [[ "$core_file" == "" ]]
+  then
+    echo 'WARNING: core file was not found'
+    return 1
+  fi
+
+  gdb "${executable_file}" "${core_file}" -x "${GDB_CMD_FILE}" -batch -quiet
+}
+
 
 if [ $# -le 0 ]
 then
@@ -25,43 +75,9 @@ then
   exit 1
 fi
 
-# run
-set +e
-env "${@:1:$(($#-1))}" "${@: -1}"
+core_pattern_check
 
-STATUS=$?
-set -e
-
-if [ $STATUS -eq 0 ]
-then
-  exit 0
-fi
-
-# core pattern check
-if [ -z "${CORE_PATTERN_CHECK}" ]
-then
-  echo "WARNING: ${KERNEL_CORE_PATTERN_FILE} does not match what QuickMPC expects."
-  echo "WARNING: core file analyzing is skipped."
-  exit $STATUS
-fi
-
-# find executable file
-executable_file=""
-
-for arg in "$@"
+while true
 do
-  if [[ -x "$arg" ]]
-  then
-    executable_file="$arg"
-  fi
+  run
 done
-
-# find latest core file
-core_file=$(find /tmp/cores/ -maxdepth 1 -type f -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1,NR==3 {print $2}' | head -1)
-
-if [ $STATUS -ne 0 ]
-then
-  gdb "${executable_file}" "${core_file}" -x "${GDB_CMD_FILE}" -batch -quiet
-fi
-
-exit $STATUS


### PR DESCRIPTION
# Summary

- write `/Db/result/*/status_ERROR` when CC exited with code non-zero

# Purpose

- If CC was aborted, client could not know correct job status

# Contents

- Change wrapper script
  - Use infinite loop
  - Write `/Db/result/*/status_ERROR` before launching CC if `status_COMPLETED` or `status_ERROR` were not written

# Testing Methods Performed

- Run demo
  - Add code which occurs SIGSEGV in specific job
  - <details>
    <summary>patch</summary>

    ```diff
    diff --git a/src/ComputationContainer/Job/Jobs/CorrelJob.hpp b/src/ComputationContainer/Job/Jobs/CorrelJob.hpp
    index 565b0e43..d486d4d3 100644
    --- a/src/ComputationContainer/Job/Jobs/CorrelJob.hpp
    +++ b/src/ComputationContainer/Job/Jobs/CorrelJob.hpp
    @@ -18,6 +18,8 @@ public:
             const std::vector<std::list<int>> &arg
         )
         {
    +        int *ptr = nullptr;
    +        *ptr = 1;
             std::list<std::vector<Share>> cols;
             for (const auto &w : arg[0])
             {
    ```
    </details>
- Use ShellCheck for static analysis