### PR TITLE
Delete template from FixedPoint

### DIFF
--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -155,8 +155,10 @@ inline auto abs(const FixedPoint &x)
         return x;
     }
 }
-std::string to_string(const FixedPoint &fp)
+template<typename FP>
+std::string to_string(const FP &fp)
 {
+    static_assert(std::is_same_v<FP,FixedPoint>, "for FP");
     return fp.getStrVal();
 }
 }  // namespace qmpc::Utils

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -25,9 +25,11 @@ public:
     FixedPoint() : value(0) {}
     FixedPoint(const FixedPoint &v) : value(v.value) {}
     FixedPoint(FixedPoint &&v) : value(std::move(v.value)) {}
-    template <typename T, std::enable_if_t<
-        std::is_arithmetic_v<std::remove_reference_t<T>>,
-        std::nullptr_t> = nullptr>
+    template <
+        typename T,
+        std::enable_if_t<
+            std::is_arithmetic_v <std::remove_reference_t<T>>, std::nullptr_t
+        > = nullptr>
     FixedPoint(const T &v)
     {
         mp_float tmp = static_cast<mp_float>(v);

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -106,13 +106,8 @@ public:
     }
     FixedPoint &operator/=(const FixedPoint &obj)
     {
-        D inv{obj.getVal<D>()};
-        if (boost::math::isinf(inv))
-        {
-            inv = static_cast<D>(maxInt);
-        }
-        D v = (this->getVal<D>() / inv) * shift;
-        value = v.template convert_to<T>();
+        value *= shift;
+        value /= obj.value;
         return *this;
     }
     FixedPoint &operator%=(const FixedPoint &obj)
@@ -147,7 +142,7 @@ public:
     {
         os << std::fixed;
         os << std::setprecision(10);
-        os << fp.value.template convert_to<D>() / shift;
+        os << fp.value.template convert_to<mp_float>() / shift;
         os << std::resetiosflags(std::ios_base::floatfield);
         return os;
     }
@@ -169,4 +164,4 @@ std::string to_string(const FixedPoint<T> &fp)
     return fp.getStrVal();
 }
 }  // namespace qmpc::Utils
-using FixedPoint = qmpc::Utils::FixedPoint<>;
+using FixedPoint = qmpc::Utils::FixedPoint;

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -51,17 +51,14 @@ public:
         return *this;
     }
     template <typename T = mp_int>
-    T getShiftedVal() const
+    T getVal() const
     {
+        // getVal() より getShiftedVal() の方が適切かもしれない
         return value.template convert_to<T>();
     }
     std::string getStrVal() const
     {
-        D ret{this->getVal<D>()};
-        if (boost::math::isinf(ret))
-        {
-            ret = static_cast<D>(maxInt);
-        }
+        mp_float ret = static_cast<mp_float>(value);
         ret /= shift;
         return ret.str(20, std::ios_base::fixed);
     }
@@ -147,9 +144,9 @@ public:
         return os;
     }
 };
-inline auto abs(const FixedPoint<> &x)
+inline auto abs(const FixedPoint &x)
 {
-    if (x < FixedPoint<>("0.0"))
+    if (x < FixedPoint("0.0"))
     {
         return -x;
     }
@@ -158,8 +155,7 @@ inline auto abs(const FixedPoint<> &x)
         return x;
     }
 }
-template <typename T>
-std::string to_string(const FixedPoint<T> &fp)
+std::string to_string(const FixedPoint &fp)
 {
     return fp.getStrVal();
 }

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -27,8 +27,8 @@ public:
     FixedPoint(FixedPoint &&v) : value(std::move(v.value)) {}
     template <
         typename T,
-        std::enable_if_t<
-            std::is_arithmetic_v<std::remove_reference_t<T>>, std::nullptr_t> = nullptr>
+        std::enable_if_t<std::is_arithmetic_v<std::remove_reference_t<T>>, std::nullptr_t> =
+            nullptr>
     FixedPoint(const T &v)
     {
         mp_float tmp = static_cast<mp_float>(v);
@@ -99,7 +99,7 @@ public:
     FixedPoint &operator*=(const FixedPoint &obj)
     {
         value *= obj.value;
-        value /= shift;  //整数で保持するため余分なshiftを除算する
+        value /= shift;  // 整数で保持するため余分なshiftを除算する
         return *this;
     }
     FixedPoint &operator/=(const FixedPoint &obj)

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -28,8 +28,7 @@ public:
     template <
         typename T,
         std::enable_if_t<
-            std::is_arithmetic_v <std::remove_reference_t<T>>,
-            std::nullptr_t> = nullptr>
+            std::is_arithmetic_v<std::remove_reference_t<T>>, std::nullptr_t> = nullptr>
     FixedPoint(const T &v)
     {
         mp_float tmp = static_cast<mp_float>(v);

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -11,93 +11,49 @@
 
 namespace qmpc::Utils
 {
-template <typename T, typename U>
-inline static constexpr T mypow(T a_, U n_) noexcept
-{
-    T a = a_;
-    U n = n_;
-    T ret = 1;
-    while (n > 0)
-    {
-        if (n & 1) ret *= a;
-        a *= a;
-        n >>= 1;
-    }
-    return ret;
-}
 namespace mp = boost::multiprecision;
-using cpp_dec_float = mp::number<mp::cpp_dec_float<50>>;
-/*
-T:保持する整数型
-D:変換する浮動小数点型
-length:10^length が最大値
-resolution:10^resolutionを1とする
-*/
-template <
-    typename T = boost::multiprecision::cpp_int,
-    typename D = cpp_dec_float,
-    int length = 18,
-    int resolution = 8>
-class FixedPointImpl : private boost::operators<FixedPointImpl<>>
+using mp_int = boost::multiprecision::cpp_int;
+using mp_float = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<50>>;
+
+class FixedPoint : private boost::operators<FixedPoint>
 {
 private:
-    constexpr static long long shift = mypow(10ll, resolution);
-    constexpr static long long maxInt =
-        mypow(10ll, length - resolution);  // FixedPointImplがとりうる整数の最大値
-    T value;
+    constexpr static long long shift = 100'000'000;
+    mp_int value;
 
 public:
-    FixedPointImpl() : value(0) {}
-    FixedPointImpl(const FixedPointImpl &v) : value(v.value) {}
-    FixedPointImpl(FixedPointImpl &&v) : value(std::move(v.value)) {}
-    template <
-        typename U,
-        std::enable_if_t<
-            std::is_arithmetic_v<
-                std::remove_reference_t<U>> or std::is_convertible_v<T, std::remove_reference_t<U>>,
-            std::nullptr_t> = nullptr>
-    FixedPointImpl(const U &v)
+    FixedPoint() : value(0) {}
+    FixedPoint(const FixedPoint &v) : value(v.value) {}
+    FixedPoint(FixedPoint &&v) : value(std::move(v.value)) {}
+    template <typename T, std::enable_if_t<
+        std::is_arithmetic_v<std::remove_reference_t<T>>,
+        std::nullptr_t> = nullptr>
+    FixedPoint(const T &v)
     {
-        if constexpr (std::is_floating_point_v<U>)
-        {
-            if (boost::math::isinf(v))
-            {
-                value = static_cast<T>(maxInt);
-            }
-            else
-            {
-                // cast to `D` first to avoid going infinity
-                const D value_float = static_cast<D>(v);
-                value = static_cast<T>(value_float * shift);
-            }
-        }
-        else
-            value = static_cast<T>(v) * shift;
+        mp_float tmp = static_cast<mp_float>(v);
+        tmp *= shift;
+        value = static_cast<mp_int>(tmp);
     }
-    FixedPointImpl(const std::string &str)
+
+    FixedPoint(const std::string &str)
     {
-        D v_{str};
-        if (boost::math::isinf(v_))
-        {
-            value = static_cast<T>(maxInt);
-        }
-        else
-            value = static_cast<T>(v_ * shift);
+        mp_float v_{str};
+        value = static_cast<mp_int>(v_ * shift);
     }
-    FixedPointImpl &operator=(const FixedPointImpl &obj)
+    FixedPoint &operator=(const FixedPoint &obj)
     {
         value = obj.value;
         return *this;
     }
-    FixedPointImpl &operator=(FixedPointImpl &&obj)
+    FixedPoint &operator=(FixedPoint &&obj)
     {
         value = std::move(obj.value);
         return *this;
     }
-    template <typename U = T>
-    U getVal() const
+    template <typename T = mp_int>
+    T getShiftedVal() const
     {
-        return value.template convert_to<U>();
+        return value.template convert_to<T>();
     }
     std::string getStrVal() const
     {
@@ -109,83 +65,46 @@ public:
         ret /= shift;
         return ret.str(20, std::ios_base::fixed);
     }
-    T getRoundValue() const
+    mp_int getRoundValue() const
     {
-        D ret{this->getVal<D>()};
-        if (boost::math::isinf(ret))
+        mp_int ret = value / shift;
+        if ((value % shift) * 2 >= shift)
         {
-            ret = static_cast<D>(maxInt);
+            ret++;
         }
-        ret /= shift;
-        ret = mp::round(ret);
-        return static_cast<T>(ret);
-    }
-
-    D getSqrtValue() const
-    {
-        D ret{this->getVal<D>()};
-        if (boost::math::isinf(ret))
-        {
-            ret = static_cast<D>(maxInt);
-        }
-        ret /= shift;
-        ret = mp::sqrt(ret);
         return ret;
     }
     double getDoubleVal() const
     {
-        auto ret{this->getVal<double>()};
-        if (boost::math::isinf(ret))
-        {
-            ret = static_cast<double>(maxInt);
-        }
-        return ret / shift;
+        mp_float ret = static_cast<mp_float>(value);
+        return static_cast<double>(ret / shift);
     }
     constexpr static auto getShift() noexcept { return shift; }
-    constexpr static auto getMaxInt() noexcept { return maxInt; }
-    FixedPointImpl getInv() const
+
+    FixedPoint operator-() const
     {
-        D inv{this->getVal<D>()};
-        if (boost::math::isinf(inv))
-        {
-            inv = static_cast<D>(maxInt);
-        }
-        return FixedPointImpl(D{shift} / inv);
-    }
-    FixedPointImpl operator-() const
-    {
-        FixedPointImpl ret{};
+        FixedPoint ret{};
         ret.value = -value;
         return ret;
     }
 
-    FixedPointImpl &operator+=(const FixedPointImpl &obj)
+    FixedPoint &operator+=(const FixedPoint &obj)
     {
         value += obj.value;
         return *this;
     }
-    FixedPointImpl &operator-=(const FixedPointImpl &obj)
+    FixedPoint &operator-=(const FixedPoint &obj)
     {
         value -= obj.value;
         return *this;
     }
-    /*
-    TODO:
-    オーバーフローの可能性が10^shift^2 = 10^12の掛け算でかなり高くなってしまうので
-    一時的に浮動小数点に戻してから演算を行うことも考慮しておく
-    */
-    FixedPointImpl &operator*=(const FixedPointImpl &obj)
+    FixedPoint &operator*=(const FixedPoint &obj)
     {
-        //直接変換でオーバーフローする場合は以下のように文字列に変換する
-        // D tmp{D(value.template str()) * D(obj.value.template str())};
-        // std::string str = tmp.template str();
-        // value = T(str);
-        // value /= shift;
         value *= obj.value;
         value /= shift;  //整数で保持するため余分なshiftを除算する
         return *this;
     }
-    FixedPointImpl &operator/=(const FixedPointImpl &obj)
+    FixedPoint &operator/=(const FixedPoint &obj)
     {
         D inv{obj.getVal<D>()};
         if (boost::math::isinf(inv))
@@ -196,26 +115,26 @@ public:
         value = v.template convert_to<T>();
         return *this;
     }
-    FixedPointImpl &operator%=(const FixedPointImpl &obj)
+    FixedPoint &operator%=(const FixedPoint &obj)
     {
         value %= obj.value;
         return *this;
     }
-    FixedPointImpl &operator++()
+    FixedPoint &operator++()
     {
         value += shift;  // shift分ずれるので1*shift
         return *this;
     }
-    FixedPointImpl &operator--()
+    FixedPoint &operator--()
     {
         value -= shift;  // shift分ずれるので1*shift
         return *this;
     }
-    bool operator==(const FixedPointImpl &obj) const noexcept
+    bool operator==(const FixedPoint &obj) const noexcept
     {
         return (value - obj.value >= -1 and value - obj.value <= 1) ? true : false;
     }
-    bool operator<(const FixedPointImpl &obj) const noexcept { return value < obj.value; }
+    bool operator<(const FixedPoint &obj) const noexcept { return value < obj.value; }
     /*
     標準入出力に入力するとShiftで割った結果が出力される。
     FixedPoint a{5};
@@ -224,7 +143,7 @@ public:
     5が出力される
 
     */
-    friend std::ostream &operator<<(std::ostream &os, const FixedPointImpl &fp)
+    friend std::ostream &operator<<(std::ostream &os, const FixedPoint &fp)
     {
         os << std::fixed;
         os << std::setprecision(10);
@@ -233,9 +152,9 @@ public:
         return os;
     }
 };
-inline auto abs(const FixedPointImpl<> &x)
+inline auto abs(const FixedPoint<> &x)
 {
-    if (x < FixedPointImpl<>("0.0"))
+    if (x < FixedPoint<>("0.0"))
     {
         return -x;
     }
@@ -245,9 +164,9 @@ inline auto abs(const FixedPointImpl<> &x)
     }
 }
 template <typename T>
-std::string to_string(const FixedPointImpl<T> &fp)
+std::string to_string(const FixedPoint<T> &fp)
 {
     return fp.getStrVal();
 }
 }  // namespace qmpc::Utils
-using FixedPoint = qmpc::Utils::FixedPointImpl<>;
+using FixedPoint = qmpc::Utils::FixedPoint<>;

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -28,8 +28,8 @@ public:
     template <
         typename T,
         std::enable_if_t<
-            std::is_arithmetic_v <std::remove_reference_t<T>>, std::nullptr_t
-        > = nullptr>
+            std::is_arithmetic_v <std::remove_reference_t<T>>,
+            std::nullptr_t> = nullptr>
     FixedPoint(const T &v)
     {
         mp_float tmp = static_cast<mp_float>(v);
@@ -157,10 +157,10 @@ inline auto abs(const FixedPoint &x)
         return x;
     }
 }
-template<typename FP>
+template <typename FP>
 std::string to_string(const FP &fp)
 {
-    static_assert(std::is_same_v<FP,FixedPoint>, "for FP");
+    static_assert(std::is_same_v<FP, FixedPoint>, "for FP");
     return fp.getStrVal();
 }
 }  // namespace qmpc::Utils

--- a/packages/server/computation_container/share/share.hpp
+++ b/packages/server/computation_container/share/share.hpp
@@ -323,18 +323,6 @@ auto _isZero(const T &x)
         return x == 0.0;
     }
 }
-template <class T>
-auto _sqrt(const T &x)
-{
-    if constexpr (std::is_same_v<T, FixedPoint>)
-    {
-        return T(x.getSqrtValue());
-    }
-    else
-    {
-        return std::sqrt(x);
-    }
-}
 
 template <typename SV>
 Share<SV> getRandBitShare()


### PR DESCRIPTION
# Summary
Delete template from FixedPoint.
# Purpose
Prevent FixedPoint from becoming a type not supported by the client or BTS.
# Contents
Delete template from FixedPoint.
# Testing Methods Performed
CI