### PR TITLE
Update: change share netwoking to stream only

### DIFF
--- a/packages/server/computation_container/client/computation_to_computation_container/client.hpp
+++ b/packages/server/computation_container/client/computation_to_computation_container/client.hpp
@@ -168,15 +168,14 @@ public:
         google::protobuf::Empty response;
         shares = makeShares(values, share_ids, length, party_id);
         grpc::Status status;
-
         // リトライポリシーに従ってリクエストを送る
         auto retry_manager = RetryManager("CC", "exchangeShares");
+        grpc::ClientContext context;
+        std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
+            stub_->ExchangeShares(&context, &response)
+        );
         do
         {
-            grpc::ClientContext context;
-            std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
-                stub_->ExchangeShares(&context, &response)
-            );
             for (size_t i = 0; i < shares.size(); i++)
             {
                 if (!stream->Write(shares[i]))

--- a/packages/server/computation_container/share/networking.hpp
+++ b/packages/server/computation_container/share/networking.hpp
@@ -58,8 +58,11 @@ void send(const T &shares, const int &pt_id)
     }
     else if constexpr (is_share<T>::value)
     {
+        using SV = typename T::value_type;
         // pt_idで指定されたパーティにシェアの値を送信する
-        client->exchangeShare(shares.getVal(), shares.getId(), conf->party_id);
+        std::vector<SV> str_value = {shares.getVal()};
+        std::vector<qmpc::Share::AddressId> share_id = {shares.getId()};
+        client->exchangeShares(str_value, share_id, 1, conf->party_id);
     }
 }
 template <class SV>

--- a/packages/server/computation_container/test/benchmark/share_benchmark.hpp
+++ b/packages/server/computation_container/test/benchmark/share_benchmark.hpp
@@ -378,7 +378,7 @@ TEST(ShareBenchmark, BulkComparisonOperation)
     }
 }
 
-//一括open,reconsテスト
+// 一括open,reconsテスト
 TEST(ShareBenchmark, ReconsBulk)
 {
     constexpr int SIZE = 10000;
@@ -408,7 +408,7 @@ TEST(ShareBenchmark, ReconsBulk)
     measureExecTime(test_name_recons, 1, [&]() { auto u = recons(s); });
 }
 
-//一括加算のテスト
+// 一括加算のテスト
 TEST(ShareBenchmark, AddBulk)
 {
     constexpr int SIZE = 10000;
@@ -424,7 +424,7 @@ TEST(ShareBenchmark, AddBulk)
     measureExecTime(test_name, N, [&]() { auto ret = a + b; });
 }
 
-//一括減算のテスト
+// 一括減算のテスト
 TEST(ShareBenchmark, SubBulk)
 {
     constexpr int SIZE = 10000;
@@ -440,7 +440,7 @@ TEST(ShareBenchmark, SubBulk)
     measureExecTime(test_name, N, [&]() { auto ret = a - b; });
 }
 
-//一括乗算のテスト
+// 一括乗算のテスト
 TEST(ShareBenchmark, MulBulk)
 {
     constexpr int SIZE = 10000;
@@ -492,4 +492,27 @@ TEST(ShareBenchmark, Sqrt)
     b += FixedPoint(121);
 
     measureExecTime("Sqrt", 5, [&]() { auto b_sqrt = qmpc::Share::sqrt(b); });
+}
+
+TEST(ShareBench, unarySend)
+{
+    for (int i = 0; i < 1000; ++i)
+    {
+        Share a = Share(FixedPoint("2.0"));
+        open(a);
+        auto rec = recons(a);
+    }
+    measureExecTime(
+        "unaryMulti",
+        4,
+        [&]()
+        {
+            for (int i = 0; i < 1000; ++i)
+            {
+                Share a = Share(FixedPoint("2.0"));
+                open(a);
+                auto rec = recons(a);
+            }
+        }
+    );
 }


### PR DESCRIPTION
# Summary
change Share-network which are unary and streaming to stream only. 
# Purpose

# Contents

# Testing Methods Performed
streaming-network by one data is slower than unary network , but it is little bit.