### PR TITLE
Memory reduction of send_share

### DIFF
--- a/packages/client/libclient-py/quickmpc/utils/parse_csv.py
+++ b/packages/client/libclient-py/quickmpc/utils/parse_csv.py
@@ -2,7 +2,7 @@ import csv
 import logging
 from dataclasses import dataclass
 from hashlib import sha512
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -123,8 +123,7 @@ def find_types(schema: List[str],
                matching_column: Optional[int] = None
                ) -> List[ShareValueTypeEnum.ValueType]:
     # transpose to get column oriented list
-    transposed: List[List[str]] = np.array(
-        data, dtype=str).transpose().tolist()
+    transposed: Iterable[List[str]] = map(list, zip(*data))
     return [find_type(sch, col, idx == matching_column)
             for idx, (sch, col) in enumerate(zip(schema, transposed), start=1)]
 


### PR DESCRIPTION
# Summary
Memory reduction of `send_share`

# Purpose
Memory savings

# Contents
- Remove comprehension

# Testing Methods Performed
- pytest
- make test t=libclient p=medium m=run
- 10,000,000 rows benchmark

# Memory
Memory consumption of `send_share`
## 1,000,000 rows, 10 columns (local machine)
||before|after|
|-|-|-|
|max memory(GB)|None|None|
|transition|![before](https://user-images.githubusercontent.com/14158932/234268398-e2d3394c-5377-4103-9077-bc3e55c21d9e.png)|![zip_after](https://user-images.githubusercontent.com/14158932/234268414-fcaf485a-5314-4db4-b025-eaec56548418.png)|

The first peak is `np.array(data, dtype=str).transpose().tolist()`, After that, `sharize`
## 10,000,000 rows, 10 columns (server)
||before|after|
|-|-|-|
|max memory(GB)|40.76|16.30|
|transition|None|None|

