### PR TITLE
"FIX: use cstdint"

### DIFF
--- a/packages/server/computation_container/random/csprng.cpp
+++ b/packages/server/computation_container/random/csprng.cpp
@@ -13,7 +13,7 @@ bool CSPRNG::entropyCheck()
 {
     while (sodium_init() < 0)
     {
-        static unsigned int ctr = 0;
+        static uint16_t ctr = 0;
         ctr++;
         if (ctr > 3000)  // エントロピーが出来上がるのに最大3分程度待つ
         {
@@ -33,7 +33,7 @@ bool CSPRNG::entropyCheck()
     return true;
 };
 
-void CSPRNG::GetRand(const std::unique_ptr<unsigned char[]>& buf, const std::size_t byteSize)
+void CSPRNG::GetRand(const std::unique_ptr<std::uint8_t[]>& buf, const std::size_t byteSize)
 {
     if (!this->CSPRNG::entropyCheck())
     {
@@ -49,22 +49,22 @@ void CSPRNG::GetRand(const std::unique_ptr<unsigned char[]>& buf, const std::siz
     }
     else
     {
-        std::unique_ptr<unsigned char[]> seed =
-            std::make_unique<unsigned char[]>(randombytes_SEEDBYTES);
+        std::unique_ptr<std::uint8_t[]> seed =
+            std::make_unique<std::uint8_t[]>(randombytes_SEEDBYTES);
         syscall(SYS_getrandom, seed.get(), randombytes_SEEDBYTES, 1);
         randombytes_buf_deterministic(buf.get(), byteSize, seed.get());
     }
 };
 
-long long int CSPRNG::GetRandLL()
+std::int64_t CSPRNG::GetRandLL()
 {
-    constexpr std::size_t LL_SIZE = sizeof(long long int);  // 8byte = 64bit
+    constexpr std::size_t LL_SIZE = sizeof(std::int64_t);  // 8byte = 64bit
 
-    std::unique_ptr<unsigned char[]> rnd = std::make_unique<unsigned char[]>(LL_SIZE);
-    // 64bit乱数[unsigned char*]生成
+    std::unique_ptr<std::uint8_t[]> rnd = std::make_unique<std::uint8_t[]>(LL_SIZE);
+    // 64bit乱数[std::uint8_t*]生成
     this->CSPRNG::GetRand(rnd, LL_SIZE);
 
-    // unsiged char* -> str(bin)
+    // uint8_t* -> str(bin)
     std::stringstream str;
     for (std::size_t i = 0; i < LL_SIZE; i++)
     {
@@ -72,22 +72,22 @@ long long int CSPRNG::GetRandLL()
     }
     std::string rndBinStr = str.str();
 
-    long long int rndVal = std::stoull(rndBinStr, nullptr, 2);
+    std::int64_t rndVal = std::stoull(rndBinStr, nullptr, 2);
     return rndVal;
 };
 
-std::vector<long long int> CSPRNG::GetRandLLVec(const std::size_t size)
+std::vector<std::int64_t> CSPRNG::GetRandLLVec(const std::size_t size)
 {
-    std::vector<long long int> randLLVec = {};
+    std::vector<std::int64_t> randLLVec = {};
 
-    constexpr std::size_t LL_SIZE = sizeof(long long int);  // 8byte
-    const std::size_t byteSize = size * LL_SIZE;            // size * 8[byte/llsize]
+    constexpr std::size_t LL_SIZE = sizeof(std::int64_t);  // 8byte
+    const std::size_t byteSize = size * LL_SIZE;           // size * 8[byte/llsize]
 
-    std::unique_ptr<unsigned char[]> rnd = std::make_unique<unsigned char[]>(byteSize);
-    // 64bit乱数[unsigned char*]生成
+    std::unique_ptr<std::uint8_t[]> rnd = std::make_unique<std::uint8_t[]>(byteSize);
+    // 64bit乱数[std::uint8_t*]生成
     this->CSPRNG::GetRand(rnd, byteSize);
 
-    // unsiged char* -> str(bin)
+    // unit8_t* -> str(bin)
     for (std::size_t i = 0; i < byteSize; i += LL_SIZE)
     {
         std::stringstream str;
@@ -96,7 +96,7 @@ std::vector<long long int> CSPRNG::GetRandLLVec(const std::size_t size)
             str << std::bitset<LL_SIZE>(rnd[i + j]);
         }
 
-        long long int rndVal = std::stoull(str.str(), nullptr, 2);
+        std::int64_t rndVal = std::stoull(str.str(), nullptr, 2);
         randLLVec.push_back(rndVal);
     }
 

--- a/packages/server/computation_container/random/csprng.cpp
+++ b/packages/server/computation_container/random/csprng.cpp
@@ -13,7 +13,7 @@ bool CSPRNG::entropyCheck()
 {
     while (sodium_init() < 0)
     {
-        static uint16_t ctr = 0;
+        static std::uint16_t ctr = 0;
         ctr++;
         if (ctr > 3000)  // エントロピーが出来上がるのに最大3分程度待つ
         {

--- a/packages/server/computation_container/random/csprng.hpp
+++ b/packages/server/computation_container/random/csprng.hpp
@@ -29,7 +29,7 @@ public:
 
     // size is the byte size of random (ex. 128bit -> size is 16)
     // byteSizeが256bit以下だと/dev/urandomを使用
-    void GetRand(const std::unique_ptr<unsigned char[]> &buf, const std::size_t byteSize);
+    void GetRand(const std::unique_ptr<std::uint8_t[]> &buf, const std::size_t byteSize);
     std::int64_t GetRandLL();
     std::vector<std::int64_t> GetRandLLVec(const std::size_t size);
 };

--- a/packages/server/computation_container/random/csprng.hpp
+++ b/packages/server/computation_container/random/csprng.hpp
@@ -30,8 +30,8 @@ public:
     // size is the byte size of random (ex. 128bit -> size is 16)
     // byteSizeが256bit以下だと/dev/urandomを使用
     void GetRand(const std::unique_ptr<unsigned char[]> &buf, const std::size_t byteSize);
-    long long int GetRandLL();
-    std::vector<long long int> GetRandLLVec(const std::size_t size);
+    std::int64_t GetRandLL();
+    std::vector<std::int64_t> GetRandLLVec(const std::size_t size);
 };
 }  // namespace Utility
 

--- a/packages/server/computation_container/random/random.cpp
+++ b/packages/server/computation_container/random/random.cpp
@@ -6,7 +6,7 @@
 
 #include "random/csprng.hpp"
 
-unsigned long long RandGenerator::generateRand()
+std::uint64_t RandGenerator::generateRand()
 {
     if (this->rands.empty())
     {
@@ -14,7 +14,7 @@ unsigned long long RandGenerator::generateRand()
         this->rands = generator.GetRandLLVec(n_hold);
     }
 
-    unsigned long long rnd = static_cast<unsigned long long>(*(this->rands.end() - 1));
+    std::uint64_t rnd = static_cast<std::uint64_t>(*(this->rands.end() - 1));
     this->rands.pop_back();
 
     return rnd;

--- a/packages/server/computation_container/random/random.hpp
+++ b/packages/server/computation_container/random/random.hpp
@@ -8,12 +8,12 @@ class RandGenerator
 {
 private:
     size_t n_hold = 1000;
-    std::vector<long long int> rands;
+    std::vector<std::int64_t> rands;
 
     RandGenerator(){};
     ~RandGenerator(){};
 
-    unsigned long long generateRand();
+    std::uint64_t generateRand();
 
 public:
     static RandGenerator *getInstance()
@@ -23,17 +23,17 @@ public:
     };
 
     template <class T>
-    T getRand(long long min_val = 0, long long max_val = 9223372036854775807ll)
+    T getRand(std::int64_t min_val = 0, std::int64_t max_val = 9223372036854775807ll)
     {
         auto rnd = RandGenerator::getInstance()->generateRand();
-        auto rnd_mod = static_cast<long long>(rnd % (max_val - min_val));
+        auto rnd_mod = static_cast<std::int64_t>(rnd % (max_val - min_val));
         auto val = T(std::abs(rnd_mod) + min_val);
         return val;
     }
 
     template <class T>
     std::vector<T> getRandVec(
-        long long min_val = 0, long long max_val = 9223372036854775807ll, int n = 5
+        std::int64_t min_val = 0, std::int64_t max_val = 9223372036854775807ll, int n = 5
     )
     {
         std::vector<T> ret;

--- a/packages/server/computation_container/test/unit_test/csprng_test.cpp
+++ b/packages/server/computation_container/test/unit_test/csprng_test.cpp
@@ -9,16 +9,16 @@
 
 TEST(CsprngTest, GetRand)
 {
-    const unsigned int byteSize = 8;  // 8byte = 64bit
+    const std::uint32_t byteSize = 8;  // 8byte = 64bit
 
-    std::unique_ptr<unsigned char[]> rnd = std::make_unique<unsigned char[]>(byteSize);
+    std::unique_ptr<std::uint8_t[]> rnd = std::make_unique<std::uint8_t[]>(byteSize);
 
     Utility::CSPRNG rng = Utility::CSPRNG();
     rng.GetRand(rnd, byteSize);
 
-    for (unsigned int i = 0; i < byteSize; i++)
+    for (std::uint32_t i = 0; i < byteSize; i++)
     {
-        unsigned int r = (unsigned int)rnd[i];
+        std::uint32_t r = (std::uint32_t)rnd[i];
         QMPC_LOG_INFO("{:d}", r);
         ASSERT_TRUE((r >= 0) && (r <= 255));
     }
@@ -27,11 +27,11 @@ TEST(CsprngTest, GetRand)
 TEST(CsprngTest, GetRandLL)
 {
     Utility::CSPRNG rng = Utility::CSPRNG();
-    std::vector<long long int> rndLLVec = {};
-    std::set<long long int> rndLLSet;
-    for (unsigned int i = 0; i < 10'000; i++)
+    std::vector<std::int64_t> rndLLVec = {};
+    std::set<std::int64_t> rndLLSet;
+    for (std::uint32_t i = 0; i < 10'000; i++)
     {
-        long long int rndLL = rng.GetRandLL();
+        std::int64_t rndLL = rng.GetRandLL();
         rndLLVec.push_back(rndLL);
         rndLLSet.insert(rndLL);
     }
@@ -43,9 +43,9 @@ TEST(CsprngTest, GetRandLL)
 TEST(CsprngTest, GetRandLLVec)
 {
     Utility::CSPRNG rng = Utility::CSPRNG();
-    unsigned int vecSize = 1000;
-    std::vector<long long int> rndLLVec = rng.GetRandLLVec(vecSize);
-    std::set<long long int> rndLLSet(rndLLVec.begin(), rndLLVec.end());
+    std::size_t vecSize = 1000;
+    std::vector<std::int64_t> rndLLVec = rng.GetRandLLVec(vecSize);
+    std::set<std::int64_t> rndLLSet(rndLLVec.begin(), rndLLVec.end());
     ;
 
     // SetとVecのサイズで重複チェックテスト
@@ -56,16 +56,16 @@ TEST(CsprngTest, HowUse)
 {
     Utility::CSPRNG rng = Utility::CSPRNG();
 
-    const unsigned int byteSize = 8;  // 8byte = 64bit
-    const unsigned int bitSize = byteSize * 8;
+    const std::uint32_t byteSize = 8;  // 8byte = 64bit
+    const std::uint32_t bitSize = byteSize * 8;
 
-    std::unique_ptr<unsigned char[]> rnd = std::make_unique<unsigned char[]>(byteSize);
+    std::unique_ptr<std::uint8_t[]> rnd = std::make_unique<std::uint8_t[]>(byteSize);
     rng.GetRand(rnd, byteSize);
 
     QMPC_LOG_INFO("変換前");
-    QMPC_LOG_INFO("[bin] unsigned char*: ");
+    QMPC_LOG_INFO("[bin] std::uint8_t*: ");
     std::string rnd_bin_str = "";
-    for (unsigned int i = 0; i < byteSize; i++)
+    for (std::uint32_t i = 0; i < byteSize; i++)
     {
         QMPC_LOG_INFO(std::bitset<8>(rnd[i]));
         std::stringstream str;
@@ -73,26 +73,26 @@ TEST(CsprngTest, HowUse)
         rnd_bin_str += str.str();
     }
 
-    QMPC_LOG_INFO("[hex] unsigned char*: ");
-    for (unsigned int i = 0; i < byteSize; i++)
+    QMPC_LOG_INFO("[hex] std::uint8_t*: ");
+    for (std::uint32_t i = 0; i < byteSize; i++)
     {
-        QMPC_LOG_INFO("{:x}", (unsigned int)rnd[i]);
+        QMPC_LOG_INFO("{:x}", (std::uint32_t)rnd[i]);
     }
 
-    QMPC_LOG_INFO("[dec] unsigned char*: ");
-    for (unsigned int i = 0; i < byteSize; i++)
+    QMPC_LOG_INFO("[dec] std::uint8_t*: ");
+    for (std::uint32_t i = 0; i < byteSize; i++)
     {
-        QMPC_LOG_INFO((unsigned int)rnd[i]);
+        QMPC_LOG_INFO((std::uint32_t)rnd[i]);
     }
     QMPC_LOG_INFO("\n");
 
     QMPC_LOG_INFO("変換");
-    QMPC_LOG_INFO("[bin] unsigned char* -> string: ");
+    QMPC_LOG_INFO("[bin] std::uint8_t* -> string: ");
     QMPC_LOG_INFO("{}\n", rnd_bin_str);
 
-    // unsigned char* から long longへキャスト
-    long long val = std::stoull(rnd_bin_str, nullptr, 2);
-    unsigned long long uval = std::stoull(rnd_bin_str, nullptr, 2);
+    // std::uint8_t* から std::int64_t へキャスト
+    std::int64_t val = std::stoull(rnd_bin_str, nullptr, 2);
+    std::uint64_t uval = std::stoull(rnd_bin_str, nullptr, 2);
 
     QMPC_LOG_INFO("変換後");
     std::stringstream str;
@@ -134,15 +134,15 @@ TEST(CsprngTest, HowUse)
 
     /* 例
     変換前
-    [bin] unsigned char*:
+    [bin] std::uint8_t*:
     1010010010110000111000111010011111001100000010100110101001100010
-    [hex] unsigned char*:
+    [hex] std::uint8_t*:
     a4 b0 e3 a7 cc a 6a 62
-    [dec] unsigned char*:
+    [dec] std::uint8_t*:
     164 176 227 167 204 10 106 98
 
     変換
-    [bin] unsigned char* -> string:
+    [bin] std::uint8_t* -> string:
     1010010010110000111000111010011111001100000010100110101001100010
 
     変換後


### PR DESCRIPTION
# Summary
use cstdint
# Purpose
to clarfy the size of range of integer
# Contents
replace:
unsigned int -> std::uint16_t (where the integer is guaranteed that does not take the value over 3001)
unsigned char -> std::uint8_t
long long int -> std::int64_t
unsigned long long int -> std::uint64_t
# Testing Methods Performed
bazel build all