### PR TITLE
Fix to run benchmark on remote server

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,4 +26,4 @@ jobs:
         run: ssh ubuntu@${{ secrets.RUNNER_IP }} -i secret "cd ${{ github.run_number }} && git clone https://github.com/acompany-develop/QuickMPC"
 
       - name: run benchmark
-        run: ssh ubuntu@${{ secrets.RUNNER_IP }} -i secret "nohup bash -c \"cd ${{ github.run_number }}/QuickMPC/benchmark_src; chmod +x benchamrk_runner.sh; ./benchmark_runner.sh ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }} ${{ secrets.GCP_PROJECT_ID }} ${{ github.run_number }} ${{ secrets.SLACK_CHENNEL_ID }} ${{ secrets.SLACK_API_TOKEN }}; sudo rm -r ~/${{ github.run_number }}\" &> /home/ubuntu/log/runner-${{ github.run_number }}.log;   &"
+        run: ssh ubuntu@${{ secrets.RUNNER_IP }} -i secret "nohup bash -c \"cd ${{ github.run_number }}/QuickMPC/benchmark_src; chmod +x benchamrk_runner.sh; ./benchmark_runner.sh ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }} ${{ secrets.GCP_PROJECT_ID }} ${{ github.run_number }} ${{ secrets.SLACK_CHANNEL_ID }} ${{ secrets.SLACK_API_TOKEN }}; sudo rm -r ~/${{ github.run_number }}\" &> /home/ubuntu/log/runner-${{ github.run_number }}.log;   &"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,35 +16,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: get tag
-        run: |
-          git fetch --tags
-          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "TAG_NAME=$latest_tag" >> $GITHUB_ENV
+      - name: decode secret key
+        run: echo ${{ secrets.RUNNER_SECRET_KEY }} | base64 -d > secret && chmod 600 secret
 
-      - name: Set up terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.4.6
-          terraform_wrapper: false
+      - name: mkdir ${{ github.run_number }}
+        run: ssh ubuntu@${{ secrets.RUNNER_IP }} -i secret "mkdir ${{ github.run_number }}"
 
-      - name: setup
-        run: ./setup.sh ${{ env.TAG_NAME }} ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }} ${{ secrets.GCP_PROJECT_ID }}
-        working-directory: ./benchmark_src/
+      - name: clone QuickMPC
+        run: ssh ubuntu@${{ secrets.RUNNER_IP }} -i secret "cd ${{ github.run_number }} && git clone https://github.com/acompany-develop/QuickMPC"
 
-      - name: create gcp instance
-        run: terraform init && terraform plan && terraform apply --auto-approve && terraform output -json > ../application/output.json
-        working-directory: ./demo/terraform/gcp
-
-      - name: deploy quickmpc
-        run: terraform init && terraform plan && terraform apply --auto-approve && terraform output -json > ../../../benchmark_src/terraform/output.json
-        working-directory: ./demo/terraform/application
-
-      - name: benchmark test
-        run: terraform init && terraform plan && terraform apply --auto-approve
-        working-directory: ./benchmark_src/terraform
-
-      - if: always()
-        name: post-processing
-        run: terraform destroy --auto-approve
-        working-directory: ./demo/terraform/gcp
+      - name: run benchmark
+        run: ssh ubuntu@${{ secrets.RUNNER_IP }} -i secret "nohup bash -c \"cd ${{ github.run_number }}/QuickMPC/benchmark_src; chmod +x benchamrk_runner.sh; ./benchmark_runner.sh ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }} ${{ secrets.GCP_PROJECT_ID }} ${{ github.run_number }} ${{ secrets.SLACK_CHENNEL_ID }} ${{ secrets.SLACK_API_TOKEN }}; sudo rm -r ~/${{ github.run_number }}\" &> /home/ubuntu/log/runner-${{ github.run_number }}.log;   &"

--- a/benchmark_src/benchmark_runner.sh
+++ b/benchmark_src/benchmark_runner.sh
@@ -14,8 +14,10 @@ latest_tag=$(git tag --list | grep -E '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
 
 function finally() {
     # logをslackに送信
+    # 更新日 2023/06/30
     curl -F initial_comment="QuickMPC version: $latest_tag \`\`\`$( sed -n '/test_print_result/,$p' /home/ubuntu/log/result-$runner_id.log | sed 's/\[[0-9][0-9]*m//g')\`\`\`" -F file=@/home/ubuntu/log/result-$runner_id.log -F channels=$channel_id -H "Authorization: Bearer $slack_token" https://slack.com/api/files.upload
     # post processing
+    # NOTE: `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!`の回避のためknown_hostsを毎回削除する
     rm ~/.ssh/known_hosts
     cd $SCRIPT_DIR/../demo/terraform/gcp
     terraform destroy --auto-approve

--- a/benchmark_src/benchmark_runner.sh
+++ b/benchmark_src/benchmark_runner.sh
@@ -14,7 +14,7 @@ latest_tag=$(git tag --list | grep -E '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
 
 function finally() {
     # logをslackに送信
-    curl -F title="Benchmark QuickMPC==$latest_tag" -F file=@/home/ubuntu/log/result-$runner_id.log -F channels=$channel_id -H "Authorization: Bearer $slack_token" https://slack.com/api/files.upload
+    curl -F initial_comment="QuickMPC version: $latest_tag \`\`\`$( sed -n '/test_print_result/,$p' /home/ubuntu/log/result-$runner_id.log | sed 's/\[[0-9][0-9]*m//g')\`\`\`" -F file=@/home/ubuntu/log/result-$runner_id.log -F channels=$channel_id -H "Authorization: Bearer $slack_token" https://slack.com/api/files.upload
     # post processing
     rm ~/.ssh/known_hosts
     cd $SCRIPT_DIR/../demo/terraform/gcp

--- a/benchmark_src/benchmark_runner.sh
+++ b/benchmark_src/benchmark_runner.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+trap finally EXIT
+
+gcp_service_account_key=$1
+gcp_project_id=$2
+runner_id=$3
+channel_id=$4
+slack_token=$5
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+
+git fetch --tags
+latest_tag=$(git tag --list | grep -E '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+
+function finally() {
+    # logをslackに送信
+    curl -F title="Benchmark QuickMPC==$latest_tag" -F file=@/home/ubuntu/log/result-$runner_id.log -F channels=$channel_id -H "Authorization: Bearer $slack_token" https://slack.com/api/files.upload
+    # post processing
+    rm ~/.ssh/known_hosts
+    cd $SCRIPT_DIR/../demo/terraform/gcp
+    terraform destroy --auto-approve
+}
+
+./setup.sh $latest_tag $gcp_service_account_key $gcp_project_id
+
+# Create GCP instance
+cd ../demo/terraform/gcp
+terraform init && terraform plan && terraform apply --auto-approve && terraform output -json > ../application/output.json
+
+# Deploy quickmpc
+cd ../application
+terraform init && terraform plan && terraform apply --auto-approve && terraform output -json > ../../../benchmark_src/terraform/output.json
+
+#Run benchmark test
+cd ../../../benchmark_src/terraform
+terraform init && terraform plan && terraform apply --auto-approve > /home/ubuntu/log/result-$runner_id.log


### PR DESCRIPTION
# Summary
Fix to run benchmark on remote server
# Purpose
Because github action has a 6 hour limit and the benchmark stops in the middle of the action.
# Contents
Fix github action to send only requests from github action
Add shell script to run benchmark
Sent result to Slack
# Testing Methods Performed
Example of a message sent to slack
<img width="1233" alt="スクリーンショット 2023-06-30 17 28 34" src="https://github.com/acompany-develop/QuickMPC/assets/91713065/5d39e2bf-06e9-4a48-af46-2d137fd6cf41">