### PR TITLE
make test&debug terminates mid-process when process fails

### DIFF
--- a/scripts/debugger.sh
+++ b/scripts/debugger.sh
@@ -42,19 +42,17 @@ main() {
     fi
     case $2 in
     all)
-        local ret
-        ret=$tmp
         main $1 build
-        ret=$?
-        if [ $ret -gt 0 ]; then
-            return $ret
+        tmp=$?
+        if [ $tmp -gt 0 ]; then
+            return $tmp
         fi
         main $1 run
-        ret=$(($ret + $?))
-        if [ $ret -gt 0 ]; then
-            return $ret
+        tmp=$?
+        if [ $tmp -gt 0 ]; then
+            return $tmp
         fi
-        return $ret
+        return $tmp
         ;;
     build)
         build
@@ -63,6 +61,7 @@ main() {
             echo "buildで失敗"
             return $tmp
         fi
+        return $tmp
         ;;
     run)
         setup
@@ -85,6 +84,7 @@ main() {
             echo "runで失敗"
             return $tmp
         fi
+        return $tmp
         ;;
     *)
         usage_exit

--- a/scripts/tester.sh
+++ b/scripts/tester.sh
@@ -54,19 +54,17 @@ main() {
     fi
     case $2 in
     all)
-        local ret
-        ret=$tmp
         main $1 build
-        ret=$?
-        if [ $ret -gt 0 ]; then
-            return $ret
+        tmp=$?
+        if [ $tmp -gt 0 ]; then
+            return $tmp
         fi
         main $1 run
-        ret=$(($ret + $?))
-        if [ $ret -gt 0 ]; then
-            return $ret
+        tmp=$?
+        if [ $tmp -gt 0 ]; then
+            return $tmp
         fi
-        return $ret
+        return $tmp
         ;;
     build)
         build


### PR DESCRIPTION
# Summary
make test&debug terminates mid-process when process fails.

# Purpose
With the previous implementation, even if build() failed in a make test, the process continued to the end. This makes it difficult to visually confirm the failure, so we have modified it so that it terminates immediately in the middle of the process.

# Contents
- Modification of tester.sh
- Modification to debugger.sh

# Testing Methods Performed
make test
make debug