### PR TITLE
separate checking channel from f in retry

### DIFF
--- a/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
+++ b/packages/client/libclient-py/tests/unit_tests/test_qmpc.py
@@ -168,4 +168,4 @@ class TestQMPC:
                    run_server1, run_server2, run_server3):
         # 10回の retry に失敗したら "All 10 times it was an error" が log に出るかをテスト
         _ = function(*argument)
-        assert "All 10 times it was an error" in caplog.text
+        assert "channel の準備が出来ません" in caplog.text


### PR DESCRIPTION
# Summary
separate checking channel from f in retry
# Purpose
to simplify the loop and shorten the time of test
# Contents
separate loop of checking channel from loop of doing f 
# Testing Methods Performed
pytest