### PR TITLE
Fix column to be deleted

### DIFF
--- a/Test/LibClient/src/tests/test_join.py
+++ b/Test/LibClient/src/tests/test_join.py
@@ -20,7 +20,7 @@ def execute_computation_param(dataIds=[data_id([[1000, 1, 2], [1001, 1, 2]],
     [
         # not share join case
         (execute_computation_param(join=[0]),
-         [[1, 2, 2]]),
+         [[1, 2, 1, 2]]),
 
         # all match case
         (execute_computation_param(dataIds=[data_id([[1000, 1, 2], [1001, 3, 4]],
@@ -94,7 +94,7 @@ def test_vjoin(param: tuple, expected: list):
     [
         # not share join case
         (execute_computation_param(join=[2]),
-         [[1, 2, 2]]),
+         [[1, 2, 1, 2]]),
 
         # all match case
         (execute_computation_param(dataIds=[data_id([[1000, 1, 2], [1001, 3, 4]],

--- a/src/ComputationContainer/Client/ComputationToDb/ValueTable.cpp
+++ b/src/ComputationContainer/Client/ComputationToDb/ValueTable.cpp
@@ -337,7 +337,19 @@ ValueTable ValueTable::vjoin(const ValueTable &join_table, int idx, int idx_tgt)
 ValueTable ValueTable::hjoin(const ValueTable &join_table, int idx, int idx_tgt) const
 {
     // joinしたschemasを構築
-    auto [schemas_it, schemas_join_it] = unionValueIndex(schemas, join_table.schemas);
+    auto schemas_it = std::vector<int>(schemas.size());
+    std::iota(schemas_it.begin(), schemas_it.end(), 0);
+    auto schemas_join_it = std::vector<int>();
+    schemas_join_it.reserve(join_table.schemas.size());
+    for (size_t i = 0; i < join_table.schemas.size(); ++i)
+    {
+        if (static_cast<int>(i) == idx_tgt - 1)
+        {
+            continue;
+        }
+        schemas_join_it.emplace_back(i);
+    }
+
     auto new_schemas_size = schemas_it.size() + schemas_join_it.size();
     auto new_schemas = schemas;
     new_schemas.reserve(new_schemas_size);
@@ -409,7 +421,19 @@ ValueTable parseRead(
 ValueTable ValueTable::hjoinShare(const ValueTable &join_table, int idx, int idx_tgt) const
 {
     // joinしたschemasを構築
-    auto [schemas_it, schemas_join_it] = unionValueIndex(schemas, join_table.schemas);
+    auto schemas_it = std::vector<int>(schemas.size());
+    std::iota(schemas_it.begin(), schemas_it.end(), 0);
+    auto schemas_join_it = std::vector<int>();
+    schemas_join_it.reserve(join_table.schemas.size());
+    for (size_t i = 0; i < join_table.schemas.size(); ++i)
+    {
+        if (static_cast<int>(i) == idx_tgt - 1)
+        {
+            continue;
+        }
+        schemas_join_it.emplace_back(i);
+    }
+
     auto new_schemas_size = schemas_it.size() + schemas_join_it.size();
     auto new_schemas = schemas;
     new_schemas.reserve(new_schemas_size);

--- a/src/ComputationContainer/Job/Jobs/JoinTableJob.hpp
+++ b/src/ComputationContainer/Job/Jobs/JoinTableJob.hpp
@@ -16,8 +16,7 @@ class JoinTableJob : public JobBase<JoinTableJob>
         const std::list<int> &id_column
     )
     {
-        // 最左列(ID列)と突合に使用した列をテーブルから削除する
-        constexpr size_t ID_ROW = 0;
+        // 突合に使用した列をテーブルから削除する
         const size_t match_row = id_column.front() - 1;
 
         std::vector<std::vector<std::string>> remove_table;
@@ -28,7 +27,7 @@ class JoinTableJob : public JobBase<JoinTableJob>
             remove_row.reserve(row.size());
             for (size_t i = 0; i < row.size(); ++i)
             {
-                if (i != ID_ROW && i != match_row)
+                if (i != match_row)
                 {
                     remove_row.emplace_back(row[i]);
                 }
@@ -40,7 +39,7 @@ class JoinTableJob : public JobBase<JoinTableJob>
         remove_schema.reserve(schema.size());
         for (size_t i = 0; i < schema.size(); ++i)
         {
-            if (i != ID_ROW && i != match_row)
+            if (i != match_row)
             {
                 remove_schema.emplace_back(schema[i]);
             }

--- a/src/ComputationContainer/Test/IntegrationTest/ValueTableTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ValueTableTest.hpp
@@ -49,14 +49,16 @@ TEST(ValueTableTest, vjoinTest)
 TEST(ValueTableTest, hjoinTest)
 {
     // table1 に table2 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_1h2{{"101", "1", "2", "6"}};
-    const std::vector<std::string> schemas_1h2{"id", "attr1", "attr2", "attr3"};
+    const std::vector<std::vector<std::string>> table_data_1h2{{"101", "1", "2", "5", "6"}};
+    const std::vector<std::string> schemas_1h2{"id", "attr1", "attr2", "attr1", "attr3"};
     const auto table_1h2 = qmpc::ComputationToDb::ValueTable(table_data_1h2, schemas_1h2);
     EXPECT_EQ(table_1h2, table1.hjoin(table2, 1, 1));
 
     // table3 に table4 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_3h4{{"103", "12", "13", "14", "17"}};
-    const std::vector<std::string> schemas_3h4{"id", "attr1", "attr3", "attr4", "attr5"};
+    const std::vector<std::vector<std::string>> table_data_3h4{
+        {"103", "12", "13", "14", "15", "16", "17"}};
+    const std::vector<std::string> schemas_3h4{
+        "id", "attr1", "attr3", "attr4", "attr3", "attr4", "attr5"};
     const auto table_3h4 = qmpc::ComputationToDb::ValueTable(table_data_3h4, schemas_3h4);
     EXPECT_EQ(table_3h4, table3.hjoin(table4, 1, 1));
 }
@@ -65,8 +67,8 @@ TEST(ValueTableTest, vhjoinTest)
 {
     // vjoin(table1,table2) と table3 を横結合した場合
     const std::vector<std::vector<std::string>> table_data_1v2h3{
-        {"102", "3", "10", "11"}, {"103", "7", "13", "14"}};
-    const std::vector<std::string> schemas_1v2h3{"id", "attr1", "attr3", "attr4"};
+        {"102", "3", "9", "10", "11"}, {"103", "7", "12", "13", "14"}};
+    const std::vector<std::string> schemas_1v2h3{"id", "attr1", "attr1", "attr3", "attr4"};
     const auto table_1v2h3 = qmpc::ComputationToDb::ValueTable(table_data_1v2h3, schemas_1v2h3);
     EXPECT_EQ(table_1v2h3, table1.vjoin(table2, 1, 1).hjoin(table3, 1, 1));
 }
@@ -101,14 +103,14 @@ TEST(ValueTableTest, vjoinColumnTest)
 TEST(ValueTableTest, hjoinColumnTest)
 {
     // 2列目を指定して table1 に table5 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_1h5_2{{"101", "1", "2"}};
-    const std::vector<std::string> schemas_1h5_2{"id", "attr1", "attr2"};
+    const std::vector<std::vector<std::string>> table_data_1h5_2{{"101", "1", "2", "101", "0"}};
+    const std::vector<std::string> schemas_1h5_2{"id", "attr1", "attr2", "id", "attr2"};
     const auto table_1h5_2 = qmpc::ComputationToDb::ValueTable(table_data_1h5_2, schemas_1h5_2);
     EXPECT_EQ(table_1h5_2, table1.hjoin(table5, 2, 2));
 
     // 3列目を指定して table1 に table5 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_1h5_3{{"102", "3", "4"}};
-    const std::vector<std::string> schemas_1h5_3{"id", "attr1", "attr2"};
+    const std::vector<std::vector<std::string>> table_data_1h5_3{{"102", "3", "4", "101", "4"}};
+    const std::vector<std::string> schemas_1h5_3{"id", "attr1", "attr2", "id", "attr1"};
     const auto table_1h5_3 = qmpc::ComputationToDb::ValueTable(table_data_1h5_3, schemas_1h5_3);
     EXPECT_EQ(table_1h5_3, table1.hjoin(table5, 3, 3));
 }

--- a/src/ComputationContainer/Test/IntegrationTest/ValueTableTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ValueTableTest.hpp
@@ -109,7 +109,7 @@ TEST(ValueTableTest, hjoinColumnTest)
     EXPECT_EQ(table_1h5_2, table1.hjoin(table5, 2, 2));
 
     // 3列目を指定して table1 に table5 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_1h5_3{{"102", "3", "4", "101", "4"}};
+    const std::vector<std::vector<std::string>> table_data_1h5_3{{"102", "3", "4", "102", "0"}};
     const std::vector<std::string> schemas_1h5_3{"id", "attr1", "attr2", "id", "attr1"};
     const auto table_1h5_3 = qmpc::ComputationToDb::ValueTable(table_data_1h5_3, schemas_1h5_3);
     EXPECT_EQ(table_1h5_3, table1.hjoin(table5, 3, 3));

--- a/src/ComputationContainer/Test/IntegrationTest/ValueTableTest.hpp
+++ b/src/ComputationContainer/Test/IntegrationTest/ValueTableTest.hpp
@@ -77,9 +77,10 @@ TEST(ValueTableTest, hvjoinTest)
 {
     // hjoin(table1,table2) と table3 を縦結合した場合
     const std::vector<std::vector<std::string>> table_data_1h2v3{
-        {"101", "1", "6"}, {"102", "9", "10"}, {"103", "12", "13"}};
-    const std::vector<std::string> schemas_1h2v3{"id", "attr1", "attr3"};
+        {"101", "1", "5", "6"}, {"102", "9", "9", "10"}, {"103", "12", "12", "13"}};
+    const std::vector<std::string> schemas_1h2v3{"id", "attr1", "attr1", "attr3"};
     const auto table_1h2v3 = qmpc::ComputationToDb::ValueTable(table_data_1h2v3, schemas_1h2v3);
+    auto t = table1.hjoin(table2, 1, 1).vjoin(table3, 1, 1);
     EXPECT_EQ(table_1h2v3, table1.hjoin(table2, 1, 1).vjoin(table3, 1, 1));
 }
 


### PR DESCRIPTION
# Summary
Fix column to be deleted

# Purpose
To make it more intuitive to use.

# Contents
- Update to not erase the left-most column
- Update to not delete duplicate Schema
```
hjoin(["s1", "id", "s2"], ["s2", "s3", "id"])
old: ["s2", "s3"]
new: ["s1", "s2", "s2", "s3"]
```

# Testing Methods Performed
- make test t=ComputationContainer p=medium
- make test t=LibClient p=medium
- CI