### PR TITLE
Add retry policy to libclient-py

### DIFF
--- a/packages/client/libclient-py/quickmpc/qmpc_server.py
+++ b/packages/client/libclient-py/quickmpc/qmpc_server.py
@@ -293,7 +293,8 @@ class QMPCServer:
         executor = ThreadPoolExecutor()
         # JobidをMCから貰う関係で単一MC（現在はSP（ID=0）のみ対応）にリクエストを送る
         futures = [executor.submit(self.__retry,
-                                   self.__client_stubs[0].ExecuteComputation, req)]
+                                   self.__client_stubs[0].ExecuteComputation,
+                                   req)]
 
         is_ok, response = QMPCServer.__futures_result(futures)
         job_uuid = response[0].job_uuid if is_ok else None

--- a/packages/client/libclient-py/quickmpc/qmpc_server.py
+++ b/packages/client/libclient-py/quickmpc/qmpc_server.py
@@ -131,6 +131,8 @@ class QMPCServer:
             if enable_progress_bar:
                 futures = tqdm.tqdm(futures, desc='receive')
             response = [f.result() for f in futures]
+        except (QMPCJobError, QMPCServerError):
+            raise
         except Exception as e:
             is_ok = False
             logger.error(e)

--- a/packages/client/libclient-py/quickmpc/qmpc_server.py
+++ b/packages/client/libclient-py/quickmpc/qmpc_server.py
@@ -131,9 +131,9 @@ class QMPCServer:
             if enable_progress_bar:
                 futures = tqdm.tqdm(futures, desc='receive')
             response = [f.result() for f in futures]
-        except Exception:
+        except Exception as e:
             is_ok = False
-            raise
+            logger.error(e)
 
         for b in response:
             if hasattr(b, "is_ok"):

--- a/packages/client/libclient-py/quickmpc/qmpc_server.py
+++ b/packages/client/libclient-py/quickmpc/qmpc_server.py
@@ -47,6 +47,8 @@ class QMPCServer:
     __client_stubs: Tuple[LibcToManageStub] = field(init=False)
     __party_size: int = field(init=False)
     token: str
+    retry_num: int = 10
+    retry_wait_time: int = 5
 
     def __post_init__(self, endpoints: List[str]) -> None:
         stubs = [LibcToManageStub(QMPCServer.__create_grpc_channel(ep))
@@ -90,8 +92,6 @@ class QMPCServer:
 
     @staticmethod
     def __retry(f: Callable, *request: Any) -> Any:
-        retry_num: int = 10
-        retry_wait_time: int = 5
         for _ in range(retry_num):
             try:
                 return f(*request)

--- a/packages/client/libclient-py/quickmpc/qmpc_server.py
+++ b/packages/client/libclient-py/quickmpc/qmpc_server.py
@@ -89,9 +89,9 @@ class QMPCServer:
         return True
 
     @staticmethod
-    def __retry(f:Callable, *request:Any)->Any:
-        retry_num:int = 10
-        retry_wait_time:int = 5
+    def __retry(f: Callable, *request: Any) -> Any:
+        retry_num: int = 10
+        retry_wait_time: int = 5
         for _ in range(retry_num):
             try:
                 return f(*request)
@@ -103,7 +103,8 @@ class QMPCServer:
                 if status is not None:
                     for detail in status.details:
                         if detail.Is(
-                            JobErrorInfo.DESCRIPTOR   # type: ignore[attr-defined]
+                            # type: ignore[attr-defined]
+                            JobErrorInfo.DESCRIPTOR
                         ):
                             # CC で Job 実行時にエラーが発生していた場合
                             # 例外を rethrow する

--- a/packages/client/libclient-py/quickmpc/qmpc_server.py
+++ b/packages/client/libclient-py/quickmpc/qmpc_server.py
@@ -242,7 +242,8 @@ class QMPCServer:
 
         # リクエストパラメータを設定して非同期にリクエスト送信
         executor = ThreadPoolExecutor()
-        futures = [executor.submit(stub.SendShares,
+        futures = [executor.submit(QMPCServer.__retry,
+                                   stub.SendShares,
                                    SendSharesRequest(
                                        data_id=data_id,
                                        shares=json.dumps(s),
@@ -262,7 +263,7 @@ class QMPCServer:
         req = DeleteSharesRequest(dataIds=data_ids, token=self.token)
         # 非同期にリクエスト送信
         executor = ThreadPoolExecutor()
-        futures = [executor.submit(stub.DeleteShares, req)
+        futures = [executor.submit(QMPCServer.__retry, stub.DeleteShares, req)
                    for stub in self.__client_stubs]
         is_ok, _ = QMPCServer.__futures_result(futures)
         return {"is_ok": is_ok}
@@ -291,8 +292,8 @@ class QMPCServer:
         # 非同期にリクエスト送信
         executor = ThreadPoolExecutor()
         # JobidをMCから貰う関係で単一MC（現在はSP（ID=0）のみ対応）にリクエストを送る
-        futures = [executor.submit(
-            self.__client_stubs[0].ExecuteComputation, req)]
+        futures = [executor.submit(QMPCServer.__retry,
+                                   self.__client_stubs[0].ExecuteComputation, req)]
 
         is_ok, response = QMPCServer.__futures_result(futures)
         job_uuid = response[0].job_uuid if is_ok else None
@@ -302,7 +303,8 @@ class QMPCServer:
     def get_data_list(self) -> Dict:
         # 非同期にリクエスト送信
         executor = ThreadPoolExecutor()
-        futures = [executor.submit(stub.GetDataList,
+        futures = [executor.submit(QMPCServer.__retry,
+                                   stub.GetDataList,
                                    GetDataListRequest(token=self.token))
                    for stub in self.__client_stubs]
         is_ok, response = QMPCServer.__futures_result(futures)
@@ -318,7 +320,8 @@ class QMPCServer:
         )
         # 非同期にリクエスト送信
         executor = ThreadPoolExecutor()
-        futures = [executor.submit(stub.GetElapsedTime,
+        futures = [executor.submit(QMPCServer.__retry,
+                                   stub.GetElapsedTime,
                                    req)
                    for stub in self.__client_stubs]
         is_ok, response = QMPCServer.__futures_result(futures)
@@ -336,7 +339,8 @@ class QMPCServer:
         )
         # 非同期にリクエスト送信
         executor = ThreadPoolExecutor()
-        futures = [executor.submit(QMPCServer.__stream_result,
+        futures = [executor.submit(QMPCServer.__retry,
+                                   QMPCServer.__stream_result,
                                    stub.GetComputationResult(req),
                                    job_uuid, party, path)
                    for party, stub in enumerate(self.__client_stubs)]
@@ -409,7 +413,7 @@ class QMPCServer:
         )
         # 非同期にリクエスト送信
         executor = ThreadPoolExecutor()
-        futures = [executor.submit(stub.GetJobErrorInfo, req)
+        futures = [executor.submit(QMPCServer.__retry, stub.GetJobErrorInfo, req)
                    for stub in self.__client_stubs]
         is_ok, response = QMPCServer.__futures_result(
             futures, enable_progress_bar=False)

--- a/packages/client/libclient-py/quickmpc/qmpc_server.py
+++ b/packages/client/libclient-py/quickmpc/qmpc_server.py
@@ -102,7 +102,6 @@ class QMPCServer:
                 if status is not None:
                     for detail in status.details:
                         if detail.Is(
-                            # type: ignore[attr-defined]
                             JobErrorInfo.DESCRIPTOR
                         ):
                             # CC で Job 実行時にエラーが発生していた場合

--- a/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
+++ b/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
@@ -156,12 +156,12 @@ class TestQMPC:
     @pytest.mark.parametrize(
         ("function", "argument"), [
             (qmpc_failed.send_share, send_share_param()),
-            (qmpc_failed.delete_share, []),
+            (qmpc_failed.delete_share, [[]]),
             (qmpc_failed.execute_computation, execute_computation_param()),
-            (qmpc_failed.get_data_list, ()),
-            (qmpc_failed.get_elapsed_time, "uuid"),
-            (qmpc_failed.get_computation_result, ("uuid", None)),
-            (qmpc_failed.get_job_error_info, "uuid"),
+            (qmpc_failed.get_data_list, []),
+            (qmpc_failed.get_elapsed_time, ["uuid"]),
+            (qmpc_failed.get_computation_result, ["uuid", None]),
+            (qmpc_failed.get_job_error_info, ["uuid"]),
         ]
     )
     def test_retry(self, function, argument,

--- a/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
+++ b/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
@@ -155,13 +155,13 @@ class TestQMPC:
 
     @pytest.mark.parametrize(
         ("function", "argument"), [
-            (qmpc_failed.send_share,send_share_param()),
-            (qmpc_failed.delete_share,[]),
+            (qmpc_failed.send_share, send_share_param()),
+            (qmpc_failed.delete_share, []),
             (qmpc_failed.execute_computation, execute_computation_param()),
-            (qmpc_failed.get_data_list,()),
-            (qmpc_failed.get_elapsed_time,"uuid"),
+            (qmpc_failed.get_data_list, ()),
+            (qmpc_failed.get_elapsed_time, "uuid"),
             (qmpc_failed.get_computation_result, ("uuid", None)),
-            (qmpc_failed.get_job_error_info,"uuid"),
+            (qmpc_failed.get_job_error_info, "uuid"),
         ]
     )
     def test_retry(self, function, argument,

--- a/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
+++ b/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
@@ -159,7 +159,8 @@ class TestQMPC:
             (qmpc_failed.get_computation_result, ("uuid", None)),
         ]
     )
-    def test_retry(self, function, argument, run_server1, run_server2, run_server3):
+    def test_retry(self, function, argument,
+                   run_server1, run_server2, run_server3):
         # 10回の retry に失敗したら RuntimeError が出るかをテスト
         with pytest.raises(RuntimeError):
             _ = function(*argument)

--- a/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
+++ b/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
@@ -143,7 +143,7 @@ class TestQMPC:
         for res in response["job_error_info"]:
             assert (res.what == "QMPCJobError")
 
-    qmpc_failed:QMPCServer = QMPCServer(
+    qmpc_failed: QMPCServer = QMPCServer(
         # 通信失敗する場合をテストするようのサーバー
         ["http://localhost:50011",
          "http://localhost:50012",
@@ -154,12 +154,12 @@ class TestQMPC:
     )
 
     @pytest.mark.parametrize(
-        ("function","argument"), [
-            (qmpc_failed.execute_computation,execute_computation_param()),
-            (qmpc_failed.get_computation_result,("uuid",None)),
+        ("function", "argument"), [
+            (qmpc_failed.execute_computation, execute_computation_param()),
+            (qmpc_failed.get_computation_result, ("uuid", None)),
         ]
     )
-    def test_retry(self,function, argument,run_server1, run_server2, run_server3):
+    def test_retry(self, function, argument, run_server1, run_server2, run_server3):
         # 10回の retry に失敗したら RuntimeError が出るかをテスト
         with pytest.raises(RuntimeError):
             _ = function(*argument)

--- a/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
+++ b/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
@@ -144,7 +144,7 @@ class TestQMPC:
             assert (res.what == "QMPCJobError")
 
     qmpc_failed: QMPCServer = QMPCServer(
-        # 通信失敗する場合をテストするようのサーバー
+        # 通信失敗する場合をテストする用のサーバー
         ["http://localhost:50011",
          "http://localhost:50012",
          "http://localhost:50013"],

--- a/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
+++ b/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
@@ -164,8 +164,8 @@ class TestQMPC:
             (qmpc_failed.get_job_error_info, ["uuid"]),
         ]
     )
-    def test_retry(self, function, argument,
+    def test_retry(self, function, argument, caplog,
                    run_server1, run_server2, run_server3):
-        # 10回の retry に失敗したら RuntimeError が出るかをテスト
-        with pytest.raises(RuntimeError):
-            _ = function(*argument)
+        # 10回の retry に失敗したら "All 10 times it was an error" が log に出るかをテスト
+        _ = function(*argument)
+        assert "All 10 times it was an error" in caplog.text

--- a/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
+++ b/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
@@ -142,3 +142,24 @@ class TestQMPC:
         assert (response["is_ok"])
         for res in response["job_error_info"]:
             assert (res.what == "QMPCJobError")
+
+    qmpc_failed:QMPCServer = QMPCServer(
+        # 通信失敗する場合をテストするようのサーバー
+        ["http://localhost:50011",
+         "http://localhost:50012",
+         "http://localhost:50013"],
+        "token_demo",
+        10,
+        0
+    )
+
+    @pytest.mark.parametrize(
+        ("function","argument"), [
+            (qmpc_failed.execute_computation,execute_computation_param()),
+            (qmpc_failed.get_computation_result,("uuid",None)),
+        ]
+    )
+    def test_retry(self,function, argument,run_server1, run_server2, run_server3):
+        # 10回の retry に失敗したら RuntimeError が出るかをテスト
+        with pytest.raises(RuntimeError):
+            _ = function(*argument)

--- a/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
+++ b/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
@@ -155,8 +155,13 @@ class TestQMPC:
 
     @pytest.mark.parametrize(
         ("function", "argument"), [
+            (qmpc_failed.send_share,send_share_param()),
+            (qmpc_failed.delete_share,[]),
             (qmpc_failed.execute_computation, execute_computation_param()),
+            (qmpc_failed.get_data_list,()),
+            (qmpc_failed.get_elapsed_time,"uuid"),
             (qmpc_failed.get_computation_result, ("uuid", None)),
+            (qmpc_failed.get_job_error_info,"uuid"),
         ]
     )
     def test_retry(self, function, argument,


### PR DESCRIPTION
# Summary
Add retry policy to libclient-py
# Purpose
In order to care only temporary server errors
# Contents
add retry function
# Testing Methods Performed
pytest
CI