### PR TITLE
Update ValueTable to have only data_id

### DIFF
--- a/packages/server/computation_container/client/computation_to_db/BUILD
+++ b/packages/server/computation_container/client/computation_to_db/BUILD
@@ -31,7 +31,7 @@ cc_library(
         "//share:share",
         "//share:compare",
         "//job:progressManager",
-        "//logging:log"
+        "//logging:log",
         "//client/computation_to_db:client",
     ],
     visibility = ["//visibility:public"],

--- a/packages/server/computation_container/client/computation_to_db/BUILD
+++ b/packages/server/computation_container/client/computation_to_db/BUILD
@@ -8,9 +8,8 @@ cc_library(
     ],
     deps = [
         "@nlohmann_json//:json",
-        "//client/computation_to_db:valuetable",
-        "@proto//manage_to_computation_container:manage_to_computation_cc_grpc",
         "@proto//common_types:common_types_cc_proto",
+        "//logging:log",
     ],
     linkopts = [
         "-lstdc++fs"
@@ -28,10 +27,12 @@ cc_library(
     ],
     deps = [
         "@nlohmann_json//:json",
+        "@proto//manage_to_computation_container:manage_to_computation_cc_grpc",
         "//share:share",
         "//share:compare",
         "//job:progressManager",
         "//logging:log"
+        "//client/computation_to_db:client",
     ],
     visibility = ["//visibility:public"],
 )

--- a/packages/server/computation_container/client/computation_to_db/client.cpp
+++ b/packages/server/computation_container/client/computation_to_db/client.cpp
@@ -114,31 +114,4 @@ void Client::saveErrorInfo(const std::string &job_uuid, const pb_common_types::J
 
     ofs << dst;
 }
-
-// tableデータを結合して取り出す
-ValueTable Client::readTable(const managetocomputation::JoinOrder &table)
-{
-    // requestからデータ読み取り
-    auto size = table.join().size();
-    std::vector<int> join;
-    join.reserve(size);
-    for (const auto &j : table.join())
-    {
-        join.emplace_back(j);
-    }
-    std::vector<int> index;
-    index.reserve(size);
-    for (const auto &j : table.index())
-    {
-        index.emplace_back(j);
-    }
-    std::vector<ValueTable> tables;
-    tables.reserve(size + 1);
-    for (const auto &data_id : table.dataids())
-    {
-        tables.emplace_back(readTable(data_id), readSchema(data_id));
-    }
-    return parseRead(tables, join, index);
-}
-
 }  // namespace qmpc::ComputationToDb

--- a/packages/server/computation_container/client/computation_to_db/client.cpp
+++ b/packages/server/computation_container/client/computation_to_db/client.cpp
@@ -68,11 +68,11 @@ std::vector<std::string> Client::readSchema(const std::string &data_id) const
 
 // Tableの保存
 std::string Client::writeTable(
-    std::vector<std::vector<std::string>> &table, const std::vector<std::string> &schema
+    const std::string &data_id,
+    std::vector<std::vector<std::string>> &table,
+    const std::vector<std::string> &schema
 ) const
 {
-    // TODO: data_idを生成する
-    const std::string data_id = "tmp";
     // TODO: piece_idを引数に受け取ってpieceごとに保存できるようにする
     const int piece_id = 0;
     nlohmann::json data_json = {

--- a/packages/server/computation_container/client/computation_to_db/client.cpp
+++ b/packages/server/computation_container/client/computation_to_db/client.cpp
@@ -66,6 +66,27 @@ std::vector<std::string> Client::readSchema(const std::string &data_id) const
     return schemas;
 }
 
+// Tableの保存
+std::string Client::writeTable(
+    std::vector<std::vector<std::string>> &table, const std::vector<std::string> &schema
+) const
+{
+    // TODO: data_idを生成する
+    const std::string data_id = "tmp";
+    // TODO: piece_idを引数に受け取ってpieceごとに保存できるようにする
+    const int piece_id = 0;
+    nlohmann::json data_json = {
+        {"value", table}, {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
+    const std::string data = data_json.dump();
+
+    auto data_path = shareDbPath + data_id;
+    fs::create_directories(data_path);
+    std::ofstream ofs(data_path + "/" + std::to_string(piece_id));
+    ofs << data;
+    ofs.close();
+    return data_id;
+};
+
 // Job を DB に新規登録する
 void Client::registerJob(const std::string &job_uuid, const int &status) const
 {

--- a/packages/server/computation_container/client/computation_to_db/client.hpp
+++ b/packages/server/computation_container/client/computation_to_db/client.hpp
@@ -26,6 +26,10 @@ public:
     std::vector<std::vector<std::string>> readTable(const std::string &) const;
     std::vector<std::string> readSchema(const std::string &) const;
 
+    // Tableの保存
+    std::string
+    writeTable(std::vector<std::vector<std::string>> &, const std::vector<std::string> &) const;
+
     // Job を DB に新規登録する
     void registerJob(const std::string &job_uuid, const int &status) const;
 

--- a/packages/server/computation_container/client/computation_to_db/client.hpp
+++ b/packages/server/computation_container/client/computation_to_db/client.hpp
@@ -7,7 +7,6 @@
 #include <utility>
 #include <vector>
 
-#include "Logging/Logger.hpp"
 #include "external/proto/common_types/common_types.pb.h"
 #include "logging/logger.hpp"
 #include "nlohmann/json.hpp"

--- a/packages/server/computation_container/client/computation_to_db/client.hpp
+++ b/packages/server/computation_container/client/computation_to_db/client.hpp
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -23,7 +24,7 @@ public:
     static std::shared_ptr<Client> getInstance();
 
     // Tableの取り出し
-    std::vector<std::vector<std::string>> readTable(const std::string &) const;
+    std::optional<std::vector<std::vector<std::string>>> readTable(const std::string &, int) const;
     std::vector<std::string> readSchema(const std::string &) const;
 
     // Tableの保存

--- a/packages/server/computation_container/client/computation_to_db/client.hpp
+++ b/packages/server/computation_container/client/computation_to_db/client.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
+#include <fstream>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "Logging/Logger.hpp"
 #include "external/proto/common_types/common_types.pb.h"
-#include "external/proto/manage_to_computation_container/manage_to_computation.grpc.pb.h"
 #include "logging/logger.hpp"
 #include "nlohmann/json.hpp"
-#include "value_table.hpp"
 
 namespace qmpc::ComputationToDb
 {
@@ -35,9 +35,6 @@ public:
     // Job 実行中に発生したエラーに関する情報を保存する
     void saveErrorInfo(const std::string &job_uuid, const pb_common_types::JobErrorInfo &info)
         const;
-
-    // tableデータを結合して取り出す
-    ValueTable readTable(const managetocomputation::JoinOrder &table);
 
     // resultの保存
     template <class T>

--- a/packages/server/computation_container/client/computation_to_db/client.hpp
+++ b/packages/server/computation_container/client/computation_to_db/client.hpp
@@ -22,8 +22,9 @@ public:
     Client();
     static std::shared_ptr<Client> getInstance();
 
-    // shareの取り出し
-    ValueTable readShare(const std::string &) const;
+    // Tableの取り出し
+    std::vector<std::vector<std::string>> readTable(const std::string &) const;
+    std::vector<std::string> readSchema(const std::string &) const;
 
     // Job を DB に新規登録する
     void registerJob(const std::string &job_uuid, const int &status) const;

--- a/packages/server/computation_container/client/computation_to_db/client.hpp
+++ b/packages/server/computation_container/client/computation_to_db/client.hpp
@@ -28,7 +28,8 @@ public:
 
     // Tableの保存
     std::string
-    writeTable(std::vector<std::vector<std::string>> &, const std::vector<std::string> &) const;
+    writeTable(const std::string &, std::vector<std::vector<std::string>> &, const std::vector<std::string> &)
+        const;
 
     // Job を DB に新規登録する
     void registerJob(const std::string &job_uuid, const int &status) const;

--- a/packages/server/computation_container/client/computation_to_db/value_table.cpp
+++ b/packages/server/computation_container/client/computation_to_db/value_table.cpp
@@ -38,7 +38,22 @@ std::string ValueTable::joinDataId(const ValueTable &vt) const
 std::vector<std::vector<std::string>> ValueTable::getTable() const
 {
     auto db = Client::getInstance();
-    return db->readTable(data_id);
+    int piece_id = 0;
+    std::vector<std::vector<std::string>> read_table;
+    while (true)
+    {
+        auto piece = db->readTable(data_id, piece_id);
+        if (!piece)
+        {
+            break;
+        }
+        for (const auto &row : piece.value())
+        {
+            read_table.emplace_back(row);
+        }
+        ++piece_id;
+    }
+    return read_table;
 }
 
 std::vector<std::string> ValueTable::getSchemas() const

--- a/packages/server/computation_container/client/computation_to_db/value_table.cpp
+++ b/packages/server/computation_container/client/computation_to_db/value_table.cpp
@@ -29,6 +29,11 @@ std::vector<::Share> ValueTable::getColumn(int idx) const
     }
     return column;
 }
+std::string ValueTable::joinDataId(const ValueTable &vt) const
+{
+    // TODO: sha256にする
+    return data_id + vt.data_id;
+}
 
 std::vector<std::vector<std::string>> ValueTable::getTable() const
 {
@@ -339,10 +344,10 @@ ValueTable ValueTable::vjoin(const ValueTable &join_table, int idx, int idx_tgt)
         }
         new_table.emplace_back(new_row);
     }
-    // TODO: 保存してdata_idを取得する
-    const std::string new_data_id = "tmp";
+    const std::string new_data_id = joinDataId(join_table);
+    auto db = Client::getInstance();
+    db->writeTable(new_data_id, new_table, new_schemas);
     return ValueTable(new_data_id);
-    // return ValueTable(new_table, new_schemas);
 }
 
 ValueTable ValueTable::hjoin(const ValueTable &join_table, int idx, int idx_tgt) const
@@ -404,10 +409,10 @@ ValueTable ValueTable::hjoin(const ValueTable &join_table, int idx, int idx_tgt)
         ++it_h;
         ++it_join_h;
     }
-    // TODO: 保存してdata_idを取得する
-    const std::string new_data_id = "tmp";
+    const std::string new_data_id = joinDataId(join_table);
+    auto db = Client::getInstance();
+    db->writeTable(new_data_id, new_table, new_schemas);
     return ValueTable(new_data_id);
-    // return ValueTable(new_table, new_schemas);
 }
 
 ValueTable ValueTable::hjoinShare(const ValueTable &join_table, int idx, int idx_tgt) const
@@ -461,10 +466,10 @@ ValueTable ValueTable::hjoinShare(const ValueTable &join_table, int idx, int idx
         }
         new_table.emplace_back(new_row);
     }
-    // TODO: 保存してdata_idを取得する
-    const std::string new_data_id = "tmp";
+    const std::string new_data_id = joinDataId(join_table);
+    auto db = Client::getInstance();
+    db->writeTable(new_data_id, new_table, new_schemas);
     return ValueTable(new_data_id);
-    // return ValueTable(new_table, new_schemas);
 }
 
 ValueTable parseRead(

--- a/packages/server/computation_container/client/computation_to_db/value_table.hpp
+++ b/packages/server/computation_container/client/computation_to_db/value_table.hpp
@@ -1,19 +1,21 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "external/proto/manage_to_computation_container/manage_to_computation.grpc.pb.h"
-#include "share/share.hpp"
 
 namespace qmpc::ComputationToDb
 {
 class ValueTable
 {
-    using Share = ::Share;
     const std::string data_id;
 
-    std::vector<Share> getColumn(int) const;
+    std::vector<std::vector<std::string>>
+    getSubTable(const std::optional<std::vector<int>> &, const std::optional<std::vector<int>> &)
+        const;
+    std::vector<std::string> getColumn(int) const;
     std::string joinDataId(const ValueTable &vt) const;
 
 public:

--- a/packages/server/computation_container/client/computation_to_db/value_table.hpp
+++ b/packages/server/computation_container/client/computation_to_db/value_table.hpp
@@ -16,11 +16,12 @@ class ValueTable
     getSubTable(const std::optional<std::vector<int>> &, const std::optional<std::vector<int>> &)
         const;
     std::vector<std::string> getColumn(int) const;
-    std::string joinDataId(const ValueTable &vt) const;
+    std::string joinDataId(const ValueTable &, int) const;
 
 public:
     ValueTable(const std::string &);
 
+    std::string getDataId() const;
     std::vector<std::vector<std::string>> getTable() const;
     std::vector<std::string> getSchemas() const;
     ValueTable vjoin(const ValueTable &, int, int) const;

--- a/packages/server/computation_container/client/computation_to_db/value_table.hpp
+++ b/packages/server/computation_container/client/computation_to_db/value_table.hpp
@@ -14,6 +14,7 @@ class ValueTable
     const std::string data_id;
 
     std::vector<Share> getColumn(int) const;
+    std::string joinDataId(const ValueTable &vt) const;
 
 public:
     ValueTable(const std::string &);

--- a/packages/server/computation_container/client/computation_to_db/value_table.hpp
+++ b/packages/server/computation_container/client/computation_to_db/value_table.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "external/proto/manage_to_computation_container/manage_to_computation.grpc.pb.h"
 #include "share/share.hpp"
 
 namespace qmpc::ComputationToDb
@@ -10,14 +11,12 @@ namespace qmpc::ComputationToDb
 class ValueTable
 {
     using Share = ::Share;
-    const std::vector<std::vector<std::string>> table;
-    const std::vector<std::string> schemas;
+    const std::string data_id;
 
     std::vector<Share> getColumn(int) const;
 
 public:
-    ValueTable(const std::vector<std::vector<std::string>> &, const std::vector<std::string> &);
-    bool operator==(const ValueTable &) const;
+    ValueTable(const std::string &);
 
     std::vector<std::vector<std::string>> getTable() const;
     std::vector<std::string> getSchemas() const;
@@ -28,4 +27,5 @@ public:
 
 ValueTable
 parseRead(const std::vector<ValueTable> &, const std::vector<int> &, const std::vector<int> &);
+ValueTable readTable(const managetocomputation::JoinOrder &);
 }  // namespace qmpc::ComputationToDb

--- a/packages/server/computation_container/job/BUILD
+++ b/packages/server/computation_container/job/BUILD
@@ -8,6 +8,7 @@ cc_library(
         "//computation:computation",
         "//share:share",
         "//client/computation_to_db:client",
+        "//client/computation_to_db:valuetable",
         "@proto//manage_to_computation_container:manage_to_computation_cc_grpc",
         "//logging:log"
     ],

--- a/packages/server/computation_container/job/job_base.hpp
+++ b/packages/server/computation_container/job/job_base.hpp
@@ -46,7 +46,7 @@ class JobBase : public Interface
         statusManager.nextStatus();
 
         // table結合
-        auto joinTable = db_client->readTable(request.table());
+        auto joinTable = qmpc::ComputationToDb::readTable(request.table());
         auto values = joinTable.getTable();
         if (values.empty())
         {

--- a/packages/server/computation_container/test/integration_test/value_table_test.hpp
+++ b/packages/server/computation_container/test/integration_test/value_table_test.hpp
@@ -4,164 +4,167 @@
 #include "client/computation_to_db/value_table.hpp"
 #include "gtest/gtest.h"
 
+// TODO: ValueTableのコンストラクタが変更されたので全部修正する
 /****************** Test用の各データ ******************/
-const std::vector<std::vector<std::string>> table_data1{{"101", "1", "2"}, {"102", "3", "4"}};
-const std::vector<std::string> schemas1{"id", "attr1", "attr2"};
+// const std::vector<std::vector<std::string>> table_data1{{"101", "1", "2"}, {"102", "3", "4"}};
+// const std::vector<std::string> schemas1{"id", "attr1", "attr2"};
 
-const std::vector<std::vector<std::string>> table_data2{{"101", "5", "6"}, {"103", "7", "8"}};
-const std::vector<std::string> schemas2{"id", "attr1", "attr3"};
+// const std::vector<std::vector<std::string>> table_data2{{"101", "5", "6"}, {"103", "7", "8"}};
+// const std::vector<std::string> schemas2{"id", "attr1", "attr3"};
 
-const std::vector<std::vector<std::string>> table_data3{
-    {"102", "9", "10", "11"}, {"103", "12", "13", "14"}};
-const std::vector<std::string> schemas3{"id", "attr1", "attr3", "attr4"};
+// const std::vector<std::vector<std::string>> table_data3{
+//     {"102", "9", "10", "11"}, {"103", "12", "13", "14"}};
+// const std::vector<std::string> schemas3{"id", "attr1", "attr3", "attr4"};
 
-const std::vector<std::vector<std::string>> table_data4{
-    {"103", "15", "16", "17"}, {"104", "18", "19", "20"}, {"105", "21", "22", "23"}};
-const std::vector<std::string> schemas4{"id", "attr3", "attr4", "attr5"};
+// const std::vector<std::vector<std::string>> table_data4{
+//     {"103", "15", "16", "17"}, {"104", "18", "19", "20"}, {"105", "21", "22", "23"}};
+// const std::vector<std::string> schemas4{"id", "attr3", "attr4", "attr5"};
 
-const std::vector<std::vector<std::string>> table_data5{{"101", "1", "0"}, {"102", "0", "4"}};
-const std::vector<std::string> schemas5{"id", "attr1", "attr2"};
+// const std::vector<std::vector<std::string>> table_data5{{"101", "1", "0"}, {"102", "0", "4"}};
+// const std::vector<std::string> schemas5{"id", "attr1", "attr2"};
 
-const auto table1 = qmpc::ComputationToDb::ValueTable(table_data1, schemas1);
-const auto table2 = qmpc::ComputationToDb::ValueTable(table_data2, schemas2);
-const auto table3 = qmpc::ComputationToDb::ValueTable(table_data3, schemas3);
-const auto table4 = qmpc::ComputationToDb::ValueTable(table_data4, schemas4);
-const auto table5 = qmpc::ComputationToDb::ValueTable(table_data5, schemas5);
+// const auto table1 = qmpc::ComputationToDb::ValueTable(table_data1, schemas1);
+// const auto table2 = qmpc::ComputationToDb::ValueTable(table_data2, schemas2);
+// const auto table3 = qmpc::ComputationToDb::ValueTable(table_data3, schemas3);
+// const auto table4 = qmpc::ComputationToDb::ValueTable(table_data4, schemas4);
+// const auto table5 = qmpc::ComputationToDb::ValueTable(table_data5, schemas5);
 
-/********************** Test **********************/
-TEST(ValueTableTest, vjoinTest)
-{
-    // table1 に table2 を縦結合した場合
-    const std::vector<std::vector<std::string>> table_data_1v2{
-        {"101", "1"}, {"102", "3"}, {"103", "7"}};
-    const std::vector<std::string> schemas_1v2{"id", "attr1"};
-    const auto table_1v2 = qmpc::ComputationToDb::ValueTable(table_data_1v2, schemas_1v2);
-    EXPECT_EQ(table_1v2, table1.vjoin(table2, 1, 1));
+// /********************** Test **********************/
+// TEST(ValueTableTest, vjoinTest)
+// {
+//     // table1 に table2 を縦結合した場合
+//     const std::vector<std::vector<std::string>> table_data_1v2{
+//         {"101", "1"}, {"102", "3"}, {"103", "7"}};
+//     const std::vector<std::string> schemas_1v2{"id", "attr1"};
+//     const auto table_1v2 = qmpc::ComputationToDb::ValueTable(table_data_1v2, schemas_1v2);
+//     EXPECT_EQ(table_1v2, table1.vjoin(table2, 1, 1));
 
-    // table3 に table4 を縦結合した場合
-    const std::vector<std::vector<std::string>> table_data_3v4{
-        {"102", "10", "11"}, {"103", "13", "14"}, {"104", "18", "19"}, {"105", "21", "22"}};
-    const std::vector<std::string> schemas_3v4{"id", "attr3", "attr4"};
-    const auto table_3v4 = qmpc::ComputationToDb::ValueTable(table_data_3v4, schemas_3v4);
-    EXPECT_EQ(table_3v4, table3.vjoin(table4, 1, 1));
-}
+//     // table3 に table4 を縦結合した場合
+//     const std::vector<std::vector<std::string>> table_data_3v4{
+//         {"102", "10", "11"}, {"103", "13", "14"}, {"104", "18", "19"}, {"105", "21", "22"}};
+//     const std::vector<std::string> schemas_3v4{"id", "attr3", "attr4"};
+//     const auto table_3v4 = qmpc::ComputationToDb::ValueTable(table_data_3v4, schemas_3v4);
+//     EXPECT_EQ(table_3v4, table3.vjoin(table4, 1, 1));
+// }
 
-TEST(ValueTableTest, hjoinTest)
-{
-    // table1 に table2 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_1h2{{"101", "1", "2", "5", "6"}};
-    const std::vector<std::string> schemas_1h2{"id", "attr1", "attr2", "attr1", "attr3"};
-    const auto table_1h2 = qmpc::ComputationToDb::ValueTable(table_data_1h2, schemas_1h2);
-    EXPECT_EQ(table_1h2, table1.hjoin(table2, 1, 1));
+// TEST(ValueTableTest, hjoinTest)
+// {
+//     // table1 に table2 を横結合した場合
+//     const std::vector<std::vector<std::string>> table_data_1h2{{"101", "1", "2", "5", "6"}};
+//     const std::vector<std::string> schemas_1h2{"id", "attr1", "attr2", "attr1", "attr3"};
+//     const auto table_1h2 = qmpc::ComputationToDb::ValueTable(table_data_1h2, schemas_1h2);
+//     EXPECT_EQ(table_1h2, table1.hjoin(table2, 1, 1));
 
-    // table3 に table4 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_3h4{
-        {"103", "12", "13", "14", "15", "16", "17"}};
-    const std::vector<std::string> schemas_3h4{
-        "id", "attr1", "attr3", "attr4", "attr3", "attr4", "attr5"};
-    const auto table_3h4 = qmpc::ComputationToDb::ValueTable(table_data_3h4, schemas_3h4);
-    EXPECT_EQ(table_3h4, table3.hjoin(table4, 1, 1));
-}
+//     // table3 に table4 を横結合した場合
+//     const std::vector<std::vector<std::string>> table_data_3h4{
+//         {"103", "12", "13", "14", "15", "16", "17"}};
+//     const std::vector<std::string> schemas_3h4{
+//         "id", "attr1", "attr3", "attr4", "attr3", "attr4", "attr5"};
+//     const auto table_3h4 = qmpc::ComputationToDb::ValueTable(table_data_3h4, schemas_3h4);
+//     EXPECT_EQ(table_3h4, table3.hjoin(table4, 1, 1));
+// }
 
-TEST(ValueTableTest, vhjoinTest)
-{
-    // vjoin(table1,table2) と table3 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_1v2h3{
-        {"102", "3", "9", "10", "11"}, {"103", "7", "12", "13", "14"}};
-    const std::vector<std::string> schemas_1v2h3{"id", "attr1", "attr1", "attr3", "attr4"};
-    const auto table_1v2h3 = qmpc::ComputationToDb::ValueTable(table_data_1v2h3, schemas_1v2h3);
-    EXPECT_EQ(table_1v2h3, table1.vjoin(table2, 1, 1).hjoin(table3, 1, 1));
-}
+// TEST(ValueTableTest, vhjoinTest)
+// {
+//     // vjoin(table1,table2) と table3 を横結合した場合
+//     const std::vector<std::vector<std::string>> table_data_1v2h3{
+//         {"102", "3", "9", "10", "11"}, {"103", "7", "12", "13", "14"}};
+//     const std::vector<std::string> schemas_1v2h3{"id", "attr1", "attr1", "attr3", "attr4"};
+//     const auto table_1v2h3 = qmpc::ComputationToDb::ValueTable(table_data_1v2h3, schemas_1v2h3);
+//     EXPECT_EQ(table_1v2h3, table1.vjoin(table2, 1, 1).hjoin(table3, 1, 1));
+// }
 
-TEST(ValueTableTest, hvjoinTest)
-{
-    // hjoin(table1,table2) と table3 を縦結合した場合
-    const std::vector<std::vector<std::string>> table_data_1h2v3{
-        {"101", "1", "5", "6"}, {"102", "9", "9", "10"}, {"103", "12", "12", "13"}};
-    const std::vector<std::string> schemas_1h2v3{"id", "attr1", "attr1", "attr3"};
-    const auto table_1h2v3 = qmpc::ComputationToDb::ValueTable(table_data_1h2v3, schemas_1h2v3);
-    auto t = table1.hjoin(table2, 1, 1).vjoin(table3, 1, 1);
-    EXPECT_EQ(table_1h2v3, table1.hjoin(table2, 1, 1).vjoin(table3, 1, 1));
-}
+// TEST(ValueTableTest, hvjoinTest)
+// {
+//     // hjoin(table1,table2) と table3 を縦結合した場合
+//     const std::vector<std::vector<std::string>> table_data_1h2v3{
+//         {"101", "1", "5", "6"}, {"102", "9", "9", "10"}, {"103", "12", "12", "13"}};
+//     const std::vector<std::string> schemas_1h2v3{"id", "attr1", "attr1", "attr3"};
+//     const auto table_1h2v3 = qmpc::ComputationToDb::ValueTable(table_data_1h2v3, schemas_1h2v3);
+//     auto t = table1.hjoin(table2, 1, 1).vjoin(table3, 1, 1);
+//     EXPECT_EQ(table_1h2v3, table1.hjoin(table2, 1, 1).vjoin(table3, 1, 1));
+// }
 
-TEST(ValueTableTest, vjoinColumnTest)
-{
-    // 2列目を指定して table1 に table5 を縦結合した場合
-    const std::vector<std::vector<std::string>> table_data_1v5_2{
-        {"101", "1", "2"}, {"102", "3", "4"}, {"102", "0", "4"}};
-    const std::vector<std::string> schemas_1v5_2{"id", "attr1", "attr2"};
-    const auto table_1v5_2 = qmpc::ComputationToDb::ValueTable(table_data_1v5_2, schemas_1v5_2);
-    EXPECT_EQ(table_1v5_2, table1.vjoin(table5, 2, 2));
+// TEST(ValueTableTest, vjoinColumnTest)
+// {
+//     // 2列目を指定して table1 に table5 を縦結合した場合
+//     const std::vector<std::vector<std::string>> table_data_1v5_2{
+//         {"101", "1", "2"}, {"102", "3", "4"}, {"102", "0", "4"}};
+//     const std::vector<std::string> schemas_1v5_2{"id", "attr1", "attr2"};
+//     const auto table_1v5_2 = qmpc::ComputationToDb::ValueTable(table_data_1v5_2, schemas_1v5_2);
+//     EXPECT_EQ(table_1v5_2, table1.vjoin(table5, 2, 2));
 
-    // 3列目を指定して table1 に table5 を縦結合した場合
-    const std::vector<std::vector<std::string>> table_data_1v5_3{
-        {"101", "1", "2"}, {"102", "3", "4"}, {"101", "1", "0"}};
-    const std::vector<std::string> schemas_1v5_3{"id", "attr1", "attr2"};
-    const auto table_1v5_3 = qmpc::ComputationToDb::ValueTable(table_data_1v5_3, schemas_1v5_3);
-    EXPECT_EQ(table_1v5_3, table1.vjoin(table5, 3, 3));
-}
+//     // 3列目を指定して table1 に table5 を縦結合した場合
+//     const std::vector<std::vector<std::string>> table_data_1v5_3{
+//         {"101", "1", "2"}, {"102", "3", "4"}, {"101", "1", "0"}};
+//     const std::vector<std::string> schemas_1v5_3{"id", "attr1", "attr2"};
+//     const auto table_1v5_3 = qmpc::ComputationToDb::ValueTable(table_data_1v5_3, schemas_1v5_3);
+//     EXPECT_EQ(table_1v5_3, table1.vjoin(table5, 3, 3));
+// }
 
-TEST(ValueTableTest, hjoinColumnTest)
-{
-    // 2列目を指定して table1 に table5 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_1h5_2{{"101", "1", "2", "101", "0"}};
-    const std::vector<std::string> schemas_1h5_2{"id", "attr1", "attr2", "id", "attr2"};
-    const auto table_1h5_2 = qmpc::ComputationToDb::ValueTable(table_data_1h5_2, schemas_1h5_2);
-    EXPECT_EQ(table_1h5_2, table1.hjoin(table5, 2, 2));
+// TEST(ValueTableTest, hjoinColumnTest)
+// {
+//     // 2列目を指定して table1 に table5 を横結合した場合
+//     const std::vector<std::vector<std::string>> table_data_1h5_2{{"101", "1", "2", "101", "0"}};
+//     const std::vector<std::string> schemas_1h5_2{"id", "attr1", "attr2", "id", "attr2"};
+//     const auto table_1h5_2 = qmpc::ComputationToDb::ValueTable(table_data_1h5_2, schemas_1h5_2);
+//     EXPECT_EQ(table_1h5_2, table1.hjoin(table5, 2, 2));
 
-    // 3列目を指定して table1 に table5 を横結合した場合
-    const std::vector<std::vector<std::string>> table_data_1h5_3{{"102", "3", "4", "102", "0"}};
-    const std::vector<std::string> schemas_1h5_3{"id", "attr1", "attr2", "id", "attr1"};
-    const auto table_1h5_3 = qmpc::ComputationToDb::ValueTable(table_data_1h5_3, schemas_1h5_3);
-    EXPECT_EQ(table_1h5_3, table1.hjoin(table5, 3, 3));
-}
+//     // 3列目を指定して table1 に table5 を横結合した場合
+//     const std::vector<std::vector<std::string>> table_data_1h5_3{{"102", "3", "4", "102", "0"}};
+//     const std::vector<std::string> schemas_1h5_3{"id", "attr1", "attr2", "id", "attr1"};
+//     const auto table_1h5_3 = qmpc::ComputationToDb::ValueTable(table_data_1h5_3, schemas_1h5_3);
+//     EXPECT_EQ(table_1h5_3, table1.hjoin(table5, 3, 3));
+// }
 
-TEST(ValueTableTest, hjoinShareTest)
-{
-    // table1 に table2 を横結合した場合
-    EXPECT_EQ(table1.hjoinShare(table2, 1, 1), table1.hjoin(table2, 1, 1));
+// TEST(ValueTableTest, hjoinShareTest)
+// {
+//     // table1 に table2 を横結合した場合
+//     EXPECT_EQ(table1.hjoinShare(table2, 1, 1), table1.hjoin(table2, 1, 1));
 
-    // table3 に table4 を横結合した場合
-    EXPECT_EQ(table3.hjoinShare(table4, 1, 1), table3.hjoin(table4, 1, 1));
-}
+//     // table3 に table4 を横結合した場合
+//     EXPECT_EQ(table3.hjoinShare(table4, 1, 1), table3.hjoin(table4, 1, 1));
+// }
 
-TEST(ValueTableTest, hjoinShareColumnTest)
-{
-    auto table_tmp1 = table_data1;
-    auto table_tmp5 = table_data5;
+// TEST(ValueTableTest, hjoinShareColumnTest)
+// {
+//     auto table_tmp1 = table_data1;
+//     auto table_tmp5 = table_data5;
 
-    // 2列目を指定して table1 に table5 を横結合した場合
-    // IDがソートされてる必要があるのでソートしておく
-    std::sort(
-        table_tmp1.begin(),
-        table_tmp1.end(),
-        [](const auto& a, const auto& b) { return a[1] < b[1]; }
-    );
-    std::sort(
-        table_tmp5.begin(),
-        table_tmp5.end(),
-        [](const auto& a, const auto& b) { return a[1] < b[1]; }
-    );
-    const auto table1_sorted1 = qmpc::ComputationToDb::ValueTable(table_tmp1, schemas1);
-    const auto table5_sorted1 = qmpc::ComputationToDb::ValueTable(table_tmp5, schemas5);
-    EXPECT_EQ(
-        table1_sorted1.hjoinShare(table5_sorted1, 2, 2), table1_sorted1.hjoin(table5_sorted1, 2, 2)
-    );
+//     // 2列目を指定して table1 に table5 を横結合した場合
+//     // IDがソートされてる必要があるのでソートしておく
+//     std::sort(
+//         table_tmp1.begin(),
+//         table_tmp1.end(),
+//         [](const auto& a, const auto& b) { return a[1] < b[1]; }
+//     );
+//     std::sort(
+//         table_tmp5.begin(),
+//         table_tmp5.end(),
+//         [](const auto& a, const auto& b) { return a[1] < b[1]; }
+//     );
+//     const auto table1_sorted1 = qmpc::ComputationToDb::ValueTable(table_tmp1, schemas1);
+//     const auto table5_sorted1 = qmpc::ComputationToDb::ValueTable(table_tmp5, schemas5);
+//     EXPECT_EQ(
+//         table1_sorted1.hjoinShare(table5_sorted1, 2, 2), table1_sorted1.hjoin(table5_sorted1, 2,
+//         2)
+//     );
 
-    // 3列目を指定して table1 に table5 を横結合した場合
-    std::sort(
-        table_tmp1.begin(),
-        table_tmp1.end(),
-        [](const auto& a, const auto& b) { return a[2] < b[2]; }
-    );
-    std::sort(
-        table_tmp5.begin(),
-        table_tmp5.end(),
-        [](const auto& a, const auto& b) { return a[2] < b[2]; }
-    );
-    const auto table1_sorted2 = qmpc::ComputationToDb::ValueTable(table_tmp1, schemas1);
-    const auto table5_sorted2 = qmpc::ComputationToDb::ValueTable(table_tmp5, schemas5);
-    EXPECT_EQ(
-        table1_sorted2.hjoinShare(table5_sorted2, 3, 3), table1_sorted2.hjoin(table5_sorted2, 3, 3)
-    );
-}
+//     // 3列目を指定して table1 に table5 を横結合した場合
+//     std::sort(
+//         table_tmp1.begin(),
+//         table_tmp1.end(),
+//         [](const auto& a, const auto& b) { return a[2] < b[2]; }
+//     );
+//     std::sort(
+//         table_tmp5.begin(),
+//         table_tmp5.end(),
+//         [](const auto& a, const auto& b) { return a[2] < b[2]; }
+//     );
+//     const auto table1_sorted2 = qmpc::ComputationToDb::ValueTable(table_tmp1, schemas1);
+//     const auto table5_sorted2 = qmpc::ComputationToDb::ValueTable(table_tmp5, schemas5);
+//     EXPECT_EQ(
+//         table1_sorted2.hjoinShare(table5_sorted2, 3, 3), table1_sorted2.hjoin(table5_sorted2, 3,
+//         3)
+//     );
+// }

--- a/packages/server/computation_container/test/integration_test/value_table_test.hpp
+++ b/packages/server/computation_container/test/integration_test/value_table_test.hpp
@@ -250,3 +250,21 @@ TEST_F(ValueTableTest, hjoinShareColumnTest)
         initialize(join_table.getDataId());
     }
 }
+
+TEST_F(ValueTableTest, hjoinMultiple)
+{
+    auto vt1 = genValueTable(0);
+    auto vt2 = genValueTable(1);
+    auto join_table = vt1.hjoin(vt2, 1, 1);
+    const std::vector<std::vector<std::string>> expect_table{{"101", "1", "2", "5", "6"}};
+    const std::vector<std::string> expect_schema{"id", "attr1", "attr2", "attr1", "attr3"};
+
+    // 同じ結合を何回も行う
+    for (int i = 0; i < 10; ++i)
+    {
+        auto join_table = vt1.hjoin(vt2, 1, 1);
+        EXPECT_EQ(join_table.getTable(), expect_table);
+        EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    }
+    initialize(join_table.getDataId());
+}

--- a/packages/server/computation_container/test/integration_test/value_table_test.hpp
+++ b/packages/server/computation_container/test/integration_test/value_table_test.hpp
@@ -79,6 +79,7 @@ TEST_F(ValueTableTest, vjoinTest)
         const std::vector<std::string> expect_schema{"id", "attr1"};
         EXPECT_EQ(join_table.getTable(), expect_table);
         EXPECT_EQ(join_table.getSchemas(), expect_schema);
+        initialize(join_table.getDataId());
     }
     {
         auto vt1 = genValueTable(2);
@@ -90,6 +91,7 @@ TEST_F(ValueTableTest, vjoinTest)
         const std::vector<std::string> expect_schema{"id", "attr3", "attr4"};
         EXPECT_EQ(join_table.getTable(), expect_table);
         EXPECT_EQ(join_table.getSchemas(), expect_schema);
+        initialize(join_table.getDataId());
     }
 }
 
@@ -104,6 +106,7 @@ TEST_F(ValueTableTest, hjoinTest)
         const std::vector<std::string> expect_schema{"id", "attr1", "attr2", "attr1", "attr3"};
         EXPECT_EQ(join_table.getTable(), expect_table);
         EXPECT_EQ(join_table.getSchemas(), expect_schema);
+        initialize(join_table.getDataId());
     }
     {
         auto vt1 = genValueTable(2);
@@ -116,6 +119,7 @@ TEST_F(ValueTableTest, hjoinTest)
             "id", "attr1", "attr3", "attr4", "attr3", "attr4", "attr5"};
         EXPECT_EQ(join_table.getTable(), expect_table);
         EXPECT_EQ(join_table.getSchemas(), expect_schema);
+        initialize(join_table.getDataId());
     }
 }
 
@@ -131,6 +135,7 @@ TEST_F(ValueTableTest, vhjoinTest)
     const std::vector<std::string> expect_schema{"id", "attr1", "attr1", "attr3", "attr4"};
     EXPECT_EQ(join_table.getTable(), expect_table);
     EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    initialize(join_table.getDataId());
 }
 
 TEST_F(ValueTableTest, hvjoinTest)
@@ -145,6 +150,7 @@ TEST_F(ValueTableTest, hvjoinTest)
     const std::vector<std::string> expect_schema{"id", "attr1", "attr1", "attr3"};
     EXPECT_EQ(join_table.getTable(), expect_table);
     EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    initialize(join_table.getDataId());
 }
 
 TEST_F(ValueTableTest, vjoinColumnTest)
@@ -159,6 +165,7 @@ TEST_F(ValueTableTest, vjoinColumnTest)
         const std::vector<std::string> expect_schema{"id", "attr1", "attr2"};
         EXPECT_EQ(join_table.getTable(), expect_table);
         EXPECT_EQ(join_table.getSchemas(), expect_schema);
+        initialize(join_table.getDataId());
     }
     {
         auto join_table = vt1.vjoin(vt2, 3, 3);
@@ -168,6 +175,7 @@ TEST_F(ValueTableTest, vjoinColumnTest)
         const std::vector<std::string> expect_schema{"id", "attr1", "attr2"};
         EXPECT_EQ(join_table.getTable(), expect_table);
         EXPECT_EQ(join_table.getSchemas(), expect_schema);
+        initialize(join_table.getDataId());
     }
 }
 
@@ -182,6 +190,7 @@ TEST_F(ValueTableTest, hjoinColumnTest)
         const std::vector<std::string> expect_schema{"id", "attr1", "attr2", "id", "attr2"};
         EXPECT_EQ(join_table.getTable(), expect_table);
         EXPECT_EQ(join_table.getSchemas(), expect_schema);
+        initialize(join_table.getDataId());
     }
     {
         auto join_table = vt1.hjoin(vt2, 3, 3);
@@ -190,6 +199,7 @@ TEST_F(ValueTableTest, hjoinColumnTest)
         const std::vector<std::string> expect_schema{"id", "attr1", "attr2", "id", "attr1"};
         EXPECT_EQ(join_table.getTable(), expect_table);
         EXPECT_EQ(join_table.getSchemas(), expect_schema);
+        initialize(join_table.getDataId());
     }
 }
 
@@ -203,6 +213,7 @@ TEST_F(ValueTableTest, hjoinShareTest)
         auto expect = vt1.hjoin(vt2, 1, 1);
         EXPECT_EQ(join_table.getTable(), expect.getTable());
         EXPECT_EQ(join_table.getSchemas(), expect.getSchemas());
+        initialize(join_table.getDataId());
     }
     {
         auto vt1 = genValueTable(2);
@@ -212,6 +223,7 @@ TEST_F(ValueTableTest, hjoinShareTest)
         auto expect = vt1.hjoin(vt2, 1, 1);
         EXPECT_EQ(join_table.getTable(), expect.getTable());
         EXPECT_EQ(join_table.getSchemas(), expect.getSchemas());
+        initialize(join_table.getDataId());
     }
 }
 
@@ -225,6 +237,7 @@ TEST_F(ValueTableTest, hjoinShareColumnTest)
         auto expect = vt1.hjoin(vt2, 1, 1);
         EXPECT_EQ(join_table.getTable(), expect.getTable());
         EXPECT_EQ(join_table.getSchemas(), expect.getSchemas());
+        initialize(join_table.getDataId());
     }
     {
         auto vt1 = genValueTable(0);
@@ -234,5 +247,6 @@ TEST_F(ValueTableTest, hjoinShareColumnTest)
         auto expect = vt1.hjoin(vt2, 1, 1);
         EXPECT_EQ(join_table.getTable(), expect.getTable());
         EXPECT_EQ(join_table.getSchemas(), expect.getSchemas());
+        initialize(join_table.getDataId());
     }
 }

--- a/packages/server/computation_container/test/integration_test/value_table_test.hpp
+++ b/packages/server/computation_container/test/integration_test/value_table_test.hpp
@@ -27,8 +27,8 @@ protected:
 
     static auto initialize(const std::string& id)
     {
-        fs::remove_all("/Db/share/" + id);
-        fs::remove_all("/Db/result/" + id);
+        fs::remove_all("/db/share/" + id);
+        fs::remove_all("/db/result/" + id);
     }
 
     auto genValueTable(int table_itr)
@@ -45,7 +45,7 @@ protected:
             {"value", table}, {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
         const std::string data = data_json.dump();
 
-        auto data_path = "/Db/share/" + data_id;
+        auto data_path = "/db/share/" + data_id;
         fs::create_directories(data_path);
         std::ofstream ofs(data_path + "/" + std::to_string(piece_id));
         ofs << data;

--- a/packages/server/computation_container/test/integration_test/value_table_test.hpp
+++ b/packages/server/computation_container/test/integration_test/value_table_test.hpp
@@ -6,209 +6,233 @@
 #include "gtest/gtest.h"
 namespace fs = std::experimental::filesystem;
 
-// TODO: ValueTableのコンストラクタが変更されたので全部修正する
+using Schema = std::vector<std::string>;
+using Table = std::vector<std::vector<std::string>>;
 
-/****************** Test用の各データ ******************/
-// DBを初期化する
-auto initialize(const std::string& id)
+/******************** 前処理，後処理 **********************/
+class ValueTableTest : public testing::Test
 {
-    fs::remove_all("/Db/share/" + id);
-    fs::remove_all("/Db/result/" + id);
-}
-const std::vector<std::vector<std::string>> table_data1{{"101", "1", "2"}, {"102", "3", "4"}};
-const std::vector<std::string> schemas1{"id", "attr1", "attr2"};
+protected:
+    // Testに用いる{schema, table}のリスト
+    const std::vector<std::pair<Schema, Table>> test_tables{
+        {{"id", "attr1", "attr2"}, {{"101", "1", "2"}, {"102", "3", "4"}}},
+        {{"id", "attr1", "attr3"}, {{"101", "5", "6"}, {"103", "7", "8"}}},
+        {{"id", "attr1", "attr3", "attr4"}, {{"102", "9", "10", "11"}, {"103", "12", "13", "14"}}},
+        {{"id", "attr3", "attr4", "attr5"},
+         {{"103", "15", "16", "17"}, {"104", "18", "19", "20"}, {"105", "21", "22", "23"}}},
+        {{"id", "attr1", "attr2"}, {{"101", "1", "0"}, {"102", "0", "4"}}},
+        {{"id", "attr1", "attr2"}, {{"102", "0", "4"}, {"102", "1", "0"}}},
+    };
+    std::deque<std::string> data_ids;
 
-const std::vector<std::vector<std::string>> table_data2{{"101", "5", "6"}, {"103", "7", "8"}};
-const std::vector<std::string> schemas2{"id", "attr1", "attr3"};
+    static auto initialize(const std::string& id)
+    {
+        fs::remove_all("/Db/share/" + id);
+        fs::remove_all("/Db/result/" + id);
+    }
 
-const std::vector<std::vector<std::string>> table_data3{
-    {"102", "9", "10", "11"}, {"103", "12", "13", "14"}};
-const std::vector<std::string> schemas3{"id", "attr1", "attr3", "attr4"};
+    auto genValueTable(int table_itr)
+    {
+        // 初期化してリストに登録する(テスト後に削除するため)
+        auto data_id = "ValueTableTest" + std::to_string(table_itr);
+        initialize(data_id);
+        data_ids.emplace_back(data_id);
 
-const std::vector<std::vector<std::string>> table_data4{
-    {"103", "15", "16", "17"}, {"104", "18", "19", "20"}, {"105", "21", "22", "23"}};
-const std::vector<std::string> schemas4{"id", "attr3", "attr4", "attr5"};
+        //テストで使用するデータをDBに保存する
+        const int piece_id = 0;
+        auto [schema, table] = test_tables[table_itr];
+        nlohmann::json data_json = {
+            {"value", table}, {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
+        const std::string data = data_json.dump();
 
-const std::vector<std::vector<std::string>> table_data5{{"101", "1", "0"}, {"102", "0", "4"}};
-const std::vector<std::string> schemas5{"id", "attr1", "attr2"};
+        auto data_path = "/Db/share/" + data_id;
+        fs::create_directories(data_path);
+        std::ofstream ofs(data_path + "/" + std::to_string(piece_id));
+        ofs << data;
+        ofs.close();
 
-auto writeTable(
-    const std::string& data_id,
-    const std::vector<std::vector<std::string>>& table,
-    const std::vector<std::string>& schema
-)
-{
-    const int piece_id = 0;
-    nlohmann::json data_json = {
-        {"value", table}, {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
-    const std::string data = data_json.dump();
+        return qmpc::ComputationToDb::ValueTable(data_id);
+    }
 
-    auto data_path = "/Db/share/" + data_id;
-    fs::create_directories(data_path);
-    std::ofstream ofs(data_path + "/" + std::to_string(piece_id));
-    ofs << data;
-    ofs.close();
-    return data_id;
-}
+    void TearDown() override
+    {
+        // テストで使用したデータを削除する
+        while (!data_ids.empty())
+        {
+            initialize(data_ids.front());
+            data_ids.pop_front();
+        }
+    }
+};
 
+// TODO: Parameterテストを導入してテストデータを各テストごとに設定する
 /********************** Test **********************/
-TEST(ValueTableTest, vjoinTest)
+TEST_F(ValueTableTest, vjoinTest)
 {
-    auto data_id1 = "vjoinTest1";
-    auto data_id2 = "vjoinTest2";
-    auto data_id3 = "vjoinTest3";
-    auto data_id4 = "vjoinTest4";
-    writeTable(data_id1, table_data1, schemas1);
-    writeTable(data_id2, table_data2, schemas2);
-    writeTable(data_id3, table_data3, schemas3);
-    writeTable(data_id4, table_data4, schemas4);
+    {
+        auto vt1 = genValueTable(0);
+        auto vt2 = genValueTable(1);
+        auto join_table = vt1.vjoin(vt2, 1, 1);
 
-    // table1 に table2 を縦結合した場合
-    auto vt1 = qmpc::ComputationToDb::ValueTable(data_id1);
-    auto vt2 = qmpc::ComputationToDb::ValueTable(data_id2);
-    auto join_table1 = vt1.vjoin(vt2, 1, 1);
+        const std::vector<std::vector<std::string>> expect_table{
+            {"101", "1"}, {"102", "3"}, {"103", "7"}};
+        const std::vector<std::string> expect_schema{"id", "attr1"};
+        EXPECT_EQ(join_table.getTable(), expect_table);
+        EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    }
+    {
+        auto vt1 = genValueTable(2);
+        auto vt2 = genValueTable(3);
+        auto join_table = vt1.vjoin(vt2, 1, 1);
 
-    const std::vector<std::vector<std::string>> table_data_1v2{
-        {"101", "1"}, {"102", "3"}, {"103", "7"}};
-    const std::vector<std::string> schemas_1v2{"id", "attr1"};
-    EXPECT_EQ(join_table1.getTable(), table_data_1v2);
-    EXPECT_EQ(join_table1.getSchemas(), schemas_1v2);
-
-    // // table3 に table4 を縦結合した場合
-    // auto vt3 = qmpc::ComputationToDb::ValueTable(data_id3);
-    // auto vt4 = qmpc::ComputationToDb::ValueTable(data_id4);
-    // auto join_table2 = vt3.vjoin(vt4, 1, 1);
-
-    // const std::vector<std::vector<std::string>> table_data_3v4{
-    //     {"102", "10", "11"}, {"103", "13", "14"}, {"104", "18", "19"}, {"105", "21", "22"}};
-    // const std::vector<std::string> schemas_3v4{"id", "attr3", "attr4"};
-    // EXPECT_EQ(join_table2.getTable(), table_data_3v4);
-    // EXPECT_EQ(join_table2.getSchemas(), schemas_3v4);
-
-    // initialize(data_id1);
-    // initialize(data_id2);
-    // initialize(data_id3);
-    // initialize(data_id4);
+        const std::vector<std::vector<std::string>> expect_table{
+            {"102", "10", "11"}, {"103", "13", "14"}, {"104", "18", "19"}, {"105", "21", "22"}};
+        const std::vector<std::string> expect_schema{"id", "attr3", "attr4"};
+        EXPECT_EQ(join_table.getTable(), expect_table);
+        EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    }
 }
 
-// TEST(ValueTableTest, hjoinTest)
-// {
-//     // table1 に table2 を横結合した場合
-//     const std::vector<std::vector<std::string>> table_data_1h2{{"101", "1", "2", "5", "6"}};
-//     const std::vector<std::string> schemas_1h2{"id", "attr1", "attr2", "attr1", "attr3"};
-//     const auto table_1h2 = qmpc::ComputationToDb::ValueTable(table_data_1h2, schemas_1h2);
-//     EXPECT_EQ(table_1h2, table1.hjoin(table2, 1, 1));
+TEST_F(ValueTableTest, hjoinTest)
+{
+    {
+        auto vt1 = genValueTable(0);
+        auto vt2 = genValueTable(1);
+        auto join_table = vt1.hjoin(vt2, 1, 1);
 
-//     // table3 に table4 を横結合した場合
-//     const std::vector<std::vector<std::string>> table_data_3h4{
-//         {"103", "12", "13", "14", "15", "16", "17"}};
-//     const std::vector<std::string> schemas_3h4{
-//         "id", "attr1", "attr3", "attr4", "attr3", "attr4", "attr5"};
-//     const auto table_3h4 = qmpc::ComputationToDb::ValueTable(table_data_3h4, schemas_3h4);
-//     EXPECT_EQ(table_3h4, table3.hjoin(table4, 1, 1));
-// }
+        const std::vector<std::vector<std::string>> expect_table{{"101", "1", "2", "5", "6"}};
+        const std::vector<std::string> expect_schema{"id", "attr1", "attr2", "attr1", "attr3"};
+        EXPECT_EQ(join_table.getTable(), expect_table);
+        EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    }
+    {
+        auto vt1 = genValueTable(2);
+        auto vt2 = genValueTable(3);
+        auto join_table = vt1.hjoin(vt2, 1, 1);
 
-// TEST(ValueTableTest, vhjoinTest)
-// {
-//     // vjoin(table1,table2) と table3 を横結合した場合
-//     const std::vector<std::vector<std::string>> table_data_1v2h3{
-//         {"102", "3", "9", "10", "11"}, {"103", "7", "12", "13", "14"}};
-//     const std::vector<std::string> schemas_1v2h3{"id", "attr1", "attr1", "attr3", "attr4"};
-//     const auto table_1v2h3 = qmpc::ComputationToDb::ValueTable(table_data_1v2h3, schemas_1v2h3);
-//     EXPECT_EQ(table_1v2h3, table1.vjoin(table2, 1, 1).hjoin(table3, 1, 1));
-// }
+        const std::vector<std::vector<std::string>> expect_table{
+            {"103", "12", "13", "14", "15", "16", "17"}};
+        const std::vector<std::string> expect_schema{
+            "id", "attr1", "attr3", "attr4", "attr3", "attr4", "attr5"};
+        EXPECT_EQ(join_table.getTable(), expect_table);
+        EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    }
+}
 
-// TEST(ValueTableTest, hvjoinTest)
-// {
-//     // hjoin(table1,table2) と table3 を縦結合した場合
-//     const std::vector<std::vector<std::string>> table_data_1h2v3{
-//         {"101", "1", "5", "6"}, {"102", "9", "9", "10"}, {"103", "12", "12", "13"}};
-//     const std::vector<std::string> schemas_1h2v3{"id", "attr1", "attr1", "attr3"};
-//     const auto table_1h2v3 = qmpc::ComputationToDb::ValueTable(table_data_1h2v3, schemas_1h2v3);
-//     auto t = table1.hjoin(table2, 1, 1).vjoin(table3, 1, 1);
-//     EXPECT_EQ(table_1h2v3, table1.hjoin(table2, 1, 1).vjoin(table3, 1, 1));
-// }
+TEST_F(ValueTableTest, vhjoinTest)
+{
+    auto vt1 = genValueTable(0);
+    auto vt2 = genValueTable(1);
+    auto vt3 = genValueTable(2);
+    auto join_table = vt1.vjoin(vt2, 1, 1).hjoin(vt3, 1, 1);
 
-// TEST(ValueTableTest, vjoinColumnTest)
-// {
-//     // 2列目を指定して table1 に table5 を縦結合した場合
-//     const std::vector<std::vector<std::string>> table_data_1v5_2{
-//         {"101", "1", "2"}, {"102", "3", "4"}, {"102", "0", "4"}};
-//     const std::vector<std::string> schemas_1v5_2{"id", "attr1", "attr2"};
-//     const auto table_1v5_2 = qmpc::ComputationToDb::ValueTable(table_data_1v5_2, schemas_1v5_2);
-//     EXPECT_EQ(table_1v5_2, table1.vjoin(table5, 2, 2));
+    const std::vector<std::vector<std::string>> expect_table{
+        {"102", "3", "9", "10", "11"}, {"103", "7", "12", "13", "14"}};
+    const std::vector<std::string> expect_schema{"id", "attr1", "attr1", "attr3", "attr4"};
+    EXPECT_EQ(join_table.getTable(), expect_table);
+    EXPECT_EQ(join_table.getSchemas(), expect_schema);
+}
 
-//     // 3列目を指定して table1 に table5 を縦結合した場合
-//     const std::vector<std::vector<std::string>> table_data_1v5_3{
-//         {"101", "1", "2"}, {"102", "3", "4"}, {"101", "1", "0"}};
-//     const std::vector<std::string> schemas_1v5_3{"id", "attr1", "attr2"};
-//     const auto table_1v5_3 = qmpc::ComputationToDb::ValueTable(table_data_1v5_3, schemas_1v5_3);
-//     EXPECT_EQ(table_1v5_3, table1.vjoin(table5, 3, 3));
-// }
+TEST_F(ValueTableTest, hvjoinTest)
+{
+    auto vt1 = genValueTable(0);
+    auto vt2 = genValueTable(1);
+    auto vt3 = genValueTable(2);
+    auto join_table = vt1.hjoin(vt2, 1, 1).vjoin(vt3, 1, 1);
 
-// TEST(ValueTableTest, hjoinColumnTest)
-// {
-//     // 2列目を指定して table1 に table5 を横結合した場合
-//     const std::vector<std::vector<std::string>> table_data_1h5_2{{"101", "1", "2", "101", "0"}};
-//     const std::vector<std::string> schemas_1h5_2{"id", "attr1", "attr2", "id", "attr2"};
-//     const auto table_1h5_2 = qmpc::ComputationToDb::ValueTable(table_data_1h5_2, schemas_1h5_2);
-//     EXPECT_EQ(table_1h5_2, table1.hjoin(table5, 2, 2));
+    const std::vector<std::vector<std::string>> expect_table{
+        {"101", "1", "5", "6"}, {"102", "9", "9", "10"}, {"103", "12", "12", "13"}};
+    const std::vector<std::string> expect_schema{"id", "attr1", "attr1", "attr3"};
+    EXPECT_EQ(join_table.getTable(), expect_table);
+    EXPECT_EQ(join_table.getSchemas(), expect_schema);
+}
 
-//     // 3列目を指定して table1 に table5 を横結合した場合
-//     const std::vector<std::vector<std::string>> table_data_1h5_3{{"102", "3", "4", "102", "0"}};
-//     const std::vector<std::string> schemas_1h5_3{"id", "attr1", "attr2", "id", "attr1"};
-//     const auto table_1h5_3 = qmpc::ComputationToDb::ValueTable(table_data_1h5_3, schemas_1h5_3);
-//     EXPECT_EQ(table_1h5_3, table1.hjoin(table5, 3, 3));
-// }
+TEST_F(ValueTableTest, vjoinColumnTest)
+{
+    auto vt1 = genValueTable(0);
+    auto vt2 = genValueTable(4);
+    {
+        auto join_table = vt1.vjoin(vt2, 2, 2);
 
-// TEST(ValueTableTest, hjoinShareTest)
-// {
-//     // table1 に table2 を横結合した場合
-//     EXPECT_EQ(table1.hjoinShare(table2, 1, 1), table1.hjoin(table2, 1, 1));
+        const std::vector<std::vector<std::string>> expect_table{
+            {"101", "1", "2"}, {"102", "3", "4"}, {"102", "0", "4"}};
+        const std::vector<std::string> expect_schema{"id", "attr1", "attr2"};
+        EXPECT_EQ(join_table.getTable(), expect_table);
+        EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    }
+    {
+        auto join_table = vt1.vjoin(vt2, 3, 3);
 
-//     // table3 に table4 を横結合した場合
-//     EXPECT_EQ(table3.hjoinShare(table4, 1, 1), table3.hjoin(table4, 1, 1));
-// }
+        const std::vector<std::vector<std::string>> expect_table{
+            {"101", "1", "2"}, {"102", "3", "4"}, {"101", "1", "0"}};
+        const std::vector<std::string> expect_schema{"id", "attr1", "attr2"};
+        EXPECT_EQ(join_table.getTable(), expect_table);
+        EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    }
+}
 
-// TEST(ValueTableTest, hjoinShareColumnTest)
-// {
-//     auto table_tmp1 = table_data1;
-//     auto table_tmp5 = table_data5;
+TEST_F(ValueTableTest, hjoinColumnTest)
+{
+    auto vt1 = genValueTable(0);
+    auto vt2 = genValueTable(4);
+    {
+        auto join_table = vt1.hjoin(vt2, 2, 2);
 
-//     // 2列目を指定して table1 に table5 を横結合した場合
-//     // IDがソートされてる必要があるのでソートしておく
-//     std::sort(
-//         table_tmp1.begin(),
-//         table_tmp1.end(),
-//         [](const auto& a, const auto& b) { return a[1] < b[1]; }
-//     );
-//     std::sort(
-//         table_tmp5.begin(),
-//         table_tmp5.end(),
-//         [](const auto& a, const auto& b) { return a[1] < b[1]; }
-//     );
-//     const auto table1_sorted1 = qmpc::ComputationToDb::ValueTable(table_tmp1, schemas1);
-//     const auto table5_sorted1 = qmpc::ComputationToDb::ValueTable(table_tmp5, schemas5);
-//     EXPECT_EQ(
-//         table1_sorted1.hjoinShare(table5_sorted1, 2, 2), table1_sorted1.hjoin(table5_sorted1, 2,
-//         2)
-//     );
+        const std::vector<std::vector<std::string>> expect_table{{"101", "1", "2", "101", "0"}};
+        const std::vector<std::string> expect_schema{"id", "attr1", "attr2", "id", "attr2"};
+        EXPECT_EQ(join_table.getTable(), expect_table);
+        EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    }
+    {
+        auto join_table = vt1.hjoin(vt2, 3, 3);
 
-//     // 3列目を指定して table1 に table5 を横結合した場合
-//     std::sort(
-//         table_tmp1.begin(),
-//         table_tmp1.end(),
-//         [](const auto& a, const auto& b) { return a[2] < b[2]; }
-//     );
-//     std::sort(
-//         table_tmp5.begin(),
-//         table_tmp5.end(),
-//         [](const auto& a, const auto& b) { return a[2] < b[2]; }
-//     );
-//     const auto table1_sorted2 = qmpc::ComputationToDb::ValueTable(table_tmp1, schemas1);
-//     const auto table5_sorted2 = qmpc::ComputationToDb::ValueTable(table_tmp5, schemas5);
-//     EXPECT_EQ(
-//         table1_sorted2.hjoinShare(table5_sorted2, 3, 3), table1_sorted2.hjoin(table5_sorted2, 3,
-//         3)
-//     );
-// }
+        const std::vector<std::vector<std::string>> expect_table{{"102", "3", "4", "102", "0"}};
+        const std::vector<std::string> expect_schema{"id", "attr1", "attr2", "id", "attr1"};
+        EXPECT_EQ(join_table.getTable(), expect_table);
+        EXPECT_EQ(join_table.getSchemas(), expect_schema);
+    }
+}
+
+TEST_F(ValueTableTest, hjoinShareTest)
+{
+    {
+        auto vt1 = genValueTable(0);
+        auto vt2 = genValueTable(1);
+        auto join_table = vt1.hjoinShare(vt2, 1, 1);
+
+        auto expect = vt1.hjoin(vt2, 1, 1);
+        EXPECT_EQ(join_table.getTable(), expect.getTable());
+        EXPECT_EQ(join_table.getSchemas(), expect.getSchemas());
+    }
+    {
+        auto vt1 = genValueTable(2);
+        auto vt2 = genValueTable(3);
+        auto join_table = vt1.hjoinShare(vt2, 1, 1);
+
+        auto expect = vt1.hjoin(vt2, 1, 1);
+        EXPECT_EQ(join_table.getTable(), expect.getTable());
+        EXPECT_EQ(join_table.getSchemas(), expect.getSchemas());
+    }
+}
+
+TEST_F(ValueTableTest, hjoinShareColumnTest)
+{
+    {
+        auto vt1 = genValueTable(0);
+        auto vt2 = genValueTable(5);
+        auto join_table = vt1.hjoinShare(vt2, 2, 2);
+
+        auto expect = vt1.hjoin(vt2, 1, 1);
+        EXPECT_EQ(join_table.getTable(), expect.getTable());
+        EXPECT_EQ(join_table.getSchemas(), expect.getSchemas());
+    }
+    {
+        auto vt1 = genValueTable(0);
+        auto vt2 = genValueTable(4);
+        auto join_table = vt1.hjoinShare(vt2, 3, 3);
+
+        auto expect = vt1.hjoin(vt2, 1, 1);
+        EXPECT_EQ(join_table.getTable(), expect.getTable());
+        EXPECT_EQ(join_table.getSchemas(), expect.getSchemas());
+    }
+}

--- a/packages/server/computation_container/test/unit_test/BUILD
+++ b/packages/server/computation_container/test/unit_test/BUILD
@@ -123,6 +123,7 @@ cc_test(
     deps = [
         "@gtest//:main",
         "//client/computation_to_db:client",
+        "//client/computation_to_db:valuetable",
         "@proto//common_types:common_types_cc_proto",
     ],
     linkopts = [

--- a/packages/server/computation_container/test/unit_test/ctodb_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctodb_test.cpp
@@ -15,7 +15,7 @@ auto initialize(const std::string& id)
 }
 
 // tableの取り出し
-// qmpc::ComputationToDb::ValueTable Client::readTable(const std::string& data_id);
+// std::optional<std::vector<std::vector<std::string>>> readTable(const std::string &, int) const;
 TEST(ComputationToDbTest, SuccessReadTableTest)
 {
     const std::string data_id = "SuccessReadTableTest";
@@ -29,10 +29,10 @@ TEST(ComputationToDbTest, SuccessReadTableTest)
     ofs.close();
 
     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readTable(data_id);
+    auto read_data = cc_to_db->readTable(data_id, 0).value();
 
     std::vector<std::vector<std::string>> true_table = {{"1", "2"}, {"3", "4"}};
-    EXPECT_EQ(true_table, read_data);
+    EXPECT_EQ(read_data, true_table);
 
     initialize(data_id);
 }
@@ -57,11 +57,19 @@ TEST(ComputationToDbTest, SuccessReadTablePieceTest)
     }
 
     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readTable(data_id);
+    std::vector<std::vector<std::string>> read_data;
+    for (size_t piece_id = 0; piece_id < data.size(); ++piece_id)
+    {
+        auto piece = cc_to_db->readTable(data_id, piece_id);
+        for (const auto& row : piece.value())
+        {
+            read_data.emplace_back(row);
+        }
+    }
 
     std::vector<std::vector<std::string>> true_table = {
         {"1", "2"}, {"3", "4"}, {"5", "6"}, {"7", "8"}, {"9", "10"}};
-    EXPECT_EQ(true_table, read_data);
+    EXPECT_EQ(read_data, true_table);
 
     initialize(data_id);
 }
@@ -92,11 +100,19 @@ TEST(ComputationToDbTest, SuccessReadTableLargeTest)
     }
 
     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readTable(data_id);
+    std::vector<std::vector<std::string>> read_data;
+    for (int piece_id = 0; piece_id < H; ++piece_id)
+    {
+        auto piece = cc_to_db->readTable(data_id, piece_id);
+        for (const auto& row : piece.value())
+        {
+            read_data.emplace_back(row);
+        }
+    }
 
     std::vector<std::vector<std::string>> true_data;
     for (int i = 0; i < H; i++) true_data.push_back(data);
-    EXPECT_EQ(true_data, read_data);
+    EXPECT_EQ(read_data, true_data);
 
     initialize(data_id);
 }

--- a/packages/server/computation_container/test/unit_test/ctodb_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctodb_test.cpp
@@ -12,12 +12,11 @@ auto initialize(const std::string &id)
     fs::remove_all("/db/share/" + id);
     fs::remove_all("/db/result/" + id);
 }
-
-// shareの取り出し
-// qmpc::ComputationToDb::ValueTable Client::readShare(const std::string &data_id);
-TEST(ComputationToDbTest, SuccessReadShareTest)
+// tableの取り出し
+// qmpc::ComputationToDb::ValueTable Client::readTable(const std::string &data_id);
+TEST(ComputationToDbTest, SuccessReadTableTest)
 {
-    const std::string data_id = "SuccessReadShareTest";
+    const std::string data_id = "SuccessReadTableTest";
     initialize(data_id);
 
     const std::string data = R"({"value":[["1","2"],["3","4"]])"
@@ -28,19 +27,16 @@ TEST(ComputationToDbTest, SuccessReadShareTest)
     ofs.close();
 
     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readShare(data_id);
+    auto read_data = cc_to_db->readTable(data_id);
 
     std::vector<std::vector<std::string>> true_table = {{"1", "2"}, {"3", "4"}};
-    std::vector<std::string> true_schema = {"attr1", "attr2"};
-    EXPECT_EQ(true_table, read_data.getTable());
-    EXPECT_EQ(true_schema, read_data.getSchemas());
+    EXPECT_EQ(true_table, read_data);
 
     initialize(data_id);
 }
-
-TEST(ComputationToDbTest, SuccessReadSharePieceTest)
+TEST(ComputationToDbTest, SuccessReadTablePieceTest)
 {
-    const std::string data_id = "SuccessReadSharePieceTest";
+    const std::string data_id = "SuccessReadTablePieceTest";
     initialize(data_id);
 
     const std::vector<std::string> data = {
@@ -59,19 +55,17 @@ TEST(ComputationToDbTest, SuccessReadSharePieceTest)
     }
 
     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readShare(data_id);
+    auto read_data = cc_to_db->readTable(data_id);
 
     std::vector<std::vector<std::string>> true_table = {
         {"1", "2"}, {"3", "4"}, {"5", "6"}, {"7", "8"}, {"9", "10"}};
-    std::vector<std::string> true_schema = {"attr1", "attr2"};
-    EXPECT_EQ(true_table, read_data.getTable());
-    EXPECT_EQ(true_schema, read_data.getSchemas());
+    EXPECT_EQ(true_table, read_data);
 
     initialize(data_id);
 }
-TEST(ComputationToDbTest, SuccessReadShareLargeTest)
+TEST(ComputationToDbTest, SuccessReadTableLargeTest)
 {
-    std::string data_id = "SuccessReadShareLargeTest";
+    std::string data_id = "SuccessReadTableLargeTest";
     initialize(data_id);
 
     constexpr int H = 500;
@@ -96,12 +90,34 @@ TEST(ComputationToDbTest, SuccessReadShareLargeTest)
     }
 
     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readShare(data_id);
+    auto read_data = cc_to_db->readTable(data_id);
 
     std::vector<std::vector<std::string>> true_data;
     for (int i = 0; i < H; i++) true_data.push_back(data);
-    EXPECT_EQ(true_data, read_data.getTable());
-    EXPECT_EQ(schema, read_data.getSchemas());
+    EXPECT_EQ(true_data, read_data);
+
+    initialize(data_id);
+}
+
+// schemaの取り出し
+// qmpc::ComputationToDb::ValueTable Client::readSchema(const std::string &data_id);
+TEST(ComputationToDbTest, SuccessReadSchemaTest)
+{
+    const std::string data_id = "SuccessReadSchemaTest";
+    initialize(data_id);
+
+    const std::string data = R"({"value":[["1","2"],["3","4"]])"
+                             R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
+    fs::create_directories("/Db/share/" + data_id);
+    auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
+    ofs << data;
+    ofs.close();
+
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    auto read_data = cc_to_db->readSchema(data_id);
+
+    std::vector<std::string> true_schema = {"attr1", "attr2"};
+    EXPECT_EQ(true_schema, read_data);
 
     initialize(data_id);
 }

--- a/packages/server/computation_container/test/unit_test/ctodb_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctodb_test.cpp
@@ -14,300 +14,300 @@ auto initialize(const std::string& id)
     fs::remove_all("/db/result/" + id);
 }
 
-// // tableの取り出し
-// // qmpc::ComputationToDb::ValueTable Client::readTable(const std::string &data_id);
-// TEST(ComputationToDbTest, SuccessReadTableTest)
-// {
-//     const std::string data_id = "SuccessReadTableTest";
-//     initialize(data_id);
+// tableの取り出し
+// qmpc::ComputationToDb::ValueTable Client::readTable(const std::string &data_id);
+TEST(ComputationToDbTest, SuccessReadTableTest)
+{
+    const std::string data_id = "SuccessReadTableTest";
+    initialize(data_id);
 
-//     const std::string data = R"({"value":[["1","2"],["3","4"]])"
-//                              R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
-//     fs::create_directories("/Db/share/" + data_id);
-//     auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
-//     ofs << data;
-//     ofs.close();
+    const std::string data = R"({"value":[["1","2"],["3","4"]])"
+                             R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
+    fs::create_directories("/Db/share/" + data_id);
+    auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
+    ofs << data;
+    ofs.close();
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     auto read_data = cc_to_db->readTable(data_id);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    auto read_data = cc_to_db->readTable(data_id);
 
-//     std::vector<std::vector<std::string>> true_table = {{"1", "2"}, {"3", "4"}};
-//     EXPECT_EQ(true_table, read_data);
+    std::vector<std::vector<std::string>> true_table = {{"1", "2"}, {"3", "4"}};
+    EXPECT_EQ(true_table, read_data);
 
-//     initialize(data_id);
-// }
-// TEST(ComputationToDbTest, SuccessReadTablePieceTest)
-// {
-//     const std::string data_id = "SuccessReadTablePieceTest";
-//     initialize(data_id);
+    initialize(data_id);
+}
+TEST(ComputationToDbTest, SuccessReadTablePieceTest)
+{
+    const std::string data_id = "SuccessReadTablePieceTest";
+    initialize(data_id);
 
-//     const std::vector<std::string> data = {
-//         R"({"value":[["1","2"],["3","4"]])"
-//         R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})",
-//         R"({"value":[["5","6"],["7","8"]])"
-//         R"(,"meta":{"piece_id":1,"schema":["attr1","attr2"]}})",
-//         R"({"value":[["9","10"]])"
-//         R"(,"meta":{"piece_id":2,"schema":["attr1","attr2"]}})"};
-//     fs::create_directories("/Db/share/" + data_id);
-//     for (size_t piece_id = 0; piece_id < data.size(); ++piece_id)
-//     {
-//         auto ofs = std::ofstream("/Db/share/" + data_id + "/" + std::to_string(piece_id));
-//         ofs << data[piece_id];
-//         ofs.close();
-//     }
+    const std::vector<std::string> data = {
+        R"({"value":[["1","2"],["3","4"]])"
+        R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})",
+        R"({"value":[["5","6"],["7","8"]])"
+        R"(,"meta":{"piece_id":1,"schema":["attr1","attr2"]}})",
+        R"({"value":[["9","10"]])"
+        R"(,"meta":{"piece_id":2,"schema":["attr1","attr2"]}})"};
+    fs::create_directories("/Db/share/" + data_id);
+    for (size_t piece_id = 0; piece_id < data.size(); ++piece_id)
+    {
+        auto ofs = std::ofstream("/Db/share/" + data_id + "/" + std::to_string(piece_id));
+        ofs << data[piece_id];
+        ofs.close();
+    }
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     auto read_data = cc_to_db->readTable(data_id);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    auto read_data = cc_to_db->readTable(data_id);
 
-//     std::vector<std::vector<std::string>> true_table = {
-//         {"1", "2"}, {"3", "4"}, {"5", "6"}, {"7", "8"}, {"9", "10"}};
-//     EXPECT_EQ(true_table, read_data);
+    std::vector<std::vector<std::string>> true_table = {
+        {"1", "2"}, {"3", "4"}, {"5", "6"}, {"7", "8"}, {"9", "10"}};
+    EXPECT_EQ(true_table, read_data);
 
-//     initialize(data_id);
-// }
-// TEST(ComputationToDbTest, SuccessReadTableLargeTest)
-// {
-//     std::string data_id = "SuccessReadTableLargeTest";
-//     initialize(data_id);
+    initialize(data_id);
+}
+TEST(ComputationToDbTest, SuccessReadTableLargeTest)
+{
+    std::string data_id = "SuccessReadTableLargeTest";
+    initialize(data_id);
 
-//     constexpr int H = 500;
-//     constexpr int W = 500;
-//     std::vector<std::string> schema;
-//     for (int i = 0; i < W; i++) schema.emplace_back("attr" + std::to_string(i + 1));
-//     std::vector<std::string> data;
-//     for (int i = 0; i < W; ++i) data.emplace_back(std::to_string(i + 1));
+    constexpr int H = 500;
+    constexpr int W = 500;
+    std::vector<std::string> schema;
+    for (int i = 0; i < W; i++) schema.emplace_back("attr" + std::to_string(i + 1));
+    std::vector<std::string> data;
+    for (int i = 0; i < W; ++i) data.emplace_back(std::to_string(i + 1));
 
-//     fs::create_directories("/Db/share/" + data_id);
-//     for (int piece_id = 0; piece_id < H; ++piece_id)
-//     {
-//         nlohmann::json data_json = {
-//             {"data_id", data_id},
-//             {"value", {data}},
-//             {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
-//         auto data_str = data_json.dump();
+    fs::create_directories("/Db/share/" + data_id);
+    for (int piece_id = 0; piece_id < H; ++piece_id)
+    {
+        nlohmann::json data_json = {
+            {"data_id", data_id},
+            {"value", {data}},
+            {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
+        auto data_str = data_json.dump();
 
-//         auto ofs = std::ofstream("/Db/share/" + data_id + "/" + std::to_string(piece_id));
-//         ofs << data_str;
-//         ofs.close();
-//     }
+        auto ofs = std::ofstream("/Db/share/" + data_id + "/" + std::to_string(piece_id));
+        ofs << data_str;
+        ofs.close();
+    }
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     auto read_data = cc_to_db->readTable(data_id);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    auto read_data = cc_to_db->readTable(data_id);
 
-//     std::vector<std::vector<std::string>> true_data;
-//     for (int i = 0; i < H; i++) true_data.push_back(data);
-//     EXPECT_EQ(true_data, read_data);
+    std::vector<std::vector<std::string>> true_data;
+    for (int i = 0; i < H; i++) true_data.push_back(data);
+    EXPECT_EQ(true_data, read_data);
 
-//     initialize(data_id);
-// }
+    initialize(data_id);
+}
 
-// // schemaの取り出し
-// // qmpc::ComputationToDb::ValueTable Client::readSchema(const std::string &data_id);
-// TEST(ComputationToDbTest, SuccessReadSchemaTest)
-// {
-//     const std::string data_id = "SuccessReadSchemaTest";
-//     initialize(data_id);
+// schemaの取り出し
+// qmpc::ComputationToDb::ValueTable Client::readSchema(const std::string &data_id);
+TEST(ComputationToDbTest, SuccessReadSchemaTest)
+{
+    const std::string data_id = "SuccessReadSchemaTest";
+    initialize(data_id);
 
-//     const std::string data = R"({"value":[["1","2"],["3","4"]])"
-//                              R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
-//     fs::create_directories("/Db/share/" + data_id);
-//     auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
-//     ofs << data;
-//     ofs.close();
+    const std::string data = R"({"value":[["1","2"],["3","4"]])"
+                             R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
+    fs::create_directories("/Db/share/" + data_id);
+    auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
+    ofs << data;
+    ofs.close();
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     auto read_data = cc_to_db->readSchema(data_id);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    auto read_data = cc_to_db->readSchema(data_id);
 
-//     std::vector<std::string> true_schema = {"attr1", "attr2"};
-//     EXPECT_EQ(true_schema, read_data);
+    std::vector<std::string> true_schema = {"attr1", "attr2"};
+    EXPECT_EQ(true_schema, read_data);
 
-//     initialize(data_id);
-// }
+    initialize(data_id);
+}
 
-// // Job を DB に新規登録する
-// // void Client::registerJob(const std::string &job_uuid, const int &status);
-// TEST(ComputationToDbTest, SuccessRregisterJobTest)
-// {
-//     const std::string job_uuid = "SuccessRregisterJobTest";
-//     initialize(job_uuid);
+// Job を DB に新規登録する
+// void Client::registerJob(const std::string &job_uuid, const int &status);
+TEST(ComputationToDbTest, SuccessRregisterJobTest)
+{
+    const std::string job_uuid = "SuccessRregisterJobTest";
+    initialize(job_uuid);
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     cc_to_db->registerJob(job_uuid, pb_common_types::JobStatus::UNKNOWN);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    cc_to_db->registerJob(job_uuid, pb_common_types::JobStatus::UNKNOWN);
 
-//     auto exist = fs::exists("/Db/result/" + job_uuid);
-//     EXPECT_TRUE(exist);
+    auto exist = fs::exists("/Db/result/" + job_uuid);
+    EXPECT_TRUE(exist);
 
-//     initialize(job_uuid);
-// }
+    initialize(job_uuid);
+}
 
-// // Job の実行状態を更新する
-// // void Client::updateJobStatus(const std::string &job_uuid, const int &status);
-// TEST(ComputationToDbTest, SuccessupdateJobStatusTest)
-// {
-//     const std::string job_uuid = "SuccessupdateJobStatusTest";
-//     initialize(job_uuid);
+// Job の実行状態を更新する
+// void Client::updateJobStatus(const std::string &job_uuid, const int &status);
+TEST(ComputationToDbTest, SuccessupdateJobStatusTest)
+{
+    const std::string job_uuid = "SuccessupdateJobStatusTest";
+    initialize(job_uuid);
 
-//     fs::create_directories("/Db/result/" + job_uuid);
-//     const google::protobuf::EnumDescriptor *descriptor =
-//         google::protobuf::GetEnumDescriptor<pb_common_types::JobStatus>();
-//     for (int status = 0;; ++status)
-//     {
-//         auto ptr = descriptor->FindValueByNumber(status);
-//         if (ptr == nullptr) break;
+    fs::create_directories("/Db/result/" + job_uuid);
+    const google::protobuf::EnumDescriptor* descriptor =
+        google::protobuf::GetEnumDescriptor<pb_common_types::JobStatus>();
+    for (int status = 0;; ++status)
+    {
+        auto ptr = descriptor->FindValueByNumber(status);
+        if (ptr == nullptr) break;
 
-//         auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//         cc_to_db->updateJobStatus(job_uuid, status);
+        auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+        cc_to_db->updateJobStatus(job_uuid, status);
 
-//         auto exist = fs::exists("/Db/result/" + job_uuid + "/status_" + ptr->name());
-//         EXPECT_TRUE(exist);
-//     }
+        auto exist = fs::exists("/Db/result/" + job_uuid + "/status_" + ptr->name());
+        EXPECT_TRUE(exist);
+    }
 
-//     initialize(job_uuid);
-// }
+    initialize(job_uuid);
+}
 
-// // resultの保存
-// // template <class T>
-// // void writeComputationResult(const std::string &job_uuid, const T &results, int piece_size);
-// TEST(ComputationToDbTest, SuccessWriteComputationResultArrayTest)
-// {
-//     const std::string job_uuid = "WriteComputaSuccessWriteComputationResultArrayTest";
-//     initialize(job_uuid);
+// resultの保存
+// template <class T>
+// void writeComputationResult(const std::string &job_uuid, const T &results, int piece_size);
+TEST(ComputationToDbTest, SuccessWriteComputationResultArrayTest)
+{
+    const std::string job_uuid = "WriteComputaSuccessWriteComputationResultArrayTest";
+    initialize(job_uuid);
 
-//     const std::vector<std::string> data = {"12", "15", "21"};
-//     fs::create_directories("/Db/result/" + job_uuid);
+    const std::vector<std::string> data = {"12", "15", "21"};
+    fs::create_directories("/Db/result/" + job_uuid);
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     cc_to_db->writeComputationResult(job_uuid, data);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    cc_to_db->writeComputationResult(job_uuid, data);
 
-//     auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim1_0");
-//     std::string read_data;
-//     getline(ifs, read_data);
-//     const auto true_data = R"({"job_uuid":"WriteComputaSuccessWriteComputationResultArrayTest")"
-//                            R"(,"meta":{"column_number":3,"piece_id":0})"
-//                            R"(,"result":["12","15","21"]})";
-//     EXPECT_EQ(read_data, true_data);
+    auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim1_0");
+    std::string read_data;
+    getline(ifs, read_data);
+    const auto true_data = R"({"job_uuid":"WriteComputaSuccessWriteComputationResultArrayTest")"
+                           R"(,"meta":{"column_number":3,"piece_id":0})"
+                           R"(,"result":["12","15","21"]})";
+    EXPECT_EQ(read_data, true_data);
 
-//     initialize(job_uuid);
-// }
-// TEST(ComputationToDbTest, SuccessWriteComputationResultArray2dimTest)
-// {
-//     const std::string job_uuid = "SuccessWriteComputationResultArray2dimTest";
-//     initialize(job_uuid);
+    initialize(job_uuid);
+}
+TEST(ComputationToDbTest, SuccessWriteComputationResultArray2dimTest)
+{
+    const std::string job_uuid = "SuccessWriteComputationResultArray2dimTest";
+    initialize(job_uuid);
 
-//     const std::vector<std::vector<std::string>> data = {{"12", "15"}, {"21", "51"}};
-//     fs::create_directories("/Db/result/" + job_uuid);
+    const std::vector<std::vector<std::string>> data = {{"12", "15"}, {"21", "51"}};
+    fs::create_directories("/Db/result/" + job_uuid);
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     cc_to_db->writeComputationResult(job_uuid, data);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    cc_to_db->writeComputationResult(job_uuid, data);
 
-//     auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim2_0");
-//     std::string read_data;
-//     getline(ifs, read_data);
-//     const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultArray2dimTest")"
-//                            R"(,"meta":{"column_number":2,"piece_id":0})"
-//                            R"(,"result":["12","15","21","51"]})";
-//     EXPECT_EQ(read_data, true_data);
+    auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim2_0");
+    std::string read_data;
+    getline(ifs, read_data);
+    const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultArray2dimTest")"
+                           R"(,"meta":{"column_number":2,"piece_id":0})"
+                           R"(,"result":["12","15","21","51"]})";
+    EXPECT_EQ(read_data, true_data);
 
-//     initialize(job_uuid);
-// }
+    initialize(job_uuid);
+}
 
-// TEST(ComputationToDbTest, SuccessWriteComputationResultSchemaTest)
-// {
-//     const std::string job_uuid = "SuccessWriteComputationResultSchemaTest";
-//     initialize(job_uuid);
+TEST(ComputationToDbTest, SuccessWriteComputationResultSchemaTest)
+{
+    const std::string job_uuid = "SuccessWriteComputationResultSchemaTest";
+    initialize(job_uuid);
 
-//     const std::vector<std::string> schema = {"s1", "s2", "s3"};
-//     fs::create_directories("/Db/result/" + job_uuid);
+    const std::vector<std::string> schema = {"s1", "s2", "s3"};
+    fs::create_directories("/Db/result/" + job_uuid);
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     cc_to_db->writeComputationResult(job_uuid, schema, true);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    cc_to_db->writeComputationResult(job_uuid, schema, true);
 
-//     auto ifs = std::ifstream("/Db/result/" + job_uuid + "/schema_0");
-//     std::string read_data;
-//     getline(ifs, read_data);
-//     const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultSchemaTest")"
-//                            R"(,"meta":{"column_number":3,"piece_id":0})"
-//                            R"(,"result":["s1","s2","s3"]})";
-//     EXPECT_EQ(read_data, true_data);
+    auto ifs = std::ifstream("/Db/result/" + job_uuid + "/schema_0");
+    std::string read_data;
+    getline(ifs, read_data);
+    const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultSchemaTest")"
+                           R"(,"meta":{"column_number":3,"piece_id":0})"
+                           R"(,"result":["s1","s2","s3"]})";
+    EXPECT_EQ(read_data, true_data);
 
-//     initialize(job_uuid);
-// }
-// TEST(ComputationToDbTest, SuccessWriteComputationResultTableTest)
-// {
-//     const std::string job_uuid = "SuccessWriteComputationResultTableTest";
-//     initialize(job_uuid);
+    initialize(job_uuid);
+}
+TEST(ComputationToDbTest, SuccessWriteComputationResultTableTest)
+{
+    const std::string job_uuid = "SuccessWriteComputationResultTableTest";
+    initialize(job_uuid);
 
-//     const nlohmann::json data_json = {
-//         {"schema", std::vector<std::string>{"s1", "s2"}},
-//         {"table", std::vector<std::vector<std::string>>{{"1", "2"}, {"3", "4"}}}};
-//     fs::create_directories("/Db/result/" + job_uuid);
+    const nlohmann::json data_json = {
+        {"schema", std::vector<std::string>{"s1", "s2"}},
+        {"table", std::vector<std::vector<std::string>>{{"1", "2"}, {"3", "4"}}}};
+    fs::create_directories("/Db/result/" + job_uuid);
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     cc_to_db->writeComputationResult(job_uuid, data_json, false);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    cc_to_db->writeComputationResult(job_uuid, data_json, false);
 
-//     auto ifs_schema = std::ifstream("/Db/result/" + job_uuid + "/schema_0");
-//     std::string read_data_schema;
-//     getline(ifs_schema, read_data_schema);
-//     const auto true_data_schema = R"({"job_uuid":"SuccessWriteComputationResultTableTest")"
-//                                   R"(,"meta":{"column_number":2,"piece_id":0})"
-//                                   R"(,"result":["s1","s2"]})";
-//     EXPECT_EQ(read_data_schema, true_data_schema);
+    auto ifs_schema = std::ifstream("/Db/result/" + job_uuid + "/schema_0");
+    std::string read_data_schema;
+    getline(ifs_schema, read_data_schema);
+    const auto true_data_schema = R"({"job_uuid":"SuccessWriteComputationResultTableTest")"
+                                  R"(,"meta":{"column_number":2,"piece_id":0})"
+                                  R"(,"result":["s1","s2"]})";
+    EXPECT_EQ(read_data_schema, true_data_schema);
 
-//     auto ifs_table = std::ifstream("/Db/result/" + job_uuid + "/dim2_0");
-//     std::string read_data_table;
-//     getline(ifs_table, read_data_table);
-//     const auto true_data_table = R"({"job_uuid":"SuccessWriteComputationResultTableTest")"
-//                                  R"(,"meta":{"column_number":2,"piece_id":0})"
-//                                  R"(,"result":["1","2","3","4"]})";
-//     EXPECT_EQ(read_data_table, true_data_table);
+    auto ifs_table = std::ifstream("/Db/result/" + job_uuid + "/dim2_0");
+    std::string read_data_table;
+    getline(ifs_table, read_data_table);
+    const auto true_data_table = R"({"job_uuid":"SuccessWriteComputationResultTableTest")"
+                                 R"(,"meta":{"column_number":2,"piece_id":0})"
+                                 R"(,"result":["1","2","3","4"]})";
+    EXPECT_EQ(read_data_table, true_data_table);
 
-//     initialize(job_uuid);
-// }
+    initialize(job_uuid);
+}
 
-// TEST(ComputationToDbTest, SuccessWriteComputationResultArrayPieceTest)
-// {
-//     const std::string job_uuid = "SuccessWriteComputationResultArrayPieceTest";
-//     initialize(job_uuid);
+TEST(ComputationToDbTest, SuccessWriteComputationResultArrayPieceTest)
+{
+    const std::string job_uuid = "SuccessWriteComputationResultArrayPieceTest";
+    initialize(job_uuid);
 
-//     const std::vector<std::vector<std::string>> data = {{"12", "15", "21"}};
-//     fs::create_directories("/Db/result/" + job_uuid);
+    const std::vector<std::vector<std::string>> data = {{"12", "15", "21"}};
+    fs::create_directories("/Db/result/" + job_uuid);
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     cc_to_db->writeComputationResult(job_uuid, data, false, 4);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    cc_to_db->writeComputationResult(job_uuid, data, false, 4);
 
-//     std::vector<std::string> true_result = {R"(["12"])", R"(["15"])", R"(["21"])"};
-//     for (size_t piece_id = 0; piece_id < true_result.size(); ++piece_id)
-//     {
-//         auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim2_" + std::to_string(piece_id));
-//         std::string read_data;
-//         getline(ifs, read_data);
-//         const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultArrayPieceTest")"
-//                                R"(,"meta":{"column_number":3,"piece_id":)"
-//                                + std::to_string(piece_id) + R"(},"result":)" +
-//                                true_result[piece_id]
-//                                + R"(})";
-//         EXPECT_EQ(read_data, true_data);
-//     }
+    std::vector<std::string> true_result = {R"(["12"])", R"(["15"])", R"(["21"])"};
+    for (size_t piece_id = 0; piece_id < true_result.size(); ++piece_id)
+    {
+        auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim2_" + std::to_string(piece_id));
+        std::string read_data;
+        getline(ifs, read_data);
+        const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultArrayPieceTest")"
+                               R"(,"meta":{"column_number":3,"piece_id":)"
+                               + std::to_string(piece_id) + R"(},"result":)" + true_result[piece_id]
+                               + R"(})";
+        EXPECT_EQ(read_data, true_data);
+    }
 
-//     initialize(job_uuid);
-// }
+    initialize(job_uuid);
+}
 
-// TEST(ComputationToDbTest, SuccessWriteComputationResultCompletedTest)
-// {
-//     const std::string job_uuid = "WriteComputationResultTestId";
-//     initialize(job_uuid);
+TEST(ComputationToDbTest, SuccessWriteComputationResultCompletedTest)
+{
+    const std::string job_uuid = "WriteComputationResultTestId";
+    initialize(job_uuid);
 
-//     const std::vector<std::vector<std::string>> data = {{"12", "15", "21"}};
-//     fs::create_directories("/Db/result/" + job_uuid);
+    const std::vector<std::vector<std::string>> data = {{"12", "15", "21"}};
+    fs::create_directories("/Db/result/" + job_uuid);
 
-//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-//     cc_to_db->writeComputationResult(job_uuid, data);
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    cc_to_db->writeComputationResult(job_uuid, data);
 
-//     auto exist = fs::exists("/Db/result/" + job_uuid + "/completed");
-//     EXPECT_TRUE(exist);
+    auto exist = fs::exists("/Db/result/" + job_uuid + "/completed");
+    EXPECT_TRUE(exist);
 
-//     initialize(job_uuid);
-// }
+    initialize(job_uuid);
+}
+
 TEST(ComputationToDbTest, SuccessGetTableTest)
 {
     const std::string data_id = "SuccessGetTableTest";

--- a/packages/server/computation_container/test/unit_test/ctodb_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctodb_test.cpp
@@ -2,21 +2,315 @@
 #include <fstream>
 
 #include "client/computation_to_db/client.hpp"
+#include "client/computation_to_db/value_table.hpp"
 #include "external/proto/common_types/common_types.pb.h"
 #include "gtest/gtest.h"
 namespace fs = std::experimental::filesystem;
 
 // DBを初期化する
-auto initialize(const std::string &id)
+auto initialize(const std::string& id)
 {
     fs::remove_all("/db/share/" + id);
     fs::remove_all("/db/result/" + id);
 }
-// tableの取り出し
-// qmpc::ComputationToDb::ValueTable Client::readTable(const std::string &data_id);
-TEST(ComputationToDbTest, SuccessReadTableTest)
+
+// // tableの取り出し
+// // qmpc::ComputationToDb::ValueTable Client::readTable(const std::string &data_id);
+// TEST(ComputationToDbTest, SuccessReadTableTest)
+// {
+//     const std::string data_id = "SuccessReadTableTest";
+//     initialize(data_id);
+
+//     const std::string data = R"({"value":[["1","2"],["3","4"]])"
+//                              R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
+//     fs::create_directories("/Db/share/" + data_id);
+//     auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
+//     ofs << data;
+//     ofs.close();
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     auto read_data = cc_to_db->readTable(data_id);
+
+//     std::vector<std::vector<std::string>> true_table = {{"1", "2"}, {"3", "4"}};
+//     EXPECT_EQ(true_table, read_data);
+
+//     initialize(data_id);
+// }
+// TEST(ComputationToDbTest, SuccessReadTablePieceTest)
+// {
+//     const std::string data_id = "SuccessReadTablePieceTest";
+//     initialize(data_id);
+
+//     const std::vector<std::string> data = {
+//         R"({"value":[["1","2"],["3","4"]])"
+//         R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})",
+//         R"({"value":[["5","6"],["7","8"]])"
+//         R"(,"meta":{"piece_id":1,"schema":["attr1","attr2"]}})",
+//         R"({"value":[["9","10"]])"
+//         R"(,"meta":{"piece_id":2,"schema":["attr1","attr2"]}})"};
+//     fs::create_directories("/Db/share/" + data_id);
+//     for (size_t piece_id = 0; piece_id < data.size(); ++piece_id)
+//     {
+//         auto ofs = std::ofstream("/Db/share/" + data_id + "/" + std::to_string(piece_id));
+//         ofs << data[piece_id];
+//         ofs.close();
+//     }
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     auto read_data = cc_to_db->readTable(data_id);
+
+//     std::vector<std::vector<std::string>> true_table = {
+//         {"1", "2"}, {"3", "4"}, {"5", "6"}, {"7", "8"}, {"9", "10"}};
+//     EXPECT_EQ(true_table, read_data);
+
+//     initialize(data_id);
+// }
+// TEST(ComputationToDbTest, SuccessReadTableLargeTest)
+// {
+//     std::string data_id = "SuccessReadTableLargeTest";
+//     initialize(data_id);
+
+//     constexpr int H = 500;
+//     constexpr int W = 500;
+//     std::vector<std::string> schema;
+//     for (int i = 0; i < W; i++) schema.emplace_back("attr" + std::to_string(i + 1));
+//     std::vector<std::string> data;
+//     for (int i = 0; i < W; ++i) data.emplace_back(std::to_string(i + 1));
+
+//     fs::create_directories("/Db/share/" + data_id);
+//     for (int piece_id = 0; piece_id < H; ++piece_id)
+//     {
+//         nlohmann::json data_json = {
+//             {"data_id", data_id},
+//             {"value", {data}},
+//             {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
+//         auto data_str = data_json.dump();
+
+//         auto ofs = std::ofstream("/Db/share/" + data_id + "/" + std::to_string(piece_id));
+//         ofs << data_str;
+//         ofs.close();
+//     }
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     auto read_data = cc_to_db->readTable(data_id);
+
+//     std::vector<std::vector<std::string>> true_data;
+//     for (int i = 0; i < H; i++) true_data.push_back(data);
+//     EXPECT_EQ(true_data, read_data);
+
+//     initialize(data_id);
+// }
+
+// // schemaの取り出し
+// // qmpc::ComputationToDb::ValueTable Client::readSchema(const std::string &data_id);
+// TEST(ComputationToDbTest, SuccessReadSchemaTest)
+// {
+//     const std::string data_id = "SuccessReadSchemaTest";
+//     initialize(data_id);
+
+//     const std::string data = R"({"value":[["1","2"],["3","4"]])"
+//                              R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
+//     fs::create_directories("/Db/share/" + data_id);
+//     auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
+//     ofs << data;
+//     ofs.close();
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     auto read_data = cc_to_db->readSchema(data_id);
+
+//     std::vector<std::string> true_schema = {"attr1", "attr2"};
+//     EXPECT_EQ(true_schema, read_data);
+
+//     initialize(data_id);
+// }
+
+// // Job を DB に新規登録する
+// // void Client::registerJob(const std::string &job_uuid, const int &status);
+// TEST(ComputationToDbTest, SuccessRregisterJobTest)
+// {
+//     const std::string job_uuid = "SuccessRregisterJobTest";
+//     initialize(job_uuid);
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     cc_to_db->registerJob(job_uuid, pb_common_types::JobStatus::UNKNOWN);
+
+//     auto exist = fs::exists("/Db/result/" + job_uuid);
+//     EXPECT_TRUE(exist);
+
+//     initialize(job_uuid);
+// }
+
+// // Job の実行状態を更新する
+// // void Client::updateJobStatus(const std::string &job_uuid, const int &status);
+// TEST(ComputationToDbTest, SuccessupdateJobStatusTest)
+// {
+//     const std::string job_uuid = "SuccessupdateJobStatusTest";
+//     initialize(job_uuid);
+
+//     fs::create_directories("/Db/result/" + job_uuid);
+//     const google::protobuf::EnumDescriptor *descriptor =
+//         google::protobuf::GetEnumDescriptor<pb_common_types::JobStatus>();
+//     for (int status = 0;; ++status)
+//     {
+//         auto ptr = descriptor->FindValueByNumber(status);
+//         if (ptr == nullptr) break;
+
+//         auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//         cc_to_db->updateJobStatus(job_uuid, status);
+
+//         auto exist = fs::exists("/Db/result/" + job_uuid + "/status_" + ptr->name());
+//         EXPECT_TRUE(exist);
+//     }
+
+//     initialize(job_uuid);
+// }
+
+// // resultの保存
+// // template <class T>
+// // void writeComputationResult(const std::string &job_uuid, const T &results, int piece_size);
+// TEST(ComputationToDbTest, SuccessWriteComputationResultArrayTest)
+// {
+//     const std::string job_uuid = "WriteComputaSuccessWriteComputationResultArrayTest";
+//     initialize(job_uuid);
+
+//     const std::vector<std::string> data = {"12", "15", "21"};
+//     fs::create_directories("/Db/result/" + job_uuid);
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     cc_to_db->writeComputationResult(job_uuid, data);
+
+//     auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim1_0");
+//     std::string read_data;
+//     getline(ifs, read_data);
+//     const auto true_data = R"({"job_uuid":"WriteComputaSuccessWriteComputationResultArrayTest")"
+//                            R"(,"meta":{"column_number":3,"piece_id":0})"
+//                            R"(,"result":["12","15","21"]})";
+//     EXPECT_EQ(read_data, true_data);
+
+//     initialize(job_uuid);
+// }
+// TEST(ComputationToDbTest, SuccessWriteComputationResultArray2dimTest)
+// {
+//     const std::string job_uuid = "SuccessWriteComputationResultArray2dimTest";
+//     initialize(job_uuid);
+
+//     const std::vector<std::vector<std::string>> data = {{"12", "15"}, {"21", "51"}};
+//     fs::create_directories("/Db/result/" + job_uuid);
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     cc_to_db->writeComputationResult(job_uuid, data);
+
+//     auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim2_0");
+//     std::string read_data;
+//     getline(ifs, read_data);
+//     const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultArray2dimTest")"
+//                            R"(,"meta":{"column_number":2,"piece_id":0})"
+//                            R"(,"result":["12","15","21","51"]})";
+//     EXPECT_EQ(read_data, true_data);
+
+//     initialize(job_uuid);
+// }
+
+// TEST(ComputationToDbTest, SuccessWriteComputationResultSchemaTest)
+// {
+//     const std::string job_uuid = "SuccessWriteComputationResultSchemaTest";
+//     initialize(job_uuid);
+
+//     const std::vector<std::string> schema = {"s1", "s2", "s3"};
+//     fs::create_directories("/Db/result/" + job_uuid);
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     cc_to_db->writeComputationResult(job_uuid, schema, true);
+
+//     auto ifs = std::ifstream("/Db/result/" + job_uuid + "/schema_0");
+//     std::string read_data;
+//     getline(ifs, read_data);
+//     const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultSchemaTest")"
+//                            R"(,"meta":{"column_number":3,"piece_id":0})"
+//                            R"(,"result":["s1","s2","s3"]})";
+//     EXPECT_EQ(read_data, true_data);
+
+//     initialize(job_uuid);
+// }
+// TEST(ComputationToDbTest, SuccessWriteComputationResultTableTest)
+// {
+//     const std::string job_uuid = "SuccessWriteComputationResultTableTest";
+//     initialize(job_uuid);
+
+//     const nlohmann::json data_json = {
+//         {"schema", std::vector<std::string>{"s1", "s2"}},
+//         {"table", std::vector<std::vector<std::string>>{{"1", "2"}, {"3", "4"}}}};
+//     fs::create_directories("/Db/result/" + job_uuid);
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     cc_to_db->writeComputationResult(job_uuid, data_json, false);
+
+//     auto ifs_schema = std::ifstream("/Db/result/" + job_uuid + "/schema_0");
+//     std::string read_data_schema;
+//     getline(ifs_schema, read_data_schema);
+//     const auto true_data_schema = R"({"job_uuid":"SuccessWriteComputationResultTableTest")"
+//                                   R"(,"meta":{"column_number":2,"piece_id":0})"
+//                                   R"(,"result":["s1","s2"]})";
+//     EXPECT_EQ(read_data_schema, true_data_schema);
+
+//     auto ifs_table = std::ifstream("/Db/result/" + job_uuid + "/dim2_0");
+//     std::string read_data_table;
+//     getline(ifs_table, read_data_table);
+//     const auto true_data_table = R"({"job_uuid":"SuccessWriteComputationResultTableTest")"
+//                                  R"(,"meta":{"column_number":2,"piece_id":0})"
+//                                  R"(,"result":["1","2","3","4"]})";
+//     EXPECT_EQ(read_data_table, true_data_table);
+
+//     initialize(job_uuid);
+// }
+
+// TEST(ComputationToDbTest, SuccessWriteComputationResultArrayPieceTest)
+// {
+//     const std::string job_uuid = "SuccessWriteComputationResultArrayPieceTest";
+//     initialize(job_uuid);
+
+//     const std::vector<std::vector<std::string>> data = {{"12", "15", "21"}};
+//     fs::create_directories("/Db/result/" + job_uuid);
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     cc_to_db->writeComputationResult(job_uuid, data, false, 4);
+
+//     std::vector<std::string> true_result = {R"(["12"])", R"(["15"])", R"(["21"])"};
+//     for (size_t piece_id = 0; piece_id < true_result.size(); ++piece_id)
+//     {
+//         auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim2_" + std::to_string(piece_id));
+//         std::string read_data;
+//         getline(ifs, read_data);
+//         const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultArrayPieceTest")"
+//                                R"(,"meta":{"column_number":3,"piece_id":)"
+//                                + std::to_string(piece_id) + R"(},"result":)" +
+//                                true_result[piece_id]
+//                                + R"(})";
+//         EXPECT_EQ(read_data, true_data);
+//     }
+
+//     initialize(job_uuid);
+// }
+
+// TEST(ComputationToDbTest, SuccessWriteComputationResultCompletedTest)
+// {
+//     const std::string job_uuid = "WriteComputationResultTestId";
+//     initialize(job_uuid);
+
+//     const std::vector<std::vector<std::string>> data = {{"12", "15", "21"}};
+//     fs::create_directories("/Db/result/" + job_uuid);
+
+//     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+//     cc_to_db->writeComputationResult(job_uuid, data);
+
+//     auto exist = fs::exists("/Db/result/" + job_uuid + "/completed");
+//     EXPECT_TRUE(exist);
+
+//     initialize(job_uuid);
+// }
+TEST(ComputationToDbTest, SuccessGetTableTest)
 {
-    const std::string data_id = "SuccessReadTableTest";
+    const std::string data_id = "SuccessGetTableTest";
     initialize(data_id);
 
     const std::string data = R"({"value":[["1","2"],["3","4"]])"
@@ -26,10 +320,11 @@ TEST(ComputationToDbTest, SuccessReadTableTest)
     ofs << data;
     ofs.close();
 
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readTable(data_id);
+    qmpc::ComputationToDb::ValueTable vt(data_id);
+    auto table = vt.getTable();
 
     std::vector<std::vector<std::string>> true_table = {{"1", "2"}, {"3", "4"}};
+<<<<<<< HEAD:packages/server/computation_container/test/unit_test/ctodb_test.cpp
     EXPECT_EQ(true_table, read_data);
 
     initialize(data_id);
@@ -95,15 +390,16 @@ TEST(ComputationToDbTest, SuccessReadTableLargeTest)
     std::vector<std::vector<std::string>> true_data;
     for (int i = 0; i < H; i++) true_data.push_back(data);
     EXPECT_EQ(true_data, read_data);
+=======
+    EXPECT_EQ(true_table, table);
+>>>>>>> d23aa59 (Update ValueTable to save only data_id):packages/server/ComputationContainer/Test/UnitTest/CtoDBTest.cpp
 
     initialize(data_id);
 }
 
-// schemaの取り出し
-// qmpc::ComputationToDb::ValueTable Client::readSchema(const std::string &data_id);
-TEST(ComputationToDbTest, SuccessReadSchemaTest)
+TEST(ComputationToDbTest, SuccessGetSchemasTest)
 {
-    const std::string data_id = "SuccessReadSchemaTest";
+    const std::string data_id = "SuccessGetSchemasTest";
     initialize(data_id);
 
     const std::string data = R"({"value":[["1","2"],["3","4"]])"
@@ -113,14 +409,15 @@ TEST(ComputationToDbTest, SuccessReadSchemaTest)
     ofs << data;
     ofs.close();
 
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readSchema(data_id);
+    qmpc::ComputationToDb::ValueTable vt(data_id);
+    auto schema = vt.getSchemas();
 
     std::vector<std::string> true_schema = {"attr1", "attr2"};
-    EXPECT_EQ(true_schema, read_data);
+    EXPECT_EQ(true_schema, schema);
 
     initialize(data_id);
 }
+<<<<<<< HEAD:packages/server/computation_container/test/unit_test/ctodb_test.cpp
 
 // Job を DB に新規登録する
 // void Client::registerJob(const std::string &job_uuid, const int &status);
@@ -146,7 +443,7 @@ TEST(ComputationToDbTest, SuccessupdateJobStatusTest)
     initialize(job_uuid);
 
     fs::create_directories("/db/result/" + job_uuid);
-    const google::protobuf::EnumDescriptor *descriptor =
+    const google::protobuf::EnumDescriptor* descriptor =
         google::protobuf::GetEnumDescriptor<pb_common_types::JobStatus>();
     for (int status = 0;; ++status)
     {
@@ -305,3 +602,5 @@ TEST(ComputationToDbTest, SuccessWriteComputationResultCompletedTest)
 
     initialize(job_uuid);
 }
+=======
+>>>>>>> d23aa59 (Update ValueTable to save only data_id):packages/server/ComputationContainer/Test/UnitTest/CtoDBTest.cpp

--- a/packages/server/computation_container/test/unit_test/ctodb_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctodb_test.cpp
@@ -15,7 +15,7 @@ auto initialize(const std::string& id)
 }
 
 // tableの取り出し
-// qmpc::ComputationToDb::ValueTable Client::readTable(const std::string &data_id);
+// qmpc::ComputationToDb::ValueTable Client::readTable(const std::string& data_id);
 TEST(ComputationToDbTest, SuccessReadTableTest)
 {
     const std::string data_id = "SuccessReadTableTest";
@@ -23,8 +23,8 @@ TEST(ComputationToDbTest, SuccessReadTableTest)
 
     const std::string data = R"({"value":[["1","2"],["3","4"]])"
                              R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
-    fs::create_directories("/Db/share/" + data_id);
-    auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
+    fs::create_directories("/db/share/" + data_id);
+    auto ofs = std::ofstream("/db/share/" + data_id + "/0");
     ofs << data;
     ofs.close();
 
@@ -48,10 +48,10 @@ TEST(ComputationToDbTest, SuccessReadTablePieceTest)
         R"(,"meta":{"piece_id":1,"schema":["attr1","attr2"]}})",
         R"({"value":[["9","10"]])"
         R"(,"meta":{"piece_id":2,"schema":["attr1","attr2"]}})"};
-    fs::create_directories("/Db/share/" + data_id);
+    fs::create_directories("/db/share/" + data_id);
     for (size_t piece_id = 0; piece_id < data.size(); ++piece_id)
     {
-        auto ofs = std::ofstream("/Db/share/" + data_id + "/" + std::to_string(piece_id));
+        auto ofs = std::ofstream("/db/share/" + data_id + "/" + std::to_string(piece_id));
         ofs << data[piece_id];
         ofs.close();
     }
@@ -77,7 +77,7 @@ TEST(ComputationToDbTest, SuccessReadTableLargeTest)
     std::vector<std::string> data;
     for (int i = 0; i < W; ++i) data.emplace_back(std::to_string(i + 1));
 
-    fs::create_directories("/Db/share/" + data_id);
+    fs::create_directories("/db/share/" + data_id);
     for (int piece_id = 0; piece_id < H; ++piece_id)
     {
         nlohmann::json data_json = {
@@ -86,7 +86,7 @@ TEST(ComputationToDbTest, SuccessReadTableLargeTest)
             {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
         auto data_str = data_json.dump();
 
-        auto ofs = std::ofstream("/Db/share/" + data_id + "/" + std::to_string(piece_id));
+        auto ofs = std::ofstream("/db/share/" + data_id + "/" + std::to_string(piece_id));
         ofs << data_str;
         ofs.close();
     }
@@ -110,8 +110,8 @@ TEST(ComputationToDbTest, SuccessReadSchemaTest)
 
     const std::string data = R"({"value":[["1","2"],["3","4"]])"
                              R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
-    fs::create_directories("/Db/share/" + data_id);
-    auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
+    fs::create_directories("/db/share/" + data_id);
+    auto ofs = std::ofstream("/db/share/" + data_id + "/0");
     ofs << data;
     ofs.close();
 
@@ -123,301 +123,6 @@ TEST(ComputationToDbTest, SuccessReadSchemaTest)
 
     initialize(data_id);
 }
-
-// Job を DB に新規登録する
-// void Client::registerJob(const std::string &job_uuid, const int &status);
-TEST(ComputationToDbTest, SuccessRregisterJobTest)
-{
-    const std::string job_uuid = "SuccessRregisterJobTest";
-    initialize(job_uuid);
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    cc_to_db->registerJob(job_uuid, pb_common_types::JobStatus::UNKNOWN);
-
-    auto exist = fs::exists("/Db/result/" + job_uuid);
-    EXPECT_TRUE(exist);
-
-    initialize(job_uuid);
-}
-
-// Job の実行状態を更新する
-// void Client::updateJobStatus(const std::string &job_uuid, const int &status);
-TEST(ComputationToDbTest, SuccessupdateJobStatusTest)
-{
-    const std::string job_uuid = "SuccessupdateJobStatusTest";
-    initialize(job_uuid);
-
-    fs::create_directories("/Db/result/" + job_uuid);
-    const google::protobuf::EnumDescriptor* descriptor =
-        google::protobuf::GetEnumDescriptor<pb_common_types::JobStatus>();
-    for (int status = 0;; ++status)
-    {
-        auto ptr = descriptor->FindValueByNumber(status);
-        if (ptr == nullptr) break;
-
-        auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-        cc_to_db->updateJobStatus(job_uuid, status);
-
-        auto exist = fs::exists("/Db/result/" + job_uuid + "/status_" + ptr->name());
-        EXPECT_TRUE(exist);
-    }
-
-    initialize(job_uuid);
-}
-
-// resultの保存
-// template <class T>
-// void writeComputationResult(const std::string &job_uuid, const T &results, int piece_size);
-TEST(ComputationToDbTest, SuccessWriteComputationResultArrayTest)
-{
-    const std::string job_uuid = "WriteComputaSuccessWriteComputationResultArrayTest";
-    initialize(job_uuid);
-
-    const std::vector<std::string> data = {"12", "15", "21"};
-    fs::create_directories("/Db/result/" + job_uuid);
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    cc_to_db->writeComputationResult(job_uuid, data);
-
-    auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim1_0");
-    std::string read_data;
-    getline(ifs, read_data);
-    const auto true_data = R"({"job_uuid":"WriteComputaSuccessWriteComputationResultArrayTest")"
-                           R"(,"meta":{"column_number":3,"piece_id":0})"
-                           R"(,"result":["12","15","21"]})";
-    EXPECT_EQ(read_data, true_data);
-
-    initialize(job_uuid);
-}
-TEST(ComputationToDbTest, SuccessWriteComputationResultArray2dimTest)
-{
-    const std::string job_uuid = "SuccessWriteComputationResultArray2dimTest";
-    initialize(job_uuid);
-
-    const std::vector<std::vector<std::string>> data = {{"12", "15"}, {"21", "51"}};
-    fs::create_directories("/Db/result/" + job_uuid);
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    cc_to_db->writeComputationResult(job_uuid, data);
-
-    auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim2_0");
-    std::string read_data;
-    getline(ifs, read_data);
-    const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultArray2dimTest")"
-                           R"(,"meta":{"column_number":2,"piece_id":0})"
-                           R"(,"result":["12","15","21","51"]})";
-    EXPECT_EQ(read_data, true_data);
-
-    initialize(job_uuid);
-}
-
-TEST(ComputationToDbTest, SuccessWriteComputationResultSchemaTest)
-{
-    const std::string job_uuid = "SuccessWriteComputationResultSchemaTest";
-    initialize(job_uuid);
-
-    const std::vector<std::string> schema = {"s1", "s2", "s3"};
-    fs::create_directories("/Db/result/" + job_uuid);
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    cc_to_db->writeComputationResult(job_uuid, schema, true);
-
-    auto ifs = std::ifstream("/Db/result/" + job_uuid + "/schema_0");
-    std::string read_data;
-    getline(ifs, read_data);
-    const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultSchemaTest")"
-                           R"(,"meta":{"column_number":3,"piece_id":0})"
-                           R"(,"result":["s1","s2","s3"]})";
-    EXPECT_EQ(read_data, true_data);
-
-    initialize(job_uuid);
-}
-TEST(ComputationToDbTest, SuccessWriteComputationResultTableTest)
-{
-    const std::string job_uuid = "SuccessWriteComputationResultTableTest";
-    initialize(job_uuid);
-
-    const nlohmann::json data_json = {
-        {"schema", std::vector<std::string>{"s1", "s2"}},
-        {"table", std::vector<std::vector<std::string>>{{"1", "2"}, {"3", "4"}}}};
-    fs::create_directories("/Db/result/" + job_uuid);
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    cc_to_db->writeComputationResult(job_uuid, data_json, false);
-
-    auto ifs_schema = std::ifstream("/Db/result/" + job_uuid + "/schema_0");
-    std::string read_data_schema;
-    getline(ifs_schema, read_data_schema);
-    const auto true_data_schema = R"({"job_uuid":"SuccessWriteComputationResultTableTest")"
-                                  R"(,"meta":{"column_number":2,"piece_id":0})"
-                                  R"(,"result":["s1","s2"]})";
-    EXPECT_EQ(read_data_schema, true_data_schema);
-
-    auto ifs_table = std::ifstream("/Db/result/" + job_uuid + "/dim2_0");
-    std::string read_data_table;
-    getline(ifs_table, read_data_table);
-    const auto true_data_table = R"({"job_uuid":"SuccessWriteComputationResultTableTest")"
-                                 R"(,"meta":{"column_number":2,"piece_id":0})"
-                                 R"(,"result":["1","2","3","4"]})";
-    EXPECT_EQ(read_data_table, true_data_table);
-
-    initialize(job_uuid);
-}
-
-TEST(ComputationToDbTest, SuccessWriteComputationResultArrayPieceTest)
-{
-    const std::string job_uuid = "SuccessWriteComputationResultArrayPieceTest";
-    initialize(job_uuid);
-
-    const std::vector<std::vector<std::string>> data = {{"12", "15", "21"}};
-    fs::create_directories("/Db/result/" + job_uuid);
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    cc_to_db->writeComputationResult(job_uuid, data, false, 4);
-
-    std::vector<std::string> true_result = {R"(["12"])", R"(["15"])", R"(["21"])"};
-    for (size_t piece_id = 0; piece_id < true_result.size(); ++piece_id)
-    {
-        auto ifs = std::ifstream("/Db/result/" + job_uuid + "/dim2_" + std::to_string(piece_id));
-        std::string read_data;
-        getline(ifs, read_data);
-        const auto true_data = R"({"job_uuid":"SuccessWriteComputationResultArrayPieceTest")"
-                               R"(,"meta":{"column_number":3,"piece_id":)"
-                               + std::to_string(piece_id) + R"(},"result":)" + true_result[piece_id]
-                               + R"(})";
-        EXPECT_EQ(read_data, true_data);
-    }
-
-    initialize(job_uuid);
-}
-
-TEST(ComputationToDbTest, SuccessWriteComputationResultCompletedTest)
-{
-    const std::string job_uuid = "WriteComputationResultTestId";
-    initialize(job_uuid);
-
-    const std::vector<std::vector<std::string>> data = {{"12", "15", "21"}};
-    fs::create_directories("/Db/result/" + job_uuid);
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    cc_to_db->writeComputationResult(job_uuid, data);
-
-    auto exist = fs::exists("/Db/result/" + job_uuid + "/completed");
-    EXPECT_TRUE(exist);
-
-    initialize(job_uuid);
-}
-
-TEST(ComputationToDbTest, SuccessGetTableTest)
-{
-    const std::string data_id = "SuccessGetTableTest";
-    initialize(data_id);
-
-    const std::string data = R"({"value":[["1","2"],["3","4"]])"
-                             R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
-    fs::create_directories("/db/share/" + data_id);
-    auto ofs = std::ofstream("/db/share/" + data_id + "/0");
-    ofs << data;
-    ofs.close();
-
-    qmpc::ComputationToDb::ValueTable vt(data_id);
-    auto table = vt.getTable();
-
-    std::vector<std::vector<std::string>> true_table = {{"1", "2"}, {"3", "4"}};
-<<<<<<< HEAD:packages/server/computation_container/test/unit_test/ctodb_test.cpp
-    EXPECT_EQ(true_table, read_data);
-
-    initialize(data_id);
-}
-TEST(ComputationToDbTest, SuccessReadTablePieceTest)
-{
-    const std::string data_id = "SuccessReadTablePieceTest";
-    initialize(data_id);
-
-    const std::vector<std::string> data = {
-        R"({"value":[["1","2"],["3","4"]])"
-        R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})",
-        R"({"value":[["5","6"],["7","8"]])"
-        R"(,"meta":{"piece_id":1,"schema":["attr1","attr2"]}})",
-        R"({"value":[["9","10"]])"
-        R"(,"meta":{"piece_id":2,"schema":["attr1","attr2"]}})"};
-    fs::create_directories("/db/share/" + data_id);
-    for (size_t piece_id = 0; piece_id < data.size(); ++piece_id)
-    {
-        auto ofs = std::ofstream("/db/share/" + data_id + "/" + std::to_string(piece_id));
-        ofs << data[piece_id];
-        ofs.close();
-    }
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readTable(data_id);
-
-    std::vector<std::vector<std::string>> true_table = {
-        {"1", "2"}, {"3", "4"}, {"5", "6"}, {"7", "8"}, {"9", "10"}};
-    EXPECT_EQ(true_table, read_data);
-
-    initialize(data_id);
-}
-TEST(ComputationToDbTest, SuccessReadTableLargeTest)
-{
-    std::string data_id = "SuccessReadTableLargeTest";
-    initialize(data_id);
-
-    constexpr int H = 500;
-    constexpr int W = 500;
-    std::vector<std::string> schema;
-    for (int i = 0; i < W; i++) schema.emplace_back("attr" + std::to_string(i + 1));
-    std::vector<std::string> data;
-    for (int i = 0; i < W; ++i) data.emplace_back(std::to_string(i + 1));
-
-    fs::create_directories("/db/share/" + data_id);
-    for (int piece_id = 0; piece_id < H; ++piece_id)
-    {
-        nlohmann::json data_json = {
-            {"data_id", data_id},
-            {"value", {data}},
-            {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
-        auto data_str = data_json.dump();
-
-        auto ofs = std::ofstream("/db/share/" + data_id + "/" + std::to_string(piece_id));
-        ofs << data_str;
-        ofs.close();
-    }
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readTable(data_id);
-
-    std::vector<std::vector<std::string>> true_data;
-    for (int i = 0; i < H; i++) true_data.push_back(data);
-    EXPECT_EQ(true_data, read_data);
-=======
-    EXPECT_EQ(true_table, table);
->>>>>>> d23aa59 (Update ValueTable to save only data_id):packages/server/ComputationContainer/Test/UnitTest/CtoDBTest.cpp
-
-    initialize(data_id);
-}
-
-TEST(ComputationToDbTest, SuccessGetSchemasTest)
-{
-    const std::string data_id = "SuccessGetSchemasTest";
-    initialize(data_id);
-
-    const std::string data = R"({"value":[["1","2"],["3","4"]])"
-                             R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
-    fs::create_directories("/Db/share/" + data_id);
-    auto ofs = std::ofstream("/Db/share/" + data_id + "/0");
-    ofs << data;
-    ofs.close();
-
-    qmpc::ComputationToDb::ValueTable vt(data_id);
-    auto schema = vt.getSchemas();
-
-    std::vector<std::string> true_schema = {"attr1", "attr2"};
-    EXPECT_EQ(true_schema, schema);
-
-    initialize(data_id);
-}
-<<<<<<< HEAD:packages/server/computation_container/test/unit_test/ctodb_test.cpp
 
 // Job を DB に新規登録する
 // void Client::registerJob(const std::string &job_uuid, const int &status);
@@ -602,5 +307,129 @@ TEST(ComputationToDbTest, SuccessWriteComputationResultCompletedTest)
 
     initialize(job_uuid);
 }
-=======
->>>>>>> d23aa59 (Update ValueTable to save only data_id):packages/server/ComputationContainer/Test/UnitTest/CtoDBTest.cpp
+
+TEST(ComputationToDbTest, SuccessGetTableTest)
+{
+    const std::string data_id = "SuccessGetTableTest";
+    initialize(data_id);
+
+    const std::string data = R"({"value":[["1","2"],["3","4"]])"
+                             R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
+    fs::create_directories("/db/share/" + data_id);
+    auto ofs = std::ofstream("/db/share/" + data_id + "/0");
+    ofs << data;
+    ofs.close();
+
+    qmpc::ComputationToDb::ValueTable vt(data_id);
+    auto table = vt.getTable();
+
+    std::vector<std::vector<std::string>> true_table = {{"1", "2"}, {"3", "4"}};
+<<<<<<< HEAD:packages/server/computation_container/test/unit_test/ctodb_test.cpp
+    EXPECT_EQ(true_table, read_data);
+
+    initialize(data_id);
+}
+TEST(ComputationToDbTest, SuccessReadTablePieceTest)
+{
+    const std::string data_id = "SuccessReadTablePieceTest";
+    initialize(data_id);
+
+    const std::vector<std::string> data = {
+        R"({"value":[["1","2"],["3","4"]])"
+        R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})",
+        R"({"value":[["5","6"],["7","8"]])"
+        R"(,"meta":{"piece_id":1,"schema":["attr1","attr2"]}})",
+        R"({"value":[["9","10"]])"
+        R"(,"meta":{"piece_id":2,"schema":["attr1","attr2"]}})"};
+    fs::create_directories("/db/share/" + data_id);
+    for (size_t piece_id = 0; piece_id < data.size(); ++piece_id)
+    {
+        auto ofs = std::ofstream("/db/share/" + data_id + "/" + std::to_string(piece_id));
+        ofs << data[piece_id];
+        ofs.close();
+    }
+
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    auto read_data = cc_to_db->readTable(data_id);
+
+    std::vector<std::vector<std::string>> true_table = {
+        {"1", "2"}, {"3", "4"}, {"5", "6"}, {"7", "8"}, {"9", "10"}};
+    EXPECT_EQ(true_table, read_data);
+
+    initialize(data_id);
+}
+TEST(ComputationToDbTest, SuccessReadTableLargeTest)
+{
+    std::string data_id = "SuccessReadTableLargeTest";
+    initialize(data_id);
+
+    constexpr int H = 500;
+    constexpr int W = 500;
+    std::vector<std::string> schema;
+    for (int i = 0; i < W; i++) schema.emplace_back("attr" + std::to_string(i + 1));
+    std::vector<std::string> data;
+    for (int i = 0; i < W; ++i) data.emplace_back(std::to_string(i + 1));
+
+    fs::create_directories("/db/share/" + data_id);
+    for (int piece_id = 0; piece_id < H; ++piece_id)
+    {
+        nlohmann::json data_json = {
+            {"data_id", data_id},
+            {"value", {data}},
+            {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
+        auto data_str = data_json.dump();
+
+        auto ofs = std::ofstream("/db/share/" + data_id + "/" + std::to_string(piece_id));
+        ofs << data_str;
+        ofs.close();
+    }
+
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    auto read_data = cc_to_db->readTable(data_id);
+
+    std::vector<std::vector<std::string>> true_data;
+    for (int i = 0; i < H; i++) true_data.push_back(data);
+    EXPECT_EQ(true_data, read_data);
+
+    initialize(data_id);
+}
+
+TEST(ComputationToDbTest, SuccessGetSchemasTest)
+{
+    const std::string data_id = "SuccessGetSchemasTest";
+    initialize(data_id);
+
+    const std::string data = R"({"value":[["1","2"],["3","4"]])"
+                             R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})";
+    fs::create_directories("/db/share/" + data_id);
+    auto ofs = std::ofstream("/db/share/" + data_id + "/0");
+    ofs << data;
+    ofs.close();
+
+    qmpc::ComputationToDb::ValueTable vt(data_id);
+    auto schema = vt.getSchemas();
+
+    std::vector<std::string> true_schema = {"attr1", "attr2"};
+    EXPECT_EQ(true_schema, schema);
+
+    initialize(data_id);
+}
+
+TEST(ComputationToDbTest, SuccessWriteTableTest)
+{
+    initialize("tmp");
+
+    std::vector<std::vector<std::string>> table = {{"1", "2"}, {"3", "4"}};
+    std::vector<std::string> schema = {"attr1", "attr2"};
+
+    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
+    auto data_id = cc_to_db->writeTable(table, schema);
+
+    auto ifs = std::ifstream("/db/share/" + data_id + "/0");
+    std::string data;
+    getline(ifs, data);
+
+    std::string true_data = R"({"meta":{"piece_id":0,"schema":["attr1","attr2"]})"
+                            R"(,"value":[["1","2"],["3","4"]]})";
+    EXPECT_EQ(true_data, data);
+}

--- a/packages/server/computation_container/test/unit_test/ctodb_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctodb_test.cpp
@@ -340,72 +340,7 @@ TEST(ComputationToDbTest, SuccessGetTableTest)
     auto table = vt.getTable();
 
     std::vector<std::vector<std::string>> true_table = {{"1", "2"}, {"3", "4"}};
-<<<<<<< HEAD:packages/server/computation_container/test/unit_test/ctodb_test.cpp
-    EXPECT_EQ(true_table, read_data);
-
-    initialize(data_id);
-}
-TEST(ComputationToDbTest, SuccessReadTablePieceTest)
-{
-    const std::string data_id = "SuccessReadTablePieceTest";
-    initialize(data_id);
-
-    const std::vector<std::string> data = {
-        R"({"value":[["1","2"],["3","4"]])"
-        R"(,"meta":{"piece_id":0,"schema":["attr1","attr2"]}})",
-        R"({"value":[["5","6"],["7","8"]])"
-        R"(,"meta":{"piece_id":1,"schema":["attr1","attr2"]}})",
-        R"({"value":[["9","10"]])"
-        R"(,"meta":{"piece_id":2,"schema":["attr1","attr2"]}})"};
-    fs::create_directories("/db/share/" + data_id);
-    for (size_t piece_id = 0; piece_id < data.size(); ++piece_id)
-    {
-        auto ofs = std::ofstream("/db/share/" + data_id + "/" + std::to_string(piece_id));
-        ofs << data[piece_id];
-        ofs.close();
-    }
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readTable(data_id);
-
-    std::vector<std::vector<std::string>> true_table = {
-        {"1", "2"}, {"3", "4"}, {"5", "6"}, {"7", "8"}, {"9", "10"}};
-    EXPECT_EQ(true_table, read_data);
-
-    initialize(data_id);
-}
-TEST(ComputationToDbTest, SuccessReadTableLargeTest)
-{
-    std::string data_id = "SuccessReadTableLargeTest";
-    initialize(data_id);
-
-    constexpr int H = 500;
-    constexpr int W = 500;
-    std::vector<std::string> schema;
-    for (int i = 0; i < W; i++) schema.emplace_back("attr" + std::to_string(i + 1));
-    std::vector<std::string> data;
-    for (int i = 0; i < W; ++i) data.emplace_back(std::to_string(i + 1));
-
-    fs::create_directories("/db/share/" + data_id);
-    for (int piece_id = 0; piece_id < H; ++piece_id)
-    {
-        nlohmann::json data_json = {
-            {"data_id", data_id},
-            {"value", {data}},
-            {"meta", {{"piece_id", piece_id}, {"schema", schema}}}};
-        auto data_str = data_json.dump();
-
-        auto ofs = std::ofstream("/db/share/" + data_id + "/" + std::to_string(piece_id));
-        ofs << data_str;
-        ofs.close();
-    }
-
-    auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto read_data = cc_to_db->readTable(data_id);
-
-    std::vector<std::vector<std::string>> true_data;
-    for (int i = 0; i < H; i++) true_data.push_back(data);
-    EXPECT_EQ(true_data, read_data);
+    EXPECT_EQ(true_table, table);
 
     initialize(data_id);
 }

--- a/packages/server/computation_container/test/unit_test/ctodb_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctodb_test.cpp
@@ -417,13 +417,14 @@ TEST(ComputationToDbTest, SuccessGetSchemasTest)
 
 TEST(ComputationToDbTest, SuccessWriteTableTest)
 {
-    initialize("tmp");
+    const std::string data_id = "SuccessWriteTableTest";
+    initialize(data_id);
 
     std::vector<std::vector<std::string>> table = {{"1", "2"}, {"3", "4"}};
     std::vector<std::string> schema = {"attr1", "attr2"};
 
     auto cc_to_db = qmpc::ComputationToDb::Client::getInstance();
-    auto data_id = cc_to_db->writeTable(table, schema);
+    cc_to_db->writeTable(data_id, table, schema);
 
     auto ifs = std::ifstream("/db/share/" + data_id + "/0");
     std::string data;


### PR DESCRIPTION
# Summary
Update ValueTable to have only data_id

# Purpose
Reduce memory used by join

# Contents
- Update ValueTable class
  - have only data_id
  - save table after join
- Separate ValueTable from DBClient
- Separate read schemas from read table

# Testing Methods Performed
- CI
- make test t=computation_container p=medium
- make test t=libclient p=medium