### PR TITLE
Use float Share in randBitShare

### DIFF
--- a/Test/docker-compose.yml
+++ b/Test/docker-compose.yml
@@ -128,7 +128,7 @@ services:
 
   dev_bts:
     container_name: beaver_triple_service
-    image: ghcr.io/acompany-develop/quickmpc-bts:s20221122
+    image: ghcr.io/acompany-develop/quickmpc-bts:s20221214
     environment:
       - STAGE=dev
     volumes:

--- a/src/ComputationContainer/Client/ComputationToBts/Client.cpp
+++ b/src/ComputationContainer/Client/ComputationToBts/Client.cpp
@@ -6,17 +6,6 @@
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 
-#include <chrono>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <thread>
-
-#include "Client/Helper/Helper.hpp"
-#include "ConfigParse/ConfigParse.hpp"
-#include "Logging/Logger.hpp"
-
 namespace qmpc::ComputationToBts
 {
 Client::Client() noexcept
@@ -32,37 +21,4 @@ std::shared_ptr<Client> Client::getInstance()
     return instance;
 }
 
-std::vector<Triple> Client::readTriples(const unsigned int job_id, const unsigned int amount)
-{
-    // リクエスト設定
-    enginetobts::GetTriplesRequest request;
-    request.set_job_id(job_id);
-    request.set_amount(amount);
-    enginetobts::GetTriplesResponse response;
-
-    grpc::Status status;
-
-    // リトライポリシーに従ってリクエストを送る
-    auto retry_manager = RetryManager("BTS", "readTriples");
-    do
-    {
-        grpc::ClientContext context;
-        const std::string token = Config::getInstance()->cc_to_bts_token;
-        context.AddMetadata("authorization", "bearer " + token);
-        status = stub_->GetTriples(&context, request, &response);
-    } while (retry_manager.retry(status));
-
-    // responseから結果を取り出して返す
-    std::vector<Triple> triples;
-    triples.reserve(response.triples_size());
-    for (int i = 0; i < response.triples_size(); i++)
-    {
-        auto triple = response.triples(i);
-        Triple t = std::make_tuple(
-            std::to_string(triple.a()), std::to_string(triple.b()), std::to_string(triple.c())
-        );
-        triples.emplace_back(t);
-    }
-    return triples;
-}
 }  // namespace qmpc::ComputationToBts

--- a/src/ComputationContainer/Client/ComputationToBts/Client.hpp
+++ b/src/ComputationContainer/Client/ComputationToBts/Client.hpp
@@ -3,6 +3,9 @@
 #include <string>
 #include <vector>
 
+#include "Client/Helper/Helper.hpp"
+#include "ConfigParse/ConfigParse.hpp"
+#include "Logging/Logger.hpp"
 #include "external/Proto/EngineToBts/engine_to_bts.grpc.pb.h"
 
 namespace qmpc::ComputationToBts
@@ -25,6 +28,47 @@ public:
     static std::shared_ptr<Client> getInstance();
 
     // tripleの取り出し
-    std::vector<Triple> readTriples(const unsigned int job_id, const unsigned int amount);
+    template <class SV>
+    std::vector<Triple> readTriples(const unsigned int job_id, const unsigned int amount)
+    {
+        // リクエスト設定
+        enginetobts::GetTriplesRequest request;
+        request.set_job_id(job_id);
+        request.set_amount(amount);
+        if constexpr (std::is_same_v<SV, float>)
+        {
+            request.set_triple_type(enginetobts::Type::TYPE_FLOAT);
+        }
+        else
+        {
+            request.set_triple_type(enginetobts::Type::TYPE_FIXEDPOINT);
+        }
+        enginetobts::GetTriplesResponse response;
+
+        grpc::Status status;
+
+        // リトライポリシーに従ってリクエストを送る
+        auto retry_manager = RetryManager("BTS", "readTriples");
+        do
+        {
+            grpc::ClientContext context;
+            const std::string token = Config::getInstance()->cc_to_bts_token;
+            context.AddMetadata("authorization", "bearer " + token);
+            status = stub_->GetTriples(&context, request, &response);
+        } while (retry_manager.retry(status));
+
+        // responseから結果を取り出して返す
+        std::vector<Triple> triples;
+        triples.reserve(response.triples_size());
+        for (int i = 0; i < response.triples_size(); i++)
+        {
+            auto triple = response.triples(i);
+            Triple t = std::make_tuple(
+                std::to_string(triple.a()), std::to_string(triple.b()), std::to_string(triple.c())
+            );
+            triples.emplace_back(t);
+        }
+        return triples;
+    }
 };
 }  // namespace qmpc::ComputationToBts

--- a/src/ComputationContainer/Random/Random.cpp
+++ b/src/ComputationContainer/Random/Random.cpp
@@ -19,20 +19,3 @@ unsigned long long RandGenerator::generateRand()
 
     return rnd;
 }
-
-template <>
-long long RandGenerator::getRand<long long>(long long min_val, long long max_val)
-{
-    auto rnd = RandGenerator::getInstance()->generateRand();
-    auto rnd_mod = static_cast<long long>(rnd % (max_val - min_val));
-    auto val = std::abs(rnd_mod) + min_val;
-    return val;
-}
-template <>
-FixedPoint RandGenerator::getRand<FixedPoint>(long long min_val, long long max_val)
-{
-    auto rnd = RandGenerator::getInstance()->generateRand();
-    auto rnd_mod = static_cast<long long>(rnd % (max_val - min_val));
-    FixedPoint val{std::abs(rnd_mod) + min_val};
-    return val;
-}

--- a/src/ComputationContainer/Random/Random.hpp
+++ b/src/ComputationContainer/Random/Random.hpp
@@ -23,7 +23,14 @@ public:
     };
 
     template <class T>
-    T getRand(long long min_val = 0, long long max_val = 9223372036854775807ll);
+    T getRand(long long min_val = 0, long long max_val = 9223372036854775807ll)
+    {
+        auto rnd = RandGenerator::getInstance()->generateRand();
+        auto rnd_mod = static_cast<long long>(rnd % (max_val - min_val));
+        auto val = T(std::abs(rnd_mod) + min_val);
+        return val;
+    }
+
     template <class T>
     std::vector<T> getRandVec(
         long long min_val = 0, long long max_val = 9223372036854775807ll, int n = 5
@@ -33,9 +40,7 @@ public:
         ret.reserve(n);
         for (int i = 0; i < n; i++)
         {
-            auto rnd = RandGenerator::getInstance()->generateRand();
-            auto rnd_mod = static_cast<long long>(rnd % (max_val - min_val));
-            ret.emplace_back(T(std::abs(rnd_mod) + min_val));
+            ret.emplace_back(getRand<T>(min_val, max_val));
         }
         return ret;
     }

--- a/src/ComputationContainer/Share/Share.hpp
+++ b/src/ComputationContainer/Share/Share.hpp
@@ -593,4 +593,3 @@ std::vector<Share<T>> getFloor(const std::vector<Share<T>> &s)
 }  // namespace qmpc::Share
 
 using Share = qmpc::Share::Share<FixedPoint>;
-

--- a/src/ComputationContainer/Test/IntegrationTest/ReadTripleFromBtsTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ReadTripleFromBtsTest.hpp
@@ -10,7 +10,7 @@ void readTriplesTest(const unsigned int jobIdMax, const unsigned int amount)
     for (unsigned int jobId = 1; jobId <= jobIdMax; jobId++)
     {
         QMPC_LOG_INFO("jobId[{}]: ...", jobId);
-        auto triples = cc_to_db->readTriples(jobId, amount);
+        auto triples = cc_to_db->readTriples<FixedPoint>(jobId, amount);
         EXPECT_EQ(triples.size(), amount);
         // TODO: Party間で足並みを揃えてa*b=cのチェック
 

--- a/src/Proto/EngineToBts/engine_to_bts.proto
+++ b/src/Proto/EngineToBts/engine_to_bts.proto
@@ -8,9 +8,16 @@ service EngineToBts {
     rpc GetTriples(GetTriplesRequest) returns (GetTriplesResponse) {}
 }
 
+enum Type{
+  TYPE_UNKNOWN = 0;
+  TYPE_FLOAT = 1;
+  TYPE_FIXEDPOINT = 2;
+}
+
 message GetTriplesRequest{
     uint32 job_id = 1;
     uint32 amount = 2;
+    Type triple_type = 3;
 }
 
 message Triple{


### PR DESCRIPTION
# Summary
Use float Share in randBitShare

# Purpose
Attempt to speed up the calculation by using the minimum number of bytes required

# Contents
- Add TripleType to engine2bts
- Add type for calculate in getRandBitShare, and set default type float 
- Add triple_queue_float to TripleHandler
- Update random range of getRandBitShare to [-10, 10]

# Testing Methods Performed
- Confirm that the random number is small only when float share
- make test t=LibClient p=medium
- CI