### PR TITLE
Update the even-oddness of random numbers in getRandBitShare

### DIFF
--- a/src/ComputationContainer/Share/Share.hpp
+++ b/src/ComputationContainer/Share/Share.hpp
@@ -470,16 +470,20 @@ auto _sqrt(const T &x)
 template <typename T, typename BT = float>
 Share<T> getRandBitShare()
 {
-    Config *conf = Config::getInstance();
     while (true)
     {
-        auto r_int = RandGenerator::getInstance()->getRand<int>(-10, 10);
-        // SPは奇数，それ以外は偶数になるまで再生成
-        while ((conf->party_id == conf->sp_id && !(r_int & 1))
-               || (conf->party_id != conf->sp_id && (r_int & 1)))
+        auto r_int = []()
         {
-            r_int = RandGenerator::getInstance()->getRand<int>(-10, 10);
-        }
+            Config *conf = Config::getInstance();
+            auto sgn = (RandGenerator::getInstance()->getRand<int>(0, 2) << 1) - 1;
+            auto r = (RandGenerator::getInstance()->getRand<int>(0, 6) << 1);
+            // SPは奇数，それ以外は偶数とする
+            if (conf->party_id == conf->sp_id)
+            {
+                ++r;
+            }
+            return sgn * r;
+        }();
         auto r = Share<BT>(BT(r_int));
 
         auto square_r = r * r;
@@ -499,18 +503,22 @@ Share<T> getRandBitShare()
 template <typename T, typename BT = float>
 std::vector<Share<T>> getRandBitShare(int n)
 {
-    Config *conf = Config::getInstance();
     std::vector<Share<BT>> r;
     r.reserve(n);
     for (int _ = 0; _ < n; ++_)
     {
-        auto r_int = RandGenerator::getInstance()->getRand<int>(-10, 10);
-        // SPは奇数，それ以外は偶数になるまで再生成
-        while ((conf->party_id == conf->sp_id && !(r_int & 1))
-               || (conf->party_id != conf->sp_id && (r_int & 1)))
+        auto r_int = []()
         {
-            r_int = RandGenerator::getInstance()->getRand<int>(-10, 10);
-        }
+            Config *conf = Config::getInstance();
+            auto sgn = (RandGenerator::getInstance()->getRand<int>(0, 2) << 1) - 1;
+            auto r = (RandGenerator::getInstance()->getRand<int>(0, 6) << 1);
+            // SPは奇数，それ以外は偶数とする
+            if (conf->party_id == conf->sp_id)
+            {
+                ++r;
+            }
+            return sgn * r;
+        }();
         r.emplace_back(BT(r_int));
     }
 


### PR DESCRIPTION
# Summary
Update the even-oddness of random numbers in getRandBitShare

# Purpose
Prevent re-generating random numbers

# Contents
- Update to generate odd numbers for SP and even numbers for NP

# Testing Methods Performed
- CI
- make test t=ComputationContainer p=medium
- Measure the number of regenerations

10000 horizontal joins．1 trial.

|version|#regen|
|-|-|
|previous versions(ae29a9ed8105f44c7bca8c24b056609cdd9d1137)|390|
|current version(c745c904f57a1f7befe7f0c5fe68ea0213c18226)|39871|
|this PR version|**0**|
