### PR TITLE
Fixed CC silently crashing

### DIFF
--- a/src/ComputationContainer/Job/JobBase.hpp
+++ b/src/ComputationContainer/Job/JobBase.hpp
@@ -162,47 +162,11 @@ public:
         }
         std::vector<std::list<int>> arg{src, target};
 
-        try
-        {
-            auto [share_table, schemas] = readDb();
-            validate_cols(schemas, arg);
-            auto result = static_cast<T *>(this)->compute(share_table, schemas, arg);
-            writeDb(result);
-        }
-        catch (const std::runtime_error &e)
-        {
-            QMPC_LOG_ERROR("{}", static_cast<int>(statusManager.getStatus()));
-            QMPC_LOG_ERROR("{} | Job Error", e.what());
+        auto [share_table, schemas] = readDb();
+        validate_cols(schemas, arg);
+        auto result = static_cast<T *>(this)->compute(share_table, schemas, arg);
+        writeDb(result);
 
-            auto error_info = boost::get_error_info<qmpc::Log::traced>(e);
-            if (error_info)
-            {
-                QMPC_LOG_ERROR("{}", *error_info);
-                statusManager.error(e, *error_info);
-            }
-            else
-            {
-                QMPC_LOG_ERROR("thrown exception has no stack trace information");
-                statusManager.error(e, std::nullopt);
-            }
-        }
-        catch (const std::exception &e)
-        {
-            QMPC_LOG_ERROR("unexpected Error");
-            QMPC_LOG_ERROR("{} | Job Error", e.what());
-
-            auto *error_info = boost::get_error_info<qmpc::Log::traced>(e);
-            if (error_info)
-            {
-                QMPC_LOG_ERROR("{}", *error_info);
-                statusManager.error(e, *error_info);
-            }
-            else
-            {
-                QMPC_LOG_ERROR("thrown exception has no stack trace information");
-                statusManager.error(e, std::nullopt);
-            }
-        }
         return static_cast<int>(statusManager.getStatus());
     }
 };

--- a/src/ComputationContainer/Job/JobManager.hpp
+++ b/src/ComputationContainer/Job/JobManager.hpp
@@ -141,25 +141,17 @@ public:
         std::thread job_thread(
             [=]
             {
-                try_catch_run(
-                    job_uuid,
-                    [=]()
-                    {
-                        // TODO: hogehogehugahuga~~~!!!
-                        auto job = this->selector(job_param);
-                        if (job == nullptr)
-                        {
-                            QMPC_LOG_ERROR("unknown Method Id");
-                            QMPC_LOG_ERROR("Request Failed");
-                            // TODO: statusをERRORにする
-                        }
-                        else
-                        {
-                            job->run();
-                        }
-                    }
-                );
-
+                auto job = this->selector(job_param);
+                if (job == nullptr)
+                {
+                    QMPC_LOG_ERROR("unknown Method Id");
+                    QMPC_LOG_ERROR("Request Failed");
+                    // TODO: statusをERRORにする
+                }
+                else
+                {
+                    try_catch_run(job_uuid, [&]() { job->run(); });
+                }
                 QMPC_LOG_INFO("end_job_id is {}", job_id);
                 if (is_job_trigger_party) pushJobId(job_id);
             }

--- a/src/ComputationContainer/Job/JobManager.hpp
+++ b/src/ComputationContainer/Job/JobManager.hpp
@@ -11,6 +11,7 @@
 #include "JobBase.hpp"
 #include "JobParameter.hpp"
 #include "JobSelector.hpp"
+#include "JobStatus.hpp"
 #include "Logging/Logger.hpp"
 #include "ProgressManager.hpp"
 #include "TransactionQueue/TransactionQueue.hpp"
@@ -37,6 +38,51 @@ class JobManager
 
     // JobIDをjob_id_queueから出す
     unsigned int pollingPopJobId() { return job_id_queue.pop(); }
+
+    // try-catchをしながら特定の処理を実行する
+    template <class F>
+    static auto try_catch_run(const std::string &job_uuid, const F &func)
+    {
+        StatusManager statusManager(job_uuid);
+        try
+        {
+            func();
+        }
+        catch (const std::runtime_error &e)
+        {
+            QMPC_LOG_ERROR("{}", static_cast<int>(statusManager.getStatus()));
+            QMPC_LOG_ERROR("{} | Job Error", e.what());
+
+            auto error_info = boost::get_error_info<qmpc::Log::traced>(e);
+            if (error_info)
+            {
+                QMPC_LOG_ERROR("{}", *error_info);
+                statusManager.error(e, *error_info);
+            }
+            else
+            {
+                QMPC_LOG_ERROR("thrown exception has no stack trace information");
+                statusManager.error(e, std::nullopt);
+            }
+        }
+        catch (const std::exception &e)
+        {
+            QMPC_LOG_ERROR("unexpected Error");
+            QMPC_LOG_ERROR("{} | Job Error", e.what());
+
+            auto error_info = boost::get_error_info<qmpc::Log::traced>(e);
+            if (error_info)
+            {
+                QMPC_LOG_ERROR("{}", *error_info);
+                statusManager.error(e, *error_info);
+            }
+            else
+            {
+                QMPC_LOG_ERROR("thrown exception has no stack trace information");
+                statusManager.error(e, std::nullopt);
+            }
+        }
+    }
 
 public:
     JobManager()
@@ -85,39 +131,37 @@ public:
     void asyncRun(const JobParameter &job_param, const bool is_job_trigger_party)
     {
         // Job実行の中身
-        // TODO status を DB に書き込むようにする（エラー等も）
-        // TODO:DB操作に関してはDBClientのgrpcエラーコードをそのまま返す方が良いかも
         auto job_id = job_param.getJobId();
+        auto job_uuid = job_param.getRequest().job_uuid();
         QMPC_LOG_INFO("job_id is {}", job_param.getJobId());
         QMPC_LOG_INFO("JobManager: method Id is {}", job_param.getRequest().method_id());
 
-        ProgressManager::getInstance()->registerJob(
-            job_param.getJobId(), job_param.getRequest().job_uuid()
-        );
+        ProgressManager::getInstance()->registerJob(job_id, job_uuid);
 
         std::thread job_thread(
             [=]
             {
-                try
-                {
-                    auto job = this->selector(job_param);
-                    if (job == nullptr)
+                try_catch_run(
+                    job_uuid,
+                    [=]()
                     {
-                        QMPC_LOG_ERROR("unknown Method Id");
-                        QMPC_LOG_ERROR("Request Failed");
+                        // TODO: hogehogehugahuga~~~!!!
+                        auto job = this->selector(job_param);
+                        if (job == nullptr)
+                        {
+                            QMPC_LOG_ERROR("unknown Method Id");
+                            QMPC_LOG_ERROR("Request Failed");
+                            // TODO: statusをERRORにする
+                        }
+                        else
+                        {
+                            job->run();
+                        }
                     }
-                    else
-                    {
-                        job->run();
-                    }
-                }
-                catch (...)
-                {
-                    QMPC_LOG_ERROR("Job Failed");
-                }
+                );
+
                 QMPC_LOG_INFO("end_job_id is {}", job_id);
                 if (is_job_trigger_party) pushJobId(job_id);
-                return;
             }
         );
         job_thread.detach();  // TODO Detachはスレッド管理者が消えるので，アカンかも．．．
@@ -157,7 +201,7 @@ public:
             auto job_id = job_manager->pollingPopJobId();
 
             // 3. 取りだしたJobReqの内容を全パーティに伝える
-            job_manager->sendJobInfo(job_req, job_id);
+            try_catch_run(job_req.job_uuid(), [&]() { job_manager->sendJobInfo(job_req, job_id); });
         }
     }
 };

--- a/src/ComputationContainer/Model/BUILD
+++ b/src/ComputationContainer/Model/BUILD
@@ -13,7 +13,6 @@ cc_library(
         "//Client/ComputationToDb:client",
         "//Client/ComputationToDb:valuetable",
         "//Job:jobStatus",
-        "//Job:progressManager",
         "//Logging:log",
     ],
     visibility = ["//visibility:public"],
@@ -26,6 +25,9 @@ cc_library(
     ],
     deps = [
         "@Proto//ManageToComputationContainer:manage_to_computation_cc_grpc",
+        "//Job:jobStatus",
+        "//Job:progressManager",
+        "//Share:share",
         "//Model:model",
         "//Model/Models:linearregression",
         "//Model/Models:logisticregression",

--- a/src/ComputationContainer/Model/ModelBase.cpp
+++ b/src/ComputationContainer/Model/ModelBase.cpp
@@ -72,6 +72,8 @@ int ModelBase::run(const managetocomputation::PredictRequest &request)
     constexpr int JOB_ID = 1000;  // JobIDのCompetitionを防ぐためJob上限よりも高い値を設定
     qmpc::Share::AddressId::setJobId(JOB_ID);
 
+    qmpc::Job::ProgressManager::getInstance()->registerJob(JOB_ID, request.job_uuid());
+
     statusManager.initJobID(request.job_uuid());
 
     std::list<int> src;

--- a/src/ComputationContainer/Model/ModelBase.cpp
+++ b/src/ComputationContainer/Model/ModelBase.cpp
@@ -1,6 +1,8 @@
 #include "ModelBase.hpp"
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/indexed.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
-#include "Job/ProgressManager.hpp"
 #include "Logging/Logger.hpp"
 #include "nlohmann/json.hpp"
 
@@ -36,12 +38,39 @@ std::pair<std::vector<std::vector<Share>>, std::vector<std::string>> ModelBase::
     );
 }
 
+void ModelBase::validate_cols(const std::vector<std::string> &schemas, const std::list<int> &src)
+{
+    for (const auto &iter_col : src | boost::adaptors::indexed(0))
+    {
+        const int col = iter_col.value();
+        if (col <= 0 || schemas.size() < static_cast<std::size_t>(col))
+        {
+            qmpc::Log::throw_with_trace(std::invalid_argument(
+                (boost::format("src[%1%] = %3% is out of range where column range = "
+                               "[1, %4%], schemas = [%5%]")
+                 % iter_col.index() % col % schemas.size()
+                 % boost::algorithm::join(
+                     schemas
+                         | boost::adaptors::transformed(
+                             [](const std::string &s)
+                             {
+                                 std::ostringstream ss;
+                                 ss << std::quoted(s);
+                                 return ss.str();
+                             }
+                         ),
+                     ", "
+                 ))
+                    .str()
+            ));
+        }
+    }
+}
+
 int ModelBase::run(const managetocomputation::PredictRequest &request)
 {
     constexpr int JOB_ID = 1000;  // JobIDのCompetitionを防ぐためJob上限よりも高い値を設定
     qmpc::Share::AddressId::setJobId(JOB_ID);
-
-    qmpc::Job::ProgressManager::getInstance()->registerJob(JOB_ID, request.job_uuid());
 
     statusManager.initJobID(request.job_uuid());
 
@@ -51,25 +80,10 @@ int ModelBase::run(const managetocomputation::PredictRequest &request)
         src.emplace_back(it);
     }
 
-    std::string dump_result = "";
-    try
-    {
-        auto [share_table, schemas] = readDb(request);
-        auto result = predict(share_table, schemas, src, request.model_param_job_uuid());
-        writeDb(request, result);
-    }
-    catch (const std::runtime_error &e)
-    {
-        QMPC_LOG_ERROR("{}", static_cast<int>(statusManager.getStatus()));
-        QMPC_LOG_ERROR(e.what());
-        QMPC_LOG_ERROR("Predict Error");
-    }
-    catch (const std::exception &e)
-    {
-        QMPC_LOG_ERROR("unexpected Error");
-        QMPC_LOG_ERROR(e.what());
-        QMPC_LOG_ERROR("Predict Error");
-    }
+    auto [share_table, schemas] = readDb(request);
+    validate_cols(schemas, src);
+    auto result = predict(share_table, schemas, src, request.model_param_job_uuid());
+    writeDb(request, result);
 
     return static_cast<int>(statusManager.getStatus());
 }

--- a/src/ComputationContainer/Model/ModelBase.hpp
+++ b/src/ComputationContainer/Model/ModelBase.hpp
@@ -48,6 +48,8 @@ class ModelBase
         statusManager.nextStatus();
     }
 
+    static void validate_cols(const std::vector<std::string> &schemas, const std::list<int> &src);
+
 public:
     virtual ~ModelBase() {}
 

--- a/src/ComputationContainer/Model/ModelManager.hpp
+++ b/src/ComputationContainer/Model/ModelManager.hpp
@@ -92,10 +92,6 @@ public:
     */
     auto push(const managetocomputation::PredictRequest &request) const
     {
-        // Model/ModelManager.cpp内のJOB_IDの値と合わせる．
-        // AddressId内部の値はthread_localなので共有できない
-        constexpr int JOB_ID = 1000;
-
         QMPC_LOG_INFO("Model Manager: Model Id is {}", request.model_id());
         auto model = select(request.model_id());
         if (!model)
@@ -105,7 +101,6 @@ public:
             return 0;
         }
 
-        qmpc::Job::ProgressManager::getInstance()->registerJob(JOB_ID, request.job_uuid());
         auto f = std::async(
             std::launch::async,
             [&request, model = std::move(model)]()

--- a/src/ComputationContainer/Model/ModelManager.hpp
+++ b/src/ComputationContainer/Model/ModelManager.hpp
@@ -3,6 +3,8 @@
 #include <memory>
 #include <vector>
 
+#include "Job/JobStatus.hpp"
+#include "Job/ProgressManager.hpp"
 #include "Logging/Logger.hpp"
 #include "Model/ModelBase.hpp"
 #include "Model/Models/DecisionTree.hpp"
@@ -35,6 +37,52 @@ class ModelManager
         }
     }
 
+    // try-catchをしながら特定の処理を実行する
+    template <class F>
+    static auto try_catch_run(const std::string &job_uuid, const F &func)
+    {
+        qmpc::Job::StatusManager statusManager(job_uuid);
+        try
+        {
+            return func();
+        }
+        catch (const std::runtime_error &e)
+        {
+            QMPC_LOG_ERROR("{}", static_cast<int>(statusManager.getStatus()));
+            QMPC_LOG_ERROR("{} | Predict Error", e.what());
+
+            auto error_info = boost::get_error_info<qmpc::Log::traced>(e);
+            if (error_info)
+            {
+                QMPC_LOG_ERROR("{}", *error_info);
+                statusManager.error(e, *error_info);
+            }
+            else
+            {
+                QMPC_LOG_ERROR("thrown exception has no stack trace information");
+                statusManager.error(e, std::nullopt);
+            }
+        }
+        catch (const std::exception &e)
+        {
+            QMPC_LOG_ERROR("unexpected Error");
+            QMPC_LOG_ERROR("{} | Predict Error", e.what());
+
+            auto error_info = boost::get_error_info<qmpc::Log::traced>(e);
+            if (error_info)
+            {
+                QMPC_LOG_ERROR("{}", *error_info);
+                statusManager.error(e, *error_info);
+            }
+            else
+            {
+                QMPC_LOG_ERROR("thrown exception has no stack trace information");
+                statusManager.error(e, std::nullopt);
+            }
+        }
+        return static_cast<int>(statusManager.getStatus());
+    }
+
 public:
     /*
         model_id error 0
@@ -44,6 +92,10 @@ public:
     */
     auto push(const managetocomputation::PredictRequest &request) const
     {
+        // Model/ModelManager.cpp内のJOB_IDの値と合わせる．
+        // AddressId内部の値はthread_localなので共有できない
+        constexpr int JOB_ID = 1000;
+
         QMPC_LOG_INFO("Model Manager: Model Id is {}", request.model_id());
         auto model = select(request.model_id());
         if (!model)
@@ -53,9 +105,11 @@ public:
             return 0;
         }
 
+        qmpc::Job::ProgressManager::getInstance()->registerJob(JOB_ID, request.job_uuid());
         auto f = std::async(
             std::launch::async,
-            [&request, model = std::move(model)]() { return model->run(request); }
+            [&request, model = std::move(model)]()
+            { return try_catch_run(request.job_uuid(), [&]() { return model->run(request); }); }
         );
         return f.get();
     }


### PR DESCRIPTION
# Summary
Fix silent crash

# Purpose
Keep running CC

# Contents
- Add try-catch to `sendJobInfo`
- Add try-catch to `send(open)`
- Change the timing of try-catch in `run(execute, predict)`
- Add validate to predict

# Testing Methods Performed
- Confirm that the following cases do not stop with an error.
  - Send Out-of-range request to execute and predict
  - Send request with one container dropped
  - Combination of the above two
- CI