### PR TITLE
Add retry policy to MC

### DIFF
--- a/src/ManageContainer/Client/Helper/helper.go
+++ b/src/ManageContainer/Client/Helper/helper.go
@@ -1,6 +1,8 @@
 package helper
 
 import (
+	"time"
+
 	. "github.com/acompany-develop/QuickMPC/src/ManageContainer/Log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -19,7 +21,7 @@ type RetryManager struct {
 func (rm *RetryManager) canRetry(code codes.Code) bool {
 
 	rm.count++
-	if rm.count >= 10 {
+	if rm.count >= retryNum {
 		return false
 	}
 
@@ -44,7 +46,7 @@ func (rm *RetryManager) Retry(err error) (bool, error) {
 	AppLogger.Errorf("GRPC Error : Code [%d], Message [%s]", st.Code(), st.Message())
 	if rm.canRetry(st.Code()) {
 		// リトライ可能と判断してsleepの後にリトライ
-		// TODO: sleep
+		time.Sleep(retryWaitTime * time.Second)
 		return true, err
 	}
 

--- a/src/ManageContainer/Client/Helper/helper.go
+++ b/src/ManageContainer/Client/Helper/helper.go
@@ -1,0 +1,53 @@
+package helper
+
+import (
+	. "github.com/acompany-develop/QuickMPC/src/ManageContainer/Log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// リトライ回数
+const retryNum = 10
+
+// リトライ間隔
+const retryWaitTime = 5
+
+type RetryManager struct {
+	count int
+}
+
+func (rm *RetryManager) canRetry(code codes.Code) bool {
+
+	rm.count++
+	if rm.count >= 10 {
+		return false
+	}
+
+	// 該当のエラーコードであればリトライする
+	if code == codes.DeadlineExceeded ||
+		code == codes.Unavailable ||
+		code == codes.ResourceExhausted {
+		return true
+	}
+	// retryの余地なし
+	return false
+}
+
+func (rm *RetryManager) Retry(err error) (bool, error) {
+	st, _ := status.FromError(err)
+
+	// 正常に通信できているためリトライ不要
+	if st.Code() == codes.OK {
+		return false, nil
+	}
+
+	AppLogger.Errorf("GRPC Error : Code [%d], Message [%s]", st.Code(), st.Message())
+	if rm.canRetry(st.Code()) {
+		// リトライ可能と判断してsleepの後にリトライ
+		// TODO: sleep
+		return true, err
+	}
+
+	// リトライ不能と判断
+	return false, err
+}

--- a/src/ManageContainer/Client/Helper/helper_test.go
+++ b/src/ManageContainer/Client/Helper/helper_test.go
@@ -1,0 +1,85 @@
+package helper
+
+import (
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// 正常の場合リトライがfalseになるか
+func TestRetryNotError(t *testing.T) {
+	rm := RetryManager{}
+	b, err := rm.Retry(nil)
+	if b || err != nil {
+		t.Fatalf("Retry must return `(false, nil)` when argument `err` is nil. but return `(%t, %v)`", b, err)
+	}
+}
+
+// 異常の場合リトライがtrueになるか
+func TestRetryError(t *testing.T) {
+	rm := RetryManager{}
+	b, err := rm.Retry(fmt.Errorf("Various errors"))
+	if !b || err == nil {
+		t.Fatalf("Retry must return `(true, err)` when argument `err` has error. but return `(%t, %v)`", b, err)
+	}
+}
+
+// Grpcの各StatusのErrorでRetryを区別できているか
+func TestRetryGrpcError(t *testing.T) {
+	testcases := map[string]struct {
+		grpcErr  error
+		expected bool
+	}{
+		"OK":                 {status.Error(codes.OK, ""), false},
+		"Canceled":           {status.Error(codes.Canceled, ""), false},
+		"Unknown":            {status.Error(codes.Unknown, ""), false},
+		"InvalidArgument":    {status.Error(codes.InvalidArgument, ""), false},
+		"DeadlineExceeded":   {status.Error(codes.DeadlineExceeded, ""), true},
+		"NotFound":           {status.Error(codes.NotFound, ""), false},
+		"AlreadyExists":      {status.Error(codes.AlreadyExists, ""), false},
+		"PermissionDenied":   {status.Error(codes.PermissionDenied, ""), false},
+		"ResourceExhausted":  {status.Error(codes.ResourceExhausted, ""), true},
+		"FailedPrecondition": {status.Error(codes.FailedPrecondition, ""), false},
+		"Aborted":            {status.Error(codes.Aborted, ""), false},
+		"OutOfRange":         {status.Error(codes.OutOfRange, ""), false},
+		"Unimplemented":      {status.Error(codes.Unimplemented, ""), false},
+		"Internal":           {status.Error(codes.Internal, ""), false},
+		"Unavailable":        {status.Error(codes.Unavailable, ""), true},
+		"DataLoss":           {status.Error(codes.DataLoss, ""), false},
+		"Unauthenticated":    {status.Error(codes.Unauthenticated, ""), false},
+	}
+
+	for name, tt := range testcases {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			rm := RetryManager{}
+			b, _ := rm.Retry(tt.grpcErr)
+			if b != tt.expected {
+				t.Fatalf("Retry must return `%t` when grpc error is `%s`, but return `%t`", tt.expected, name, b)
+			}
+		})
+	}
+}
+
+// リトライ回数制限が動作するか
+func TestRetryErrorMomentary(t *testing.T) {
+	rm := RetryManager{}
+
+	// 10回まではリトライする
+	for i := 0; i < 10; i++ {
+		b, err := rm.Retry(fmt.Errorf("Various errors"))
+		if !b || err == nil {
+			t.Fatalf("Retry must return `(true, err)` when argument `err` has error. but return `(%t, %v)`", b, err)
+		}
+	}
+
+	// 11回目はリトライしない
+	b, err := rm.Retry(fmt.Errorf("Various errors"))
+	if b || err == nil {
+		t.Fatalf("Retry must return `false, err` when call Retry over 10 times. but return `%t %v`", b, err)
+	}
+}

--- a/src/ManageContainer/Client/ManageToComputationContainer/Client_test.go
+++ b/src/ManageContainer/Client/ManageToComputationContainer/Client_test.go
@@ -65,11 +65,11 @@ func TestExecuteComputation(t *testing.T) {
 	}
 
 	if message != "ok" {
-		t.Fatal("ExecuteComputation must return message 'ok'")
+		t.Fatalf("ExecuteComputation must return message 'ok'. but message is '%s'", message)
 	}
 
 	if status != 0 {
-		t.Fatal("ExecuteComputation must return status '0'")
+		t.Fatalf("ExecuteComputation must return status '0'. but status is '%d'", status)
 	}
 }
 
@@ -142,10 +142,10 @@ func TestPredict(t *testing.T) {
 	}
 
 	if message != "ok" {
-		t.Fatal("Result must return message 'ok'")
+		t.Fatalf("Result must return message 'ok'. but message is '%s'", message)
 	}
 
 	if status != 0 {
-		t.Fatal("Result must return status '0'")
+		t.Fatalf("Result must return status '0'. but status is '%d'", status)
 	}
 }

--- a/src/ManageContainer/Client/ManageToManageContainer/Client.go
+++ b/src/ManageContainer/Client/ManageToManageContainer/Client.go
@@ -110,9 +110,19 @@ func (c Client) Sync(syncID string) error {
 		}
 	}
 
-	// 他のMCからリクエストが来るのを待機
-	m2mserver.Wait(syncID, func(cnt int) bool { return cnt < len(connList) })
-	return nil
+	// 他のMCからリクエストが来るのをタイムアウト付きで待機
+	timeout := time.After(50 * time.Second)
+	done := make(chan struct{})
+	go func() {
+		m2mserver.Wait(syncID, func(cnt int) bool { return cnt < len(connList) })
+		done <- struct{}{}
+	}()
+	select {
+	case <-timeout:
+		return fmt.Errorf("Sync response is not returned ERROR!")
+	case <-done:
+		return nil
+	}
 }
 
 // (conn)にシェア削除リクエストを送信する

--- a/src/ManageContainer/Client/ManageToManageContainer/Client.go
+++ b/src/ManageContainer/Client/ManageToManageContainer/Client.go
@@ -11,7 +11,6 @@ import (
 	utils "github.com/acompany-develop/QuickMPC/src/ManageContainer/Utils"
 	pb "github.com/acompany-develop/QuickMPC/src/Proto/ManageToManageContainer"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -54,14 +53,6 @@ func connect() ([]*grpc.ClientConn, error) {
 		connList = append(connList, conn)
 	}
 	return connList, nil
-}
-
-func reconnect(conn *grpc.ClientConn) bool {
-	// 20秒間だけ再接続を試みる
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
-	conn.WaitForStateChange(ctx, conn.GetState())
-	return conn.GetState() == connectivity.Idle
 }
 
 // 自分以外のMCにシェア削除リクエストを送信する


### PR DESCRIPTION
# Summary
Added communication retry constraints

# Purpose
- Align policy with CC
- Remove endless loops of waiting

# Contents
- Add retry manager
- Add timeout to Sync

# Testing Methods Performed
- CI
- make test t=ManageContainer p=medium
- Down containers before and after communication to check for infinite loops