### PR TITLE
Renovate updates library only when it has vulnerability

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "timezone": "Asia/Tokyo",
-  "schedule": ["after 10pm and before 8am every weekday", "every weekend"],
-  "rebaseWhen": "never",
-
+  "extends": [ "config:base"],
   "packageRules": [
     {
-      "matchPackagePatterns": ["^github.com/acompany-develop/QuickMPC"],
-      "enabled": false
+      "enabled": false,
+      "matchPackagePatterns": ["*"]
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
# Summary
Renovate updates library only when it has vulnerability
# Purpose
To minimize the scope of updates
# Contents
Renovate only issues PRs for vulnerabilities it detects
# Testing Methods Performed
