### PR TITLE
Change remote cache from GCS to BuildBuddy

### DIFF
--- a/.github/workflows/.bazelrc_for_ci
+++ b/.github/workflows/.bazelrc_for_ci
@@ -1,6 +1,6 @@
-common --worker_max_instances=2
-common --remote_max_connections=10000
-common --disk_cache=
-common --remote_cache=https://storage.googleapis.com/${BAZEL_CACHE_BUCKET}
-common --google_credentials=/root/sa.json
+common --bes_results_url=https://app.buildbuddy.io/invocation/
+common --bes_backend=grpcs://remote.buildbuddy.io
+common --remote_timeout=3600
+common --remote_cache=grpcs://remote.buildbuddy.io
+common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
 test --cache_test_results=no

--- a/.github/workflows/test-server-all.yml
+++ b/.github/workflows/test-server-all.yml
@@ -38,17 +38,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Setup config for using GCS as bazel remote cache
-      - name: Update GCP service account JSON
-        run: echo ${CI_REMOTE_CACHE_JSON} | base64 --decode >> ./packages/server/computation_container/sa.json
-        env:
-          CI_REMOTE_CACHE_JSON: ${{ secrets.CI_REMOTE_CACHE_JSON }}
-
       - name: Update .bazelrc for using remote cache
         run: |
           eval "echo \"$(cat ./.github/workflows/.bazelrc_for_ci)\"" >> ./packages/server/computation_container/.bazelrc
         env:
-          BAZEL_CACHE_BUCKET: ${{ secrets.BAZEL_CACHE_BUCKET }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Set up Docker buildx
         id: buildx
@@ -132,17 +126,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Setup config for using GCS as bazel remote cache
-      - name: Update GCP service account JSON
-        run: echo ${CI_REMOTE_CACHE_JSON} | base64 --decode >> ./packages/server/computation_container/sa.json
-        env:
-          CI_REMOTE_CACHE_JSON: ${{ secrets.CI_REMOTE_CACHE_JSON }}
-
       - name: Update .bazelrc for using remote cache
         run: |
           eval "echo \"$(cat ./.github/workflows/.bazelrc_for_ci)\"" >> ./packages/server/computation_container/.bazelrc
         env:
-          BAZEL_CACHE_BUCKET: ${{ secrets.BAZEL_CACHE_BUCKET }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
@@ -208,16 +196,11 @@ jobs:
           token: ${{ secrets.CI_REPOSITORY_ACCESS_TOKEN }}
           submodules: true
 
-      - name: Update GCP service account JSON
-        run: echo ${CI_REMOTE_CACHE_JSON} | base64 --decode >> ./packages/server/computation_container/sa.json
-        env:
-          CI_REMOTE_CACHE_JSON: ${{ secrets.CI_REMOTE_CACHE_JSON }}
-
       - name: Update .bazelrc for using remote cache
         run: |
           eval "echo \"$(cat ./.github/workflows/.bazelrc_for_ci)\"" >> ./packages/server/computation_container/.bazelrc
         env:
-          BAZEL_CACHE_BUCKET: ${{ secrets.BAZEL_CACHE_BUCKET }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
@@ -268,16 +251,11 @@ jobs:
           token: ${{ secrets.CI_REPOSITORY_ACCESS_TOKEN }}
           submodules: true
 
-      - name: Update GCP service account JSON
-        run: echo ${CI_REMOTE_CACHE_JSON} | base64 --decode >> ./packages/server/computation_container/sa.json
-        env:
-          CI_REMOTE_CACHE_JSON: ${{ secrets.CI_REMOTE_CACHE_JSON }}
-
       - name: Update .bazelrc for using remote cache
         run: |
           eval "echo \"$(cat ./.github/workflows/.bazelrc_for_ci)\"" >> ./packages/server/computation_container/.bazelrc
         env:
-          BAZEL_CACHE_BUCKET: ${{ secrets.BAZEL_CACHE_BUCKET }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
@@ -302,16 +280,11 @@ jobs:
           token: ${{ secrets.CI_REPOSITORY_ACCESS_TOKEN }}
           submodules: true
 
-      - name: Update GCP service account JSON
-        run: echo ${CI_REMOTE_CACHE_JSON} | base64 --decode >> ./packages/server/computation_container/sa.json
-        env:
-          CI_REMOTE_CACHE_JSON: ${{ secrets.CI_REMOTE_CACHE_JSON }}
-
       - name: Update .bazelrc for using remote cache
         run: |
           eval "echo \"$(cat ./.github/workflows/.bazelrc_for_ci)\"" >> ./packages/server/computation_container/.bazelrc
         env:
-          BAZEL_CACHE_BUCKET: ${{ secrets.BAZEL_CACHE_BUCKET }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
@@ -336,16 +309,11 @@ jobs:
           token: ${{ secrets.CI_REPOSITORY_ACCESS_TOKEN }}
           submodules: true
 
-      - name: Update GCP service account JSON
-        run: echo ${CI_REMOTE_CACHE_JSON} | base64 --decode >> ./packages/server/computation_container/sa.json
-        env:
-          CI_REMOTE_CACHE_JSON: ${{ secrets.CI_REMOTE_CACHE_JSON }}
-
       - name: Update .bazelrc for using remote cache
         run: |
           eval "echo \"$(cat ./.github/workflows/.bazelrc_for_ci)\"" >> ./packages/server/computation_container/.bazelrc
         env:
-          BAZEL_CACHE_BUCKET: ${{ secrets.BAZEL_CACHE_BUCKET }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
@@ -370,16 +338,11 @@ jobs:
           token: ${{ secrets.CI_REPOSITORY_ACCESS_TOKEN }}
           submodules: true
 
-      - name: Update GCP service account JSON
-        run: echo ${CI_REMOTE_CACHE_JSON} | base64 --decode >> ./packages/server/computation_container/sa.json
-        env:
-          CI_REMOTE_CACHE_JSON: ${{ secrets.CI_REMOTE_CACHE_JSON }}
-
       - name: Update .bazelrc for using remote cache
         run: |
           eval "echo \"$(cat ./.github/workflows/.bazelrc_for_ci)\"" >> ./packages/server/computation_container/.bazelrc
         env:
-          BAZEL_CACHE_BUCKET: ${{ secrets.BAZEL_CACHE_BUCKET }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
@@ -404,16 +367,11 @@ jobs:
           token: ${{ secrets.CI_REPOSITORY_ACCESS_TOKEN }}
           submodules: true
 
-      - name: Update GCP service account JSON
-        run: echo ${CI_REMOTE_CACHE_JSON} | base64 --decode >> ./packages/server/computation_container/sa.json
-        env:
-          CI_REMOTE_CACHE_JSON: ${{ secrets.CI_REMOTE_CACHE_JSON }}
-
       - name: Update .bazelrc for using remote cache
         run: |
           eval "echo \"$(cat ./.github/workflows/.bazelrc_for_ci)\"" >> ./packages/server/computation_container/.bazelrc
         env:
-          BAZEL_CACHE_BUCKET: ${{ secrets.BAZEL_CACHE_BUCKET }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
@@ -438,16 +396,11 @@ jobs:
           token: ${{ secrets.CI_REPOSITORY_ACCESS_TOKEN }}
           submodules: true
 
-      - name: Update GCP service account JSON
-        run: echo ${CI_REMOTE_CACHE_JSON} | base64 --decode >> ./packages/server/computation_container/sa.json
-        env:
-          CI_REMOTE_CACHE_JSON: ${{ secrets.CI_REMOTE_CACHE_JSON }}
-
       - name: Update .bazelrc for using remote cache
         run: |
           eval "echo \"$(cat ./.github/workflows/.bazelrc_for_ci)\"" >> ./packages/server/computation_container/.bazelrc
         env:
-          BAZEL_CACHE_BUCKET: ${{ secrets.BAZEL_CACHE_BUCKET }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin


### PR DESCRIPTION
# Summary
Use BuildBuddy
# Purpose
To reduce the time to download the remote cache
# Contents
Change remote cache from GCS to BuildBuddy
# Testing Methods Performed
