### PR TITLE
Add `with` to ThreadPoolExecutor

### DIFF
--- a/packages/client/libclient-py/quickmpc/qmpc_server.py
+++ b/packages/client/libclient-py/quickmpc/qmpc_server.py
@@ -293,9 +293,10 @@ class QMPCServer:
         # 非同期にリクエスト送信
         with ThreadPoolExecutor() as executor:
             # JobidをMCから貰う関係で単一MC（現在はSP（ID=0）のみ対応）にリクエストを送る
-            futures = [executor.submit(self.__retry,
-                                       self.__client_stubs[0].ExecuteComputation,
-                                       req)]
+            futures = [
+                executor.submit(self.__retry,
+                                self.__client_stubs[0].ExecuteComputation,
+                                req)]
 
         is_ok, response = QMPCServer.__futures_result(futures)
         job_uuid = response[0].job_uuid if is_ok else None


### PR DESCRIPTION
# Summary
Add `with` to `ThreadPoolExecutor`

# Purpose
Removal of unnatural behavior
ex) After an error occurs in send_share, processing may not proceed even though nothing is being done.
# Contents
Add `with` to `ThreadPoolExecutor` because shutdown is required when using `ThreadPoolExecutor`

# Testing Methods Performed
- CI
# Example
### common setteings
```Python
import time
from concurrent.futures import ThreadPoolExecutor

def func(k):
    time.sleep(k)
    print(k)
    raise RuntimeError("ERROR")
```
### Case1. do not call shutdown
If even one error is caught, later processing begins, but the thread continues to run.
```Python
executor = ThreadPoolExecutor()
futures = [
    executor.submit(func, 1),
    executor.submit(func, 3),
    executor.submit(func, 5),
]

try:
    [f.result() for f in futures]
except RuntimeError as e:
    print(e)
print("finish")
"""
1
ERROR
finish
3
5
"""
```
### Case2. call shutdown
Wait for all threads to finish processing before starting error processing.
```Python
executor = ThreadPoolExecutor()
futures = [
    executor.submit(func, 1),
    executor.submit(func, 3),
    executor.submit(func, 5),
]
executor.shutdown()

try:
    [f.result() for f in futures]
except RuntimeError as e:
    print(e)
print("finish")
"""
1
3
5
ERROR
finish
"""
```

### Case3. Add with
The same results as in Case 2 are obtained. Because shutdown is called when the executor is released.
This is the reason why the error logs were showing up, but the process was not finished and a mysterious waiting process was occurring.

ref: https://docs.python.org/3/library/concurrent.futures.html
> You can avoid having to call this method explicitly if you use the [with](https://docs.python.org/3/reference/compound_stmts.html#with) statement, which will shutdown the [Executor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor) (waiting as if [Executor.shutdown()](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor.shutdown) were called with wait set to True):

[Corresponding code](https://github.com/python/cpython/blob/8740fd855cea73146c45598d465ce327c14478cb/Lib/concurrent/futures/_base.py#L646-L648)

```Python
with ThreadPoolExecutor() as executor:
    futures = [
        executor.submit(func, 1),
        executor.submit(func, 3),
        executor.submit(func, 5),
    ]

try:
    [f.result() for f in futures]
except RuntimeError as e:
    print(e)
print("finish")
"""
1
3
5
ERROR
finish
"""
```