### PR TITLE
Delete the garbage left behind when Sync() fails

### DIFF
--- a/src/ManageContainer/Client/ManageToManageContainer/Client.go
+++ b/src/ManageContainer/Client/ManageToManageContainer/Client.go
@@ -101,19 +101,8 @@ func (c Client) Sync(syncID string) error {
 		}
 	}
 
-	// 他のMCからリクエストが来るのをタイムアウト付きで待機
-	timeout := time.After(50 * time.Second)
-	done := make(chan struct{})
-	go func() {
-		m2mserver.Wait(syncID, func(cnt int) bool { return cnt < len(connList) })
-		done <- struct{}{}
-	}()
-	select {
-	case <-timeout:
-		return fmt.Errorf("Sync response is not returned ERROR!")
-	case <-done:
-		return nil
-	}
+	// 他のMCからリクエストが来るのを待機
+	return m2mserver.Wait(syncID, 50*time.Second, func(cnt int) bool { return cnt < len(connList) })
 }
 
 // (conn)にシェア削除リクエストを送信する

--- a/src/ManageContainer/Client/ManageToManageContainer/Client.go
+++ b/src/ManageContainer/Client/ManageToManageContainer/Client.go
@@ -102,7 +102,8 @@ func (c Client) Sync(syncID string) error {
 	}
 
 	// 他のMCからリクエストが来るのを待機
-	return m2mserver.Wait(syncID, 50*time.Second, func(cnt int) bool { return cnt < len(connList) })
+	// NOTE: リトライポリシーの時間以上のtimeoutを設定する
+	return m2mserver.Wait(syncID, 60*time.Second, func(cnt int) bool { return cnt < len(connList) })
 }
 
 // (conn)にシェア削除リクエストを送信する

--- a/src/ManageContainer/Server/ManageToManageContainer/Cond_count.go
+++ b/src/ManageContainer/Server/ManageToManageContainer/Cond_count.go
@@ -1,7 +1,9 @@
 package m2mserver
 
 import (
+	"fmt"
 	"sync"
+	"time"
 )
 
 type counter struct {
@@ -49,13 +51,27 @@ func load(key string) counter {
 
 // fnがtrueとなる間waitする
 // keyに対してincrementされる度に判定が起こる
-func Wait(key string, fn func(int) bool) {
-	mp := load(key)
-	mp.mu.Lock()
-	defer mp.mu.Unlock()
+func Wait(key string, waitTime time.Duration, fn func(int) bool) error {
 
-	for fn(load(key).count) {
-		<-mp.ch
+	timeout := time.After(waitTime)
+	done := make(chan struct{})
+	go func() {
+		mp := load(key)
+		mp.mu.Lock()
+		defer mp.mu.Unlock()
+
+		for fn(load(key).count) {
+			<-mp.ch
+		}
+
+		count_map.Delete(key)
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-timeout:
+		return fmt.Errorf("Timeout ERROR! Wait %d microseccond, but the condition was not met", waitTime)
+	case <-done:
+		return nil
 	}
-	count_map.Delete(key)
 }

--- a/src/ManageContainer/Server/ManageToManageContainer/Cond_count_test.go
+++ b/src/ManageContainer/Server/ManageToManageContainer/Cond_count_test.go
@@ -6,74 +6,85 @@ import (
 	"time"
 )
 
+func generateValue() counter {
+	c := counter{
+		count: 0,
+		mu:    new(sync.Mutex),
+		ch:    make(chan bool),
+	}
+	return c
+}
+
 // incrementでcountが増えるかTest
 func TestIncrement(t *testing.T) {
-	id := "id"
-	if load(id).count != 0 {
-		t.Fatal()
+	// データ登録
+	key := "TestIncrementKey"
+	count_map.Store(key, generateValue())
+
+	increment(key)
+
+	// countが増えているか
+	val, _ := count_map.Load(key)
+	cnt := val.(counter).count
+	if cnt != 1 {
+		t.Fatalf("cnt must be 1 after increment, but cnt is %d", cnt)
 	}
-	increment(id)
-	if load(id).count != 1 {
-		t.Fatal()
-	}
-	count_map.Delete(id)
+
+	// データ削除
+	count_map.Delete(key)
 }
 
 // waitが正常に終了するかTest
 func TestWait(t *testing.T) {
-	id := "id"
+	key := "TestWaitKey"
 
+	// 1秒後にincrementで発火する
 	go func() {
 		time.Sleep(time.Second)
-		increment(id)
+		increment(key)
 	}()
 
-	// incrementで発火する
-	err := Wait(id, 2*time.Second, func(cnt int) bool {
+	// incrementの発火を待つ
+	err := Wait(key, 2*time.Second, func(cnt int) bool {
 		return cnt < 1
 	})
 
 	if err != nil {
-		t.Fatal("", err)
+		t.Fatal(err)
 	}
 }
 
-// waitがwaitし続けるかTest
+// WaitがtimeoutするまでWaitしてエラーを返すかテスト
 func TestWaitForever(t *testing.T) {
-	id := "id"
+	key := "TestWaitForeverKey"
 
-	// incrementがないためずっとwaitする
-	err := Wait(id, time.Second, func(cnt int) bool {
-		return cnt < 1
+	// timeoutが来るまでずっとwaitする
+	err := Wait(key, time.Second, func(cnt int) bool {
+		return true
 	})
 
 	if err == nil {
-		t.Fatal("", err)
+		t.Fatal("Wait must return timeout error, but return nil")
 	}
 }
 
 // waitが失敗した時にデータが削除されているか
 func TestWaitFailedDeleteData(t *testing.T) {
-	id := "id"
-	mp := counter{
-		count: 0,
-		mu:    new(sync.Mutex),
-		ch:    make(chan bool),
-	}
-
 	// データ登録
-	count_map.Store(id, mp)
+	key := "TestWaitFailedDeleteDataKey"
+	count_map.Store(key, generateValue())
 
-	err := Wait(id, time.Second, func(cnt int) bool {
+	err := Wait(key, time.Second, func(cnt int) bool {
 		return cnt < 1
 	})
+
 	if err == nil {
-		t.Fatal("", err)
+		t.Fatal("Wait must return timeout error, but return nil")
 	}
 
 	// データが削除されているか
-	_, ok := count_map.Load(id)
+	_, ok := count_map.Load(key)
 	if ok {
-		t.Fatal("")
+		t.Fatal("count_map[key] must be deleted, but exist.")
 	}
 }

--- a/src/ManageContainer/Server/ManageToManageContainer/Cond_count_test.go
+++ b/src/ManageContainer/Server/ManageToManageContainer/Cond_count_test.go
@@ -21,45 +21,32 @@ func TestIncrement(t *testing.T) {
 // waitが正常に終了するかTest
 func TestWait(t *testing.T) {
 	id := "id"
-	timeout := time.After(2 * time.Second)
-	done := make(chan bool)
 
 	go func() {
 		time.Sleep(time.Second)
 		increment(id)
 	}()
 
-	go func() {
-		// incrementで発火してdoneする
-		Wait(id, func(cnt int) bool {
-			return cnt < 1
-		})
-		done <- true
-	}()
+	// incrementで発火する
+	err := Wait(id, 2*time.Second, func(cnt int) bool {
+		return cnt < 1
+	})
 
-	select {
-	case <-timeout:
-		t.Fatal("")
-	case <-done:
+	if err != nil {
+		t.Fatal("", err)
 	}
 }
 
 // waitがwaitし続けるかTest
 func TestWaitForever(t *testing.T) {
 	id := "id"
-	timeout := time.After(time.Second)
-	done := make(chan bool)
-	go func() {
-		// incrementがないためずっとwaitする
-		Wait(id, func(cnt int) bool {
-			return cnt < 1
-		})
-		done <- true
-	}()
 
-	select {
-	case <-done:
-		t.Fatal("")
-	case <-timeout:
+	// incrementがないためずっとwaitする
+	err := Wait(id, time.Second, func(cnt int) bool {
+		return cnt < 1
+	})
+
+	if err == nil {
+		t.Fatal("", err)
 	}
 }

--- a/src/ManageContainer/Server/ManageToManageContainer/Cond_count_test.go
+++ b/src/ManageContainer/Server/ManageToManageContainer/Cond_count_test.go
@@ -1,6 +1,7 @@
 package m2mserver
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -48,5 +49,31 @@ func TestWaitForever(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("", err)
+	}
+}
+
+// waitが失敗した時にデータが削除されているか
+func TestWaitFailedDeleteData(t *testing.T) {
+	id := "id"
+	mp := counter{
+		count: 0,
+		mu:    new(sync.Mutex),
+		ch:    make(chan bool),
+	}
+
+	// データ登録
+	count_map.Store(id, mp)
+
+	err := Wait(id, time.Second, func(cnt int) bool {
+		return cnt < 1
+	})
+	if err == nil {
+		t.Fatal("", err)
+	}
+
+	// データが削除されているか
+	_, ok := count_map.Load(id)
+	if ok {
+		t.Fatal("")
 	}
 }


### PR DESCRIPTION
# Summary
manual garbage collection

# Purpose
- No unusable data is left behind
- Remove infinite loop in goroutine

# Contents
- Add error handling for `Sync()`
- Add timeout to `Cond_count`
  - Add timeout to `Wait`
  - Breaks the infinite loop in Wait when timeout is detected
- Clean `Cond_count_test`
# Testing Methods Performed
- make test t=ManageContainer p=medium
- CI
- Run send_share without one MC, and check if Share is deleted after the remaining MC throws an error