### PR TITLE
Supported the case where the length of share_ids is 0 in getShares.

### DIFF
--- a/packages/server/computation_container/server/computation_to_computation_container/server.cpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.cpp
@@ -161,7 +161,7 @@ std::vector<std::string> Server::getShares(
 )
 {
     const size_t length = share_ids.size();
-    if(length==0)
+    if(length == 0)
     {
         return std::vector<std::string>{};
     }

--- a/packages/server/computation_container/server/computation_to_computation_container/server.cpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.cpp
@@ -157,9 +157,15 @@ std::string Server::getShare(int party_id, qmpc::Share::AddressId share_id)
 
 // 複数シェアget用
 std::vector<std::string> Server::getShares(
-    int party_id, const std::vector<qmpc::Share::AddressId> &share_ids, unsigned int length
+    int party_id, const std::vector<qmpc::Share::AddressId> &share_ids
 )
 {
+    const size_t length = share_ids.size();
+    if(length==0)
+    {
+        return std::vector<std::string>{};
+    }
+
     Config *conf = Config::getInstance();
     // std::cout << "party share job thread"
     //           << " " << party_id << " " << share_ids[0].getShareId() << " "
@@ -181,6 +187,7 @@ std::vector<std::string> Server::getShares(
     }
     auto local_str_shares = shares_vec[key];
     shares_vec.erase(key);
+    assert(local_str_shares.size() == length);
     return local_str_shares;
 }
 

--- a/packages/server/computation_container/server/computation_to_computation_container/server.hpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.hpp
@@ -47,7 +47,7 @@ public:
     // 受け取ったシェアをgetするメソッド
     std::string getShare(int party_id, qmpc::Share::AddressId share_id);
     std::vector<std::string> getShares(
-        int party_id, const std::vector<qmpc::Share::AddressId> &share_ids, unsigned int length
+        int party_id, const std::vector<qmpc::Share::AddressId> &share_ids
     );
     Server(Server &&) noexcept = delete;
     Server(const Server &) noexcept = delete;

--- a/packages/server/computation_container/share/networking.hpp
+++ b/packages/server/computation_container/share/networking.hpp
@@ -207,7 +207,7 @@ auto recons(const T &share)
         }
         else
         {
-            std::vector<std::string> values = server->getShares(pt_id, ids_list, length);
+            std::vector<std::string> values = server->getShares(pt_id, ids_list);
             for (unsigned int i = 0; i < length; i++)
             {
                 if constexpr (std::is_same_v<Result, bool>)
@@ -253,7 +253,7 @@ std::vector<SV> receive(int sp_id, const std::vector<AddressId> &address_ids)
     ComputationToComputation::Server *server = ComputationToComputation::Server::getServer();
     int n = address_ids.size();
     std::vector<SV> ret(n);
-    auto shares = server->getShares(sp_id, address_ids, address_ids.size());
+    auto shares = server->getShares(sp_id, address_ids);
     for (int i = 0; i < n; ++i)
     {
         ret[i] = stosv<SV>(shares[i]);

--- a/packages/server/computation_container/test/unit_test/ctoc_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctoc_test.cpp
@@ -96,7 +96,7 @@ TEST(CtoC_Test, EXCHANGESHARES)
     EXPECT_TRUE(status.ok());
 
     auto server = qmpc::ComputationToComputation::Server::getServer();
-    auto datas = server->getShares(conf->party_id, share_ids, length);
+    auto datas = server->getShares(conf->party_id, share_ids);
     for (unsigned int i = 0; i < length; i++)
     {
         EXPECT_EQ(values[i], datas[i]);
@@ -119,7 +119,7 @@ TEST(CtoC_Test, GetSharesThrowExceptionTest)
     std::vector<qmpc::Share::AddressId> share_ids(length);
 
     auto server = qmpc::ComputationToComputation::Server::getServer();
-    EXPECT_ANY_THROW(server->getShares(conf->party_id, share_ids, length));
+    EXPECT_ANY_THROW(server->getShares(conf->party_id, share_ids));
 }
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
# Summary
1. In getShares, remove `length` from the argument.
2. Supported the case where the `length` is 0 in getShares.
# Purpose
1. To eliminate the possibility of `length` and the size of share_ids are different
2. Prevent out-of-sequence references
# Contents
1. Remove `length` from the argument.  
2. Early return 
# Testing Methods Performed
CI