### PR TITLE
Add a process to align the start timing to the test.

### DIFF
--- a/packages/server/manage_container/integration_test/3pt_test/m2m_client_test.go
+++ b/packages/server/manage_container/integration_test/3pt_test/m2m_client_test.go
@@ -115,6 +115,8 @@ func TestCreateStatusFile(t *testing.T) {
 	}
 	id := config.PartyID
 	m2m_client := m2m.Client{}
+	m2m_client.Sync("start_createStatusFile")
+
 	if id == 1 {
 		// NOTE: PT1はPT2,3へstatu_RECEIVED作成リクエストを送る
 		client := m2m.Client{}
@@ -153,6 +155,8 @@ func TestDeleteStatusFile(t *testing.T) {
 	}
 	id := config.PartyID
 	m2m_client := m2m.Client{}
+	m2m_client.Sync("start_deleteStatusFile")
+
 	if id == 1 {
 		// NOTE: PT1はPT2,3へstatu_RECEIVED削除リクエストを送る
 		m2m_client.Sync("create")


### PR DESCRIPTION
# Summary
Add a process to align the start timing to the test.
# Purpose
Because the test may fail due to incorrect start timing
# Contents
Add a process to align the start timing to the test.
# Testing Methods Performed
CI 
I ran the following command 20 times in a local environment
```
make test t=./manage_container p=medium
```