### PR TITLE
Add unregisterJob to ProgressManager

### DIFF
--- a/packages/server/computation_container/job/job_manager.hpp
+++ b/packages/server/computation_container/job/job_manager.hpp
@@ -61,6 +61,7 @@ class JobManager
                 QMPC_LOG_ERROR("thrown exception has no stack trace information");
                 statusManager.error(e, std::nullopt);
             }
+            ProgressManager::getInstance()->unregisterJob(job_uuid);
         };
 
         try

--- a/packages/server/computation_container/job/progress_manager.cpp
+++ b/packages/server/computation_container/job/progress_manager.cpp
@@ -210,6 +210,19 @@ void ProgressManager::registerJob(const int& id, const std::string& uuid)
     progresses[uuid] = std::make_shared<Observer>();
 }
 
+void ProgressManager::unregisterJob(const std::string& uuid)
+{
+    std::lock_guard<std::recursive_mutex> lock(dict_mtx);
+
+    if (progresses.find(uuid) != progresses.end())
+    {
+        progresses.erase(uuid);
+        auto id = job_uuid_to_job_id[uuid];
+        job_id_to_job_uuid.erase(id);
+        job_uuid_to_job_id.erase(uuid);
+    }
+}
+
 std::shared_ptr<Observer> ProgressManager::getObserver(const int& id)
 {
     std::lock_guard<std::recursive_mutex> lock(dict_mtx);

--- a/packages/server/computation_container/job/progress_manager.hpp
+++ b/packages/server/computation_container/job/progress_manager.hpp
@@ -221,6 +221,13 @@ public:
     void registerJob(const int& id, const std::string& uuid);
 
     /**
+     * this function applies followings:
+     * - remove mapping from dictionaries
+     * - remove Observer from manage
+     */
+    void unregisterJob(const std::string& uuid);
+
+    /**
      * Progress generator. this function applies followings:
      * - create Builder
      * - instantiate inherited progress class with args


### PR DESCRIPTION
# Summary
Fix progress log

# Purpose
Stops progress log in the event of an error.

# Contents
- Add unregisterJob to ProgressManager

# Testing Methods Performed
- Throw during join and check the stop of log
- CI