### PR TITLE
Remove test section from benchmark

### DIFF
--- a/packages/server/computation_container/test/benchmark/share_benchmark.hpp
+++ b/packages/server/computation_container/test/benchmark/share_benchmark.hpp
@@ -517,7 +517,7 @@ TEST(ShareBench, unarySend)
     );
 }
 
-TEST(ShareBench, vecOpne)
+TEST(ShareBench, vecOpen)
 {
     int N = 20000;
     {

--- a/packages/server/computation_container/test/benchmark/share_benchmark.hpp
+++ b/packages/server/computation_container/test/benchmark/share_benchmark.hpp
@@ -536,7 +536,6 @@ TEST(ShareBench, vecOpne)
         4,
         [&]()
         {
-            std::vector<FixedPoint> expect(N, FixedPoint(108));
             std::vector<Share> a;
 
             std::vector<Share> b;
@@ -548,10 +547,6 @@ TEST(ShareBench, vecOpne)
             auto c = a * b;  // 108
             open(c);
             auto c_rec = recons(c);
-            for (int i = 0; i < N; ++i)
-            {
-                EXPECT_EQ(expect[i], c_rec[i]);
-            }
         }
     );
 }

--- a/scripts/libclient/src/benchmark/test_statistics.py
+++ b/scripts/libclient/src/benchmark/test_statistics.py
@@ -46,12 +46,6 @@ def test_mean(iterate_num: int, size: int, get_data_id):
             res = get_result(qmpc.mean(table, inp), limit=10000)
         assert (res["is_ok"])
 
-        # 正しく計算されたか確認
-        secrets_np = np.array(secrets)
-        true_val = np.add.reduce(secrets_np) / len(secrets)
-        for x, y in zip(res["results"], true_val):
-            assert (math.isclose(x, y, abs_tol=0.1))
-
 
 @pytest.mark.parametrize(
     ("iterate_num", "size"), test_parameters
@@ -66,12 +60,6 @@ def test_sum(iterate_num: int, size: int, get_data_id):
         with PrintTime("sum"):
             res = get_result(qmpc.sum(table, inp), limit=10000)
         assert (res["is_ok"])
-
-        # 正しく計算されたか確認
-        secrets_np = np.array(secrets)
-        true_val = np.add.reduce(secrets_np)
-        for x, y in zip(res["results"], true_val):
-            assert (math.isclose(x, y, abs_tol=0.1))
 
 
 @pytest.mark.parametrize(
@@ -88,12 +76,6 @@ def test_variance(iterate_num: int, size: int, get_data_id):
             res = get_result(qmpc.variance(table, inp), limit=10000)
         assert (res["is_ok"])
 
-        # 正しく計算されたか確認
-        secrets_np = np.array(secrets)
-        true_val = np.var(secrets_np, axis=0)
-        for x, y in zip(res["results"], true_val):
-            assert (math.isclose(x, y, abs_tol=0.1))
-
 
 @pytest.mark.parametrize(
     ("iterate_num", "size"), test_parameters
@@ -109,13 +91,6 @@ def test_correl(iterate_num: int, size: int, get_data_id):
             res = get_result(qmpc.correl(table, inp), limit=10000)
         assert (res["is_ok"])
 
-        # 正しく計算されたか確認
-        secrets_np = np.array(secrets)
-        correl_matrix = np.corrcoef(secrets_np.transpose())
-        true_val = correl_matrix[:schema_size-1, schema_size-1].transpose()
-        for x, y in zip(res["results"][0], true_val):
-            assert (math.isclose(x, y, abs_tol=0.1))
-
 
 @pytest.mark.parametrize(
     ("iterate_num", "size"), test_parameters
@@ -129,17 +104,3 @@ def test_hjoin(iterate_num: int, size: int, get_data_id):
         with PrintTime("hjoin"):
             res = get_result(qmpc.get_join_table(table), limit=10000)
         assert (res["is_ok"])
-
-        # 正しく計算されたか確認
-        exe_schema = res["results"]["schema"]
-        assert (schema1[1:] + schema2[1:] == exe_schema)
-
-        exe_table = res["results"]["table"]
-        exe_table_sorted = sorted(exe_table)
-        true_table = []
-        for r1, r2 in zip(secrets1, secrets2):
-            true_table.append(r1[1:]+r2[1:])
-        true_table_sorted = sorted(true_table)
-        for r1, r2 in zip(true_table_sorted, exe_table_sorted):
-            for x, y in zip(r1, r2):
-                assert (math.isclose(x, y, abs_tol=0.1))

--- a/scripts/libclient/src/benchmark/test_statistics.py
+++ b/scripts/libclient/src/benchmark/test_statistics.py
@@ -20,7 +20,8 @@ def get_data_id():
             res = qmpc.send_share(secrets, schema)
         assert (res["is_ok"])
         data_id: str = res["data_id"]
-        val[(size, data_num)] = (data_id, secrets, schema)
+        schema_size: int = len(schema)
+        val[(size, data_num)] = (data_id, schema_size)
         return val[(size, data_num)]
     return lambda size, data_num=1: get(size, data_num)
 
@@ -36,8 +37,7 @@ test_parameters = [
     ("iterate_num", "size"), test_parameters
 )
 def test_mean(iterate_num: int, size: int, get_data_id):
-    data_id, secrets, schema = get_data_id(size)
-    schema_size: int = len(schema)
+    data_id, schema_size = get_data_id(size)
     for _ in range(iterate_num):
         # table情報と列指定情報を定義して計算
         table = [[data_id], [], [1]]
@@ -51,8 +51,7 @@ def test_mean(iterate_num: int, size: int, get_data_id):
     ("iterate_num", "size"), test_parameters
 )
 def test_sum(iterate_num: int, size: int, get_data_id):
-    data_id, secrets, schema = get_data_id(size)
-    schema_size: int = len(schema)
+    data_id, schema_size = get_data_id(size)
     for _ in range(iterate_num):
         # table情報と列指定情報を定義して計算
         table = [[data_id], [], [1]]
@@ -66,8 +65,7 @@ def test_sum(iterate_num: int, size: int, get_data_id):
     ("iterate_num", "size"), test_parameters
 )
 def test_variance(iterate_num: int, size: int, get_data_id):
-    data_id, secrets, schema = get_data_id(size)
-    schema_size: int = len(schema)
+    data_id, schema_size = get_data_id(size)
     for _ in range(iterate_num):
         # table情報と列指定情報を定義して計算
         table = [[data_id], [], [1]]
@@ -81,8 +79,7 @@ def test_variance(iterate_num: int, size: int, get_data_id):
     ("iterate_num", "size"), test_parameters
 )
 def test_correl(iterate_num: int, size: int, get_data_id):
-    data_id, secrets, schema = get_data_id(size)
-    schema_size: int = len(schema)
+    data_id, schema_size = get_data_id(size)
     for _ in range(iterate_num):
         # table情報と列指定情報を定義して計算
         table = [[data_id], [], [1]]
@@ -96,8 +93,8 @@ def test_correl(iterate_num: int, size: int, get_data_id):
     ("iterate_num", "size"), test_parameters
 )
 def test_hjoin(iterate_num: int, size: int, get_data_id):
-    data_id1, secrets1, schema1 = get_data_id(size, data_num=1)
-    data_id2, secrets2, schema2 = get_data_id(size, data_num=2)
+    data_id1, _ = get_data_id(size, data_num=1)
+    data_id2, _ = get_data_id(size, data_num=2)
     for _ in range(iterate_num):
         # table情報を定義して計算
         table = [[data_id1, data_id2], [2], [1, 1]]


### PR DESCRIPTION
# Summary
Remove test section from benchmark
# Purpose
Because it is not appropriate for a test to be included in a benchmark
# Contents
Remove test section from benchmark
Remove `secret` and `schema` from the return value of `get_data_id` because they are no longer needed
Modify `get_data_id` to return schema_size
Fix typo
# Testing Methods Performed
CI