### PR TITLE
Update Mono-Address Networking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ bazel-testlogs
 bazel-tools
 .bazel
 result
-
+proto/bazel-proto
 **/vendor
 
 **/db/**/data/*

--- a/packages/server/computation_container/client/computation_to_computation_container/client.hpp
+++ b/packages/server/computation_container/client/computation_to_computation_container/client.hpp
@@ -52,14 +52,12 @@ private:
         {
             // string型のバイト数の取得
             size_t value_size = sizeof(values[i]);
-            // ShareId,JobId,ThreadId,PartyIdの16byte
             if (size + value_size > 1000000)
             {
                 size = 0;
                 share_vec.push_back(s);
                 s = computationtocomputation::Shares{};
             }
-            // 一つのsharesにつきPartyIdは一つだけなので分割しない際はShareId,JobId,ThreadIdの12byte
             size = size + value_size;
             computationtocomputation::Shares_Share *multiple_shares = s.add_share_list();
             if constexpr (std::is_same_v<std::decay_t<T>, bool>)

--- a/packages/server/computation_container/client/computation_to_computation_container/client.hpp
+++ b/packages/server/computation_container/client/computation_to_computation_container/client.hpp
@@ -27,44 +27,6 @@ private:
     Client(const Url &endpoint) noexcept;
     Client &operator=(Client &&) noexcept = default;
     static std::shared_ptr<Client> getPtr(const Url &);
-    // 単一シェアを生成する場合
-    template <typename T>
-    computationtocomputation::Share makeShare(
-        T &&value, qmpc::Share::AddressId share_id, int party_id
-    ) const
-    {
-        computationtocomputation::Share s;
-        auto a = s.mutable_address_id();
-        a->set_share_id(share_id.getShareId());
-        a->set_job_id(share_id.getJobId());
-
-        if constexpr (std::is_same_v<std::decay_t<T>, bool>)
-        {
-            s.set_flag(value);
-        }
-        else if constexpr (std::is_same_v<std::decay_t<T>, int>)
-        {
-            s.set_num(value);
-        }
-        else if constexpr (std::is_same_v<std::decay_t<T>, long>)
-        {
-            s.set_num64(value);
-        }
-        else if constexpr (std::is_same_v<std::decay_t<T>, float>)
-        {
-            s.set_f(value);
-        }
-        else if constexpr (std::is_same_v<std::decay_t<T>, double>)
-        {
-            s.set_d(value);
-        }
-        else
-        {
-            s.set_byte(to_string(value));
-        }
-        s.set_party_id(party_id);
-        return s;
-    }
 
     // 複数シェアを生成する場合
     // 約1mbごとに分割して生成する

--- a/packages/server/computation_container/client/computation_to_computation_container/client.hpp
+++ b/packages/server/computation_container/client/computation_to_computation_container/client.hpp
@@ -168,15 +168,14 @@ public:
         google::protobuf::Empty response;
         shares = makeShares(values, share_ids, length, party_id);
         grpc::Status status;
-
         // リトライポリシーに従ってリクエストを送る
         auto retry_manager = RetryManager("CC", "exchangeShares");
+        grpc::ClientContext context;
+        std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
+            stub_->ExchangeShares(&context, &response)
+        );
         do
         {
-            grpc::ClientContext context;
-            std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
-                stub_->ExchangeShares(&context, &response)
-            );
             for (size_t i = 0; i < shares.size(); i++)
             {
                 if (!stream->Write(shares[i]))

--- a/packages/server/computation_container/server/computation_to_computation_container/server.cpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.cpp
@@ -151,7 +151,7 @@ std::string Server::getShare(int party_id, qmpc::Share::AddressId share_id)
         qmpc::Log::throw_with_trace(std::runtime_error("getShare is timeout"));
     }
     auto share = shares_vec[key];
-    shares.erase(key);
+    shares_vec.erase(key);
     return share[0];
 }
 

--- a/packages/server/computation_container/server/computation_to_computation_container/server.hpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.hpp
@@ -77,6 +77,7 @@ private:
     // 受け取ったシェアを保存する変数
     // party_id, share_idをキーとして保存
     std::map<address, std::string> shares;
+    std::map<address, std::vector<std::string>> shares_vec;
 };
 
 }  // namespace qmpc::ComputationToComputation

--- a/packages/server/computation_container/share/networking.hpp
+++ b/packages/server/computation_container/share/networking.hpp
@@ -58,8 +58,11 @@ void send(const T &shares, const int &pt_id)
     }
     else if constexpr (is_share<T>::value)
     {
+        using SV = typename T::value_type;
         // pt_idで指定されたパーティにシェアの値を送信する
-        client->exchangeShare(shares.getVal(), shares.getId(), conf->party_id);
+        std::vector<SV> str_value = {shares.getVal()};
+        std::vector<qmpc::Share::AddressId> share_id = {shares.getId()};
+        client->exchangeShares(str_value, share_id, 1, conf->party_id);
     }
 }
 template <class SV>

--- a/packages/server/computation_container/test/benchmark/share_benchmark.hpp
+++ b/packages/server/computation_container/test/benchmark/share_benchmark.hpp
@@ -516,3 +516,42 @@ TEST(ShareBench, unarySend)
         }
     );
 }
+
+TEST(ShareBench, vecOpne)
+{
+    int N = 20000;
+    {
+        std::vector<Share> a;
+
+        for (int i = 0; i < N; ++i)
+        {
+            a.emplace_back(FixedPoint("3"));
+        }
+        open(a);
+        auto a_rec = recons(a);
+    }
+
+    measureExecTime(
+        "vectorMul",
+        4,
+        [&]()
+        {
+            std::vector<FixedPoint> expect(N, FixedPoint(108));
+            std::vector<Share> a;
+
+            std::vector<Share> b;
+            for (int i = 0; i < N; ++i)
+            {
+                a.emplace_back(FixedPoint("3"));  // 9
+                b.emplace_back(FixedPoint("4"));  // 12
+            }
+            auto c = a * b;  // 108
+            open(c);
+            auto c_rec = recons(c);
+            for (int i = 0; i < N; ++i)
+            {
+                EXPECT_EQ(expect[i], c_rec[i]);
+            }
+        }
+    );
+}

--- a/packages/server/computation_container/test/benchmark/share_benchmark.hpp
+++ b/packages/server/computation_container/test/benchmark/share_benchmark.hpp
@@ -378,7 +378,7 @@ TEST(ShareBenchmark, BulkComparisonOperation)
     }
 }
 
-//一括open,reconsテスト
+// 一括open,reconsテスト
 TEST(ShareBenchmark, ReconsBulk)
 {
     constexpr int SIZE = 10000;
@@ -408,7 +408,7 @@ TEST(ShareBenchmark, ReconsBulk)
     measureExecTime(test_name_recons, 1, [&]() { auto u = recons(s); });
 }
 
-//一括加算のテスト
+// 一括加算のテスト
 TEST(ShareBenchmark, AddBulk)
 {
     constexpr int SIZE = 10000;
@@ -424,7 +424,7 @@ TEST(ShareBenchmark, AddBulk)
     measureExecTime(test_name, N, [&]() { auto ret = a + b; });
 }
 
-//一括減算のテスト
+// 一括減算のテスト
 TEST(ShareBenchmark, SubBulk)
 {
     constexpr int SIZE = 10000;
@@ -440,7 +440,7 @@ TEST(ShareBenchmark, SubBulk)
     measureExecTime(test_name, N, [&]() { auto ret = a - b; });
 }
 
-//一括乗算のテスト
+// 一括乗算のテスト
 TEST(ShareBenchmark, MulBulk)
 {
     constexpr int SIZE = 10000;
@@ -492,4 +492,27 @@ TEST(ShareBenchmark, Sqrt)
     b += FixedPoint(121);
 
     measureExecTime("Sqrt", 5, [&]() { auto b_sqrt = qmpc::Share::sqrt(b); });
+}
+
+TEST(ShareBench, unarySend)
+{
+    for (int i = 0; i < 1000; ++i)
+    {
+        Share a = Share(FixedPoint("2.0"));
+        open(a);
+        auto rec = recons(a);
+    }
+    measureExecTime(
+        "unaryMulti",
+        4,
+        [&]()
+        {
+            for (int i = 0; i < 1000; ++i)
+            {
+                Share a = Share(FixedPoint("2.0"));
+                open(a);
+                auto rec = recons(a);
+            }
+        }
+    );
 }

--- a/proto/bazel-proto
+++ b/proto/bazel-proto
@@ -1,0 +1,1 @@
+/root/.cache/bazel/_bazel_root/8f71f31e67e8d393e243d4f02ac64710/execroot/__main__

--- a/proto/bazel-proto
+++ b/proto/bazel-proto
@@ -1,1 +1,0 @@
-/root/.cache/bazel/_bazel_root/8f71f31e67e8d393e243d4f02ac64710/execroot/__main__

--- a/proto/computation_to_computation_container/computation_to_computation.proto
+++ b/proto/computation_to_computation_container/computation_to_computation.proto
@@ -22,6 +22,7 @@ message Address{
     int32 share_id = 1;
     uint32 job_id = 2;
     int32 thread_id = 3;
+    int32 party_id = 4; // the id of party(0, 1, 2)
 }
 /**
  * the message of share
@@ -52,8 +53,7 @@ message Shares {
             double d = 8;
             bool flag = 9;
         }
-        Address address_id = 2;
     }
     repeated Share share_list = 1;
-    int32 party_id = 2;
+    Address address_id = 2;
 }


### PR DESCRIPTION
# Summary

This pul request changed the following

- Only the first Address in Share Array is sent.
- Only the first Address in input AddressArray is refference.

After the change,Send ShareArray speed is faster than old by about 3~ 30percent.

This pull request is related to Mono-Address RFC.

# Purpose

# Contents

# Testing Methods Performed
