### PR TITLE
Stop saving shares as strings

### DIFF
--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -35,15 +35,6 @@ public:
         tmp *= shift;
         value = static_cast<mp_int>(tmp);
     }
-    FixedPoint(const SgnByte &P)
-    {
-        const auto &[sgn, abs_byte] = P;
-        import_bits(value, abs_byte.begin(), abs_byte.end(), 8);
-        if (sgn)
-        {
-            value *= -1;
-        }
-    }
     FixedPoint(const std::string &str)
     {
         mp_float v_{str};

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -14,6 +14,7 @@ namespace qmpc::Utils
 namespace mp = boost::multiprecision;
 using mp_int = boost::multiprecision::cpp_int;
 using mp_float = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<50>>;
+using SgnByte = std::pair<bool, std::string>;
 
 class FixedPoint : private boost::operators<FixedPoint>
 {
@@ -35,7 +36,15 @@ public:
         tmp *= shift;
         value = static_cast<mp_int>(tmp);
     }
-
+    FixedPoint(const SgnByte &P)
+    {
+        const auto &[sgn, abs_byte] = P;
+        import_bits(value, abs_byte.begin(), abs_byte.end(), 8);
+        if (sgn)
+        {
+            value *= -1;
+        }
+    }
     FixedPoint(const std::string &str)
     {
         mp_float v_{str};
@@ -56,6 +65,13 @@ public:
     {
         // getVal() より getShiftedVal() の方が適切かもしれない
         return value.template convert_to<T>();
+    }
+    SgnByte getSgnByte() const
+    {
+        bool sgn = value < 0;
+        std::string bytes;
+        export_bits(value, std::back_inserter(bytes), 8);
+        return std::make_pair(sgn, bytes);
     }
     std::string getStrVal() const
     {

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -14,7 +14,6 @@ namespace qmpc::Utils
 namespace mp = boost::multiprecision;
 using mp_int = boost::multiprecision::cpp_int;
 using mp_float = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<50>>;
-using SgnByte = std::pair<bool, std::string>;
 
 class FixedPoint : private boost::operators<FixedPoint>
 {
@@ -65,13 +64,6 @@ public:
     {
         // getVal() より getShiftedVal() の方が適切かもしれない
         return value.template convert_to<T>();
-    }
-    SgnByte getSgnByte() const
-    {
-        bool sgn = value < 0;
-        std::string bytes;
-        export_bits(value, std::back_inserter(bytes), 8);
-        return std::make_pair(sgn, bytes);
     }
     std::string getStrVal() const
     {

--- a/packages/server/computation_container/server/computation_to_computation_container/server.cpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.cpp
@@ -6,6 +6,7 @@
 
 namespace qmpc::ComputationToComputation
 {
+
 Server::Server() noexcept
 {
     Config *conf = Config::getInstance();
@@ -20,20 +21,6 @@ Server::Server() noexcept
     }
 }
 
-static std::string share_to_str(const computationtocomputation::Shares_Share &share)
-{
-    using cs = computationtocomputation::Shares_Share;
-    switch (share.value_case())
-    {
-        case (cs::ValueCase::kFlag):
-            return std::to_string(share.flag());
-        case (cs::ValueCase::kNum):
-            return std::to_string(share.num());
-        case (cs::ValueCase::kByte):
-        case (cs::ValueCase::VALUE_NOT_SET):
-            return share.byte();
-    }
-}
 // 複数シェアをexchangeする場合
 grpc::Status Server::ExchangeShares(
     grpc::ServerContext *context,
@@ -44,7 +31,7 @@ grpc::Status Server::ExchangeShares(
     computationtocomputation::Shares multiple_shares;
     bool first = true;
     int party_id, share_id, job_id, thread_id;
-    std::vector<std::string> share_str_vec;
+    std::vector<CtoCShare> share_vec;
 
     while (stream->Read(&multiple_shares))
     {
@@ -63,9 +50,7 @@ grpc::Status Server::ExchangeShares(
         for (int i = 0; i < multiple_shares.share_list_size(); i++)
         {
             auto share = multiple_shares.share_list(i);
-
-            auto share_str = share_to_str(share);
-            share_str_vec.emplace_back(share_str);
+            share_vec.emplace_back(share);
         }
         first = false;
     }
@@ -73,7 +58,7 @@ grpc::Status Server::ExchangeShares(
     std::lock_guard<std::mutex> lock(mtx);  // mutex発動
     if (!first)
     {
-        shares_vec[std::make_tuple(party_id, share_id, job_id, thread_id)] = share_str_vec;
+        shares_vec[std::make_tuple(party_id, share_id, job_id, thread_id)] = share_vec;
     }
 
     cond.notify_all();  // 通知
@@ -81,7 +66,7 @@ grpc::Status Server::ExchangeShares(
 }
 
 // 単一シェアget用
-std::string Server::getShare(int party_id, qmpc::Share::AddressId share_id)
+CtoCShare Server::getShare(int party_id, qmpc::Share::AddressId share_id)
 {
     Config *conf = Config::getInstance();
     std::unique_lock<std::mutex> lock(mtx);  // mutex発動
@@ -102,21 +87,21 @@ std::string Server::getShare(int party_id, qmpc::Share::AddressId share_id)
 }
 
 // 複数シェアget用
-std::vector<std::string> Server::getShares(
+std::vector<CtoCShare> Server::getShares(
     int party_id, const std::vector<qmpc::Share::AddressId> &share_ids
 )
 {
     const std::size_t length = share_ids.size();
     if (length == 0)
     {
-        return std::vector<std::string>{};
+        return std::vector<CtoCShare>{};
     }
 
     Config *conf = Config::getInstance();
     // std::cout << "party share job thread"
     //           << " " << party_id << " " << share_ids[0].getShareId() << " "
     //           << share_ids[0].getJobId() << " " << share_ids[0].getThreadId() << std::endl;
-    std::vector<std::string> str_values;
+    std::vector<CtoCShare> str_values;
     str_values.reserve(length);
     auto key = std::make_tuple(
         party_id, share_ids[0].getShareId(), share_ids[0].getJobId(), share_ids[0].getThreadId()

--- a/packages/server/computation_container/server/computation_to_computation_container/server.hpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.hpp
@@ -59,7 +59,7 @@ public:
         }
         auto share = shares_vec[key][0];
         shares_vec.erase(key);
-        return toSV(share);
+        return toSV<SV>(share);
     }
     template <typename SV>
     std::vector<SV> getShares(int party_id, const std::vector<qmpc::Share::AddressId> &share_ids)
@@ -67,15 +67,13 @@ public:
         const std::size_t length = share_ids.size();
         if (length == 0)
         {
-            return std::vector<CtoCShare>{};
+            return std::vector<SV>{};
         }
 
         Config *conf = Config::getInstance();
         // std::cout << "party share job thread"
         //           << " " << party_id << " " << share_ids[0].getShareId() << " "
         //           << share_ids[0].getJobId() << " " << share_ids[0].getThreadId() << std::endl;
-        std::vector<CtoCShare> str_values;
-        str_values.reserve(length);
         auto key = std::make_tuple(
             party_id, share_ids[0].getShareId(), share_ids[0].getJobId(), share_ids[0].getThreadId()
         );
@@ -95,7 +93,7 @@ public:
         std::vector<SV> ret(length);
         for (size_t i = 0; i < length; i++)
         {
-            ret[i] = toSV(local_str_shares[i]);
+            ret[i] = toSV<SV>(local_str_shares[i]);
         }
         return ret;
     }

--- a/packages/server/computation_container/server/computation_to_computation_container/server.hpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.hpp
@@ -23,6 +23,8 @@
 #include "unistd.h"
 namespace qmpc::ComputationToComputation
 {
+using CtoCShare = computationtocomputation::Shares_Share;
+
 class Server final : public computationtocomputation::ComputationToComputation::Service
 {
     std::map<int, std::shared_ptr<Client>> ccClients;
@@ -39,8 +41,8 @@ public:
         google::protobuf::Empty *response
     ) override;
     // 受け取ったシェアをgetするメソッド
-    std::string getShare(int party_id, qmpc::Share::AddressId share_id);
-    std::vector<std::string> getShares(
+    CtoCShare getShare(int party_id, qmpc::Share::AddressId share_id);
+    std::vector<CtoCShare> getShares(
         int party_id, const std::vector<qmpc::Share::AddressId> &share_ids
     );
     Server(Server &&) noexcept = delete;
@@ -70,7 +72,7 @@ private:
     using address_type = std::tuple<int, int, unsigned int, int>;
     // 受け取ったシェアを保存する変数
     // party_id, share_idをキーとして保存
-    std::map<address_type, std::vector<std::string>> shares_vec;
+    std::map<address_type, std::vector<CtoCShare>> shares_vec;
 };
 
 }  // namespace qmpc::ComputationToComputation

--- a/packages/server/computation_container/server/computation_to_computation_container/server.hpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.hpp
@@ -41,10 +41,64 @@ public:
         google::protobuf::Empty *response
     ) override;
     // 受け取ったシェアをgetするメソッド
-    CtoCShare getShare(int party_id, qmpc::Share::AddressId share_id);
-    std::vector<CtoCShare> getShares(
-        int party_id, const std::vector<qmpc::Share::AddressId> &share_ids
-    );
+    template <typename SV>
+    SV getShare(int party_id, qmpc::Share::AddressId share_id)
+    {
+        Config *conf = Config::getInstance();
+        std::unique_lock<std::mutex> lock(mtx);  // mutex発動
+        auto key = std::make_tuple(
+            party_id, share_id.getShareId(), share_id.getJobId(), share_id.getThreadId()
+        );
+        if (!cond.wait_for(
+                lock,
+                std::chrono::seconds(conf->getshare_time_limit),
+                [&] { return shares_vec.count(key) == 1; }
+            ))  // 待機
+        {
+            qmpc::Log::throw_with_trace(std::runtime_error("getShare is timeout"));
+        }
+        auto share = shares_vec[key][0];
+        shares_vec.erase(key);
+        return toSV(share);
+    }
+    template <typename SV>
+    std::vector<SV> getShares(int party_id, const std::vector<qmpc::Share::AddressId> &share_ids)
+    {
+        const std::size_t length = share_ids.size();
+        if (length == 0)
+        {
+            return std::vector<CtoCShare>{};
+        }
+
+        Config *conf = Config::getInstance();
+        // std::cout << "party share job thread"
+        //           << " " << party_id << " " << share_ids[0].getShareId() << " "
+        //           << share_ids[0].getJobId() << " " << share_ids[0].getThreadId() << std::endl;
+        std::vector<CtoCShare> str_values;
+        str_values.reserve(length);
+        auto key = std::make_tuple(
+            party_id, share_ids[0].getShareId(), share_ids[0].getJobId(), share_ids[0].getThreadId()
+        );
+        std::unique_lock<std::mutex> lock(mtx);  // mutex発動
+
+        if (!cond.wait_for(
+                lock,
+                std::chrono::seconds(conf->getshare_time_limit * length),
+                [&] { return shares_vec.count(key) == 1; }
+            ))  // 待機
+        {
+            qmpc::Log::throw_with_trace(std::runtime_error("getShares is timeout"));
+        }
+        auto local_str_shares = shares_vec[key];
+        shares_vec.erase(key);
+        assert(local_str_shares.size() == length);
+        std::vector<SV> ret(length);
+        for (size_t i = 0; i < length; i++)
+        {
+            ret[i] = toSV(local_str_shares[i]);
+        }
+        return ret;
+    }
     Server(Server &&) noexcept = delete;
     Server(const Server &) noexcept = delete;
     Server &operator=(Server &&) noexcept = delete;
@@ -73,6 +127,26 @@ private:
     // 受け取ったシェアを保存する変数
     // party_id, share_idをキーとして保存
     std::map<address_type, std::vector<CtoCShare>> shares_vec;
+
+    template <typename SV>
+    SV toSV(const CtoCShare &share_value)
+    {
+        if constexpr (std::is_same_v<SV, bool>)
+        {
+            assert(share_value.has_flag());
+            return share_value.flag();
+        }
+        else if constexpr (std::is_integral_v<SV>)
+        {
+            assert(share_value.has_num());
+            return share_value.num();
+        }
+        else
+        {
+            assert(share_value.has_byte());
+            return SV(share_value.byte());
+        }
+    }
 };
 
 }  // namespace qmpc::ComputationToComputation

--- a/packages/server/computation_container/share/networking.hpp
+++ b/packages/server/computation_container/share/networking.hpp
@@ -94,21 +94,25 @@ void open(const T &share)
     }
 }
 
+using CtoCShare = computationtocomputation::Shares_Share;
+
 template <typename SV>
-SV stosv(const std::string &str_value)
+SV toSV(const CtoCShare &share_value)
 {
     if constexpr (std::is_same_v<SV, bool>)
     {
-        assert(str_value == "0" || str_value == "1");
-        return str_value == "1";
+        assert(share_value.has_flag());
+        return share_value.flag();
     }
     else if constexpr (std::is_integral_v<SV>)
     {
-        return std::stoll(str_value);
+        assert(share_value.has_num());
+        return share_value.num();
     }
-    else  // TODO: constructable or convertible
+    else
     {
-        return SV(str_value);
+        assert(share_value.has_byte());
+        return SV(share_value.byte());
     }
 }
 
@@ -129,8 +133,8 @@ auto recons(const Share<SV> &share)
         }
         else
         {
-            std::string s = server->getShare(pt_id, share.getId());
-            ret += stosv<SV>(s);
+            CtoCShare s = server->getShare(pt_id, share.getId());
+            ret += toSV<SV>(s);
         }
     }
     return ret;
@@ -162,10 +166,10 @@ auto recons(const std::vector<Share<SV>> &share)
         }
         else
         {
-            std::vector<std::string> values = server->getShares(pt_id, ids_list);
+            std::vector<CtoCShare> values = server->getShares(pt_id, ids_list);
             for (unsigned int i = 0; i < length; i++)
             {
-                ret[i] += stosv<SV>(values[i]);
+                ret[i] += toSV<SV>(values[i]);
             }
         }
     }

--- a/packages/server/computation_container/share/networking.hpp
+++ b/packages/server/computation_container/share/networking.hpp
@@ -97,26 +97,6 @@ void open(const T &share)
 using CtoCShare = computationtocomputation::Shares_Share;
 
 template <typename SV>
-SV toSV(const CtoCShare &share_value)
-{
-    if constexpr (std::is_same_v<SV, bool>)
-    {
-        assert(share_value.has_flag());
-        return share_value.flag();
-    }
-    else if constexpr (std::is_integral_v<SV>)
-    {
-        assert(share_value.has_num());
-        return share_value.num();
-    }
-    else
-    {
-        assert(share_value.has_byte());
-        return SV(share_value.byte());
-    }
-}
-
-template <typename SV>
 auto recons(const Share<SV> &share)
 {
     Config *conf = Config::getInstance();
@@ -133,8 +113,7 @@ auto recons(const Share<SV> &share)
         }
         else
         {
-            CtoCShare s = server->getShare(pt_id, share.getId());
-            ret += toSV<SV>(s);
+            ret += server->getShare<SV>(pt_id, share.getId());
         }
     }
     return ret;
@@ -166,10 +145,10 @@ auto recons(const std::vector<Share<SV>> &share)
         }
         else
         {
-            std::vector<CtoCShare> values = server->getShares(pt_id, ids_list);
+            std::vector<SV> values = server->getShares(pt_id, ids_list);
             for (unsigned int i = 0; i < length; i++)
             {
-                ret[i] += toSV<SV>(values[i]);
+                ret[i] += values[i];
             }
         }
     }

--- a/packages/server/computation_container/share/networking.hpp
+++ b/packages/server/computation_container/share/networking.hpp
@@ -145,7 +145,7 @@ auto recons(const std::vector<Share<SV>> &share)
         }
         else
         {
-            std::vector<SV> values = server->getShares(pt_id, ids_list);
+            std::vector<SV> values = server->getShares<SV>(pt_id, ids_list);
             for (unsigned int i = 0; i < length; i++)
             {
                 ret[i] += values[i];

--- a/packages/server/computation_container/test/unit_test/BUILD
+++ b/packages/server/computation_container/test/unit_test/BUILD
@@ -58,7 +58,8 @@ cc_test(
         "//config_parse:config_parse",
         "@proto//computation_to_computation_container:computation_to_computation_cc_grpc",
         "//share:address",
-        "//logging:log"
+        "//logging:log",
+        "//fixed_point:fixed_point"
     ],
     linkopts = ["-pthread"],
 )

--- a/packages/server/computation_container/test/unit_test/ctoc_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctoc_test.cpp
@@ -97,7 +97,7 @@ TEST(CtoC_Test, EXCHANGESHARES)
     EXPECT_TRUE(status.ok());
 
     auto server = qmpc::ComputationToComputation::Server::getServer();
-    std::string datas = server->getShares<std::string>(conf->party_id, share_ids);
+    std::vector<std::string> datas = server->getShares<std::string>(conf->party_id, share_ids);
     for (unsigned int i = 0; i < length; i++)
     {
         EXPECT_EQ(values[i], datas[i]);

--- a/packages/server/computation_container/test/unit_test/ctoc_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctoc_test.cpp
@@ -17,126 +17,126 @@
 #include "server/computation_to_computation_container/server.hpp"
 #include "share/address_id.hpp"
 
-// void runServer(std::string endpoint)
-// {
-//     auto server = qmpc::ComputationToComputation::Server::getServer();
-//     grpc::ServerBuilder builder;
-//     /*
-//     grpc Server keepalive設定
-//     GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS　pingの間隔がこの時間より短い場合は攻撃とみなす　9秒
-//     （この時間はクライアントと調整する）
-//     GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS　通信がなくてもpingを送る　on
-//     */
-//     builder.AddChannelArgument(GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS, 9000);
-//     builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-//     builder.AddListeningPort(endpoint, grpc::InsecureServerCredentials());
-//     builder.RegisterService(server);
-//     std::unique_ptr<grpc::Server> listener(builder.BuildAndStart());
-//     QMPC_LOG_INFO("[CcToCc_test] Server listening on {}", endpoint);
-//     listener->Wait();
-// }
+void runServer(std::string endpoint)
+{
+    auto server = qmpc::ComputationToComputation::Server::getServer();
+    grpc::ServerBuilder builder;
+    /*
+    grpc Server keepalive設定
+    GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS　pingの間隔がこの時間より短い場合は攻撃とみなす　9秒
+    （この時間はクライアントと調整する）
+    GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS　通信がなくてもpingを送る　on
+    */
+    builder.AddChannelArgument(GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS, 9000);
+    builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+    builder.AddListeningPort(endpoint, grpc::InsecureServerCredentials());
+    builder.RegisterService(server);
+    std::unique_ptr<grpc::Server> listener(builder.BuildAndStart());
+    QMPC_LOG_INFO("[CcToCc_test] Server listening on {}", endpoint);
+    listener->Wait();
+}
 
-// TEST(CtoC_Test, EXCHANGESHARE)
-// {
-//     Config *conf = Config::getInstance();
-//     std::vector<qmpc::Share::AddressId> share_id(1);
-//     computationtocomputation::Shares share;
-//     std::cout << "exchangeshare id " << share_id[0] << std::endl;
-//     std::string value = "10";
-//     auto a = share.mutable_address_id();
-//     a->set_share_id(share_id[0].getShareId());
-//     a->set_job_id(share_id[0].getJobId());
-//     a->set_party_id(conf->party_id);
-//     computationtocomputation::Shares_Share *multiple_shares = share.add_share_list();
-//     multiple_shares->set_byte(value);
+TEST(CtoC_Test, EXCHANGESHARE)
+{
+    Config *conf = Config::getInstance();
+    std::vector<qmpc::Share::AddressId> share_id(1);
+    computationtocomputation::Shares share;
+    std::cout << "exchangeshare id " << share_id[0] << std::endl;
+    std::string value = "10";
+    auto a = share.mutable_address_id();
+    a->set_share_id(share_id[0].getShareId());
+    a->set_job_id(share_id[0].getJobId());
+    a->set_party_id(conf->party_id);
+    computationtocomputation::Shares_Share *multiple_shares = share.add_share_list();
+    multiple_shares->set_byte(value);
 
-//     auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
-//         Url::Parse("http://localhost:50120")
-//     );
-//     grpc::ClientContext context;
-//     google::protobuf::Empty response;
-//     std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
-//         stub_->ExchangeShares(&context, &response)
-//     );
-//     stream->Write(share);
-//     stream->WritesDone();
-//     grpc::Status status = stream->Finish();
-//     EXPECT_TRUE(status.ok());
+    auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
+        Url::Parse("http://localhost:50120")
+    );
+    grpc::ClientContext context;
+    google::protobuf::Empty response;
+    std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
+        stub_->ExchangeShares(&context, &response)
+    );
+    stream->Write(share);
+    stream->WritesDone();
+    grpc::Status status = stream->Finish();
+    EXPECT_TRUE(status.ok());
 
-//     auto server = qmpc::ComputationToComputation::Server::getServer();
-//     auto data = server->getShare(conf->party_id, share_id[0]);
-//     EXPECT_EQ(value, data);
-// }
-// TEST(CtoC_Test, EXCHANGESHARES)
-// {
-//     Config *conf = Config::getInstance();
-//     unsigned int length = 2;
-//     std::vector<qmpc::Share::AddressId> share_ids(length);
-//     std::vector<std::string> values = {"10", "11"};
-//     computationtocomputation::Shares shares;
-//     auto a = shares.mutable_address_id();
-//     a->set_share_id(share_ids[0].getShareId());
-//     a->set_job_id(share_ids[0].getJobId());
-//     a->set_party_id(conf->party_id);
-//     for (unsigned int i = 0; i < length; i++)
-//     {
-//         computationtocomputation::Shares_Share *multiple_shares = shares.add_share_list();
-//         multiple_shares->set_byte(values[i]);
-//     }
-//     auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
-//         Url::Parse("http://localhost:50120")
-//     );
-//     grpc::ClientContext context;
-//     google::protobuf::Empty response;
-//     std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
-//         stub_->ExchangeShares(&context, &response)
-//     );
-//     stream->Write(shares);
-//     stream->WritesDone();
-//     grpc::Status status = stream->Finish();
-//     EXPECT_TRUE(status.ok());
+    auto server = qmpc::ComputationToComputation::Server::getServer();
+    std::string data = server->getShare<std::string>(conf->party_id, share_id[0]);
+    EXPECT_EQ(value, data);
+}
+TEST(CtoC_Test, EXCHANGESHARES)
+{
+    Config *conf = Config::getInstance();
+    unsigned int length = 2;
+    std::vector<qmpc::Share::AddressId> share_ids(length);
+    std::vector<std::string> values = {"10", "11"};
+    computationtocomputation::Shares shares;
+    auto a = shares.mutable_address_id();
+    a->set_share_id(share_ids[0].getShareId());
+    a->set_job_id(share_ids[0].getJobId());
+    a->set_party_id(conf->party_id);
+    for (unsigned int i = 0; i < length; i++)
+    {
+        computationtocomputation::Shares_Share *multiple_shares = shares.add_share_list();
+        multiple_shares->set_byte(values[i]);
+    }
+    auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
+        Url::Parse("http://localhost:50120")
+    );
+    grpc::ClientContext context;
+    google::protobuf::Empty response;
+    std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
+        stub_->ExchangeShares(&context, &response)
+    );
+    stream->Write(shares);
+    stream->WritesDone();
+    grpc::Status status = stream->Finish();
+    EXPECT_TRUE(status.ok());
 
-//     auto server = qmpc::ComputationToComputation::Server::getServer();
-//     auto datas = server->getShares(conf->party_id, share_ids);
-//     for (unsigned int i = 0; i < length; i++)
-//     {
-//         EXPECT_EQ(values[i], datas[i]);
-//     }
-// }
+    auto server = qmpc::ComputationToComputation::Server::getServer();
+    std::string datas = server->getShares<std::string>(conf->party_id, share_ids);
+    for (unsigned int i = 0; i < length; i++)
+    {
+        EXPECT_EQ(values[i], datas[i]);
+    }
+}
 
-// TEST(CtoC_Test, GetShareThrowExceptionTest)
-// {
-//     Config *conf = Config::getInstance();
-//     qmpc::Share::AddressId share_id;
+TEST(CtoC_Test, GetShareThrowExceptionTest)
+{
+    Config *conf = Config::getInstance();
+    qmpc::Share::AddressId share_id;
 
-//     auto server = qmpc::ComputationToComputation::Server::getServer();
-//     EXPECT_ANY_THROW(server->getShare(conf->party_id, share_id));
-// }
+    auto server = qmpc::ComputationToComputation::Server::getServer();
+    EXPECT_ANY_THROW(server->getShare<std::string>(conf->party_id, share_id));
+}
 
-// TEST(CtoC_Test, GetSharesThrowExceptionTest)
-// {
-//     Config *conf = Config::getInstance();
-//     unsigned int length = 1;
-//     std::vector<qmpc::Share::AddressId> share_ids(length);
+TEST(CtoC_Test, GetSharesThrowExceptionTest)
+{
+    Config *conf = Config::getInstance();
+    unsigned int length = 1;
+    std::vector<qmpc::Share::AddressId> share_ids(length);
 
-//     auto server = qmpc::ComputationToComputation::Server::getServer();
-//     EXPECT_ANY_THROW(server->getShares(conf->party_id, share_ids));
-// }
-// int main(int argc, char **argv)
-// {
-//     Config *conf = Config::getInstance();
+    auto server = qmpc::ComputationToComputation::Server::getServer();
+    EXPECT_ANY_THROW(server->getShares<std::string>(conf->party_id, share_ids));
+}
+int main(int argc, char **argv)
+{
+    Config *conf = Config::getInstance();
 
-//     Url ctoc_ip = conf->ip_addr_map[conf->party_id];
-//     const std::string ctc_my_ip_str("0.0.0.0:" + ctoc_ip.port);
-//     std::thread th1(runServer, ctc_my_ip_str);
-//     sleep(3);
+    Url ctoc_ip = conf->ip_addr_map[conf->party_id];
+    const std::string ctc_my_ip_str("0.0.0.0:" + ctoc_ip.port);
+    std::thread th1(runServer, ctc_my_ip_str);
+    sleep(3);
 
-//     ::testing::InitGoogleTest(&argc, argv);
-//     int ok = RUN_ALL_TESTS();
-//     if (ok == 0)
-//         std::exit(EXIT_SUCCESS);
-//     else
-//         std::exit(EXIT_FAILURE);
+    ::testing::InitGoogleTest(&argc, argv);
+    int ok = RUN_ALL_TESTS();
+    if (ok == 0)
+        std::exit(EXIT_SUCCESS);
+    else
+        std::exit(EXIT_FAILURE);
 
-//     th1.detach();
-// }
+    th1.detach();
+}

--- a/packages/server/computation_container/test/unit_test/ctoc_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctoc_test.cpp
@@ -11,131 +11,132 @@
 
 #include "config_parse/config_parse.hpp"
 #include "external/proto/computation_to_computation_container/computation_to_computation.grpc.pb.h"
+#include "fixed_point/fixed_point.hpp"
 #include "gtest/gtest.h"
 #include "logging/logger.hpp"
 #include "server/computation_to_computation_container/server.hpp"
 #include "share/address_id.hpp"
 
-void runServer(std::string endpoint)
-{
-    auto server = qmpc::ComputationToComputation::Server::getServer();
-    grpc::ServerBuilder builder;
-    /*
-    grpc Server keepalive設定
-    GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS　pingの間隔がこの時間より短い場合は攻撃とみなす　9秒
-    （この時間はクライアントと調整する）
-    GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS　通信がなくてもpingを送る　on
-    */
-    builder.AddChannelArgument(GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS, 9000);
-    builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-    builder.AddListeningPort(endpoint, grpc::InsecureServerCredentials());
-    builder.RegisterService(server);
-    std::unique_ptr<grpc::Server> listener(builder.BuildAndStart());
-    QMPC_LOG_INFO("[CcToCc_test] Server listening on {}", endpoint);
-    listener->Wait();
-}
+// void runServer(std::string endpoint)
+// {
+//     auto server = qmpc::ComputationToComputation::Server::getServer();
+//     grpc::ServerBuilder builder;
+//     /*
+//     grpc Server keepalive設定
+//     GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS　pingの間隔がこの時間より短い場合は攻撃とみなす　9秒
+//     （この時間はクライアントと調整する）
+//     GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS　通信がなくてもpingを送る　on
+//     */
+//     builder.AddChannelArgument(GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS, 9000);
+//     builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+//     builder.AddListeningPort(endpoint, grpc::InsecureServerCredentials());
+//     builder.RegisterService(server);
+//     std::unique_ptr<grpc::Server> listener(builder.BuildAndStart());
+//     QMPC_LOG_INFO("[CcToCc_test] Server listening on {}", endpoint);
+//     listener->Wait();
+// }
 
-TEST(CtoC_Test, EXCHANGESHARE)
-{
-    Config *conf = Config::getInstance();
-    std::vector<qmpc::Share::AddressId> share_id(1);
-    computationtocomputation::Shares share;
-    std::cout << "exchangeshare id " << share_id[0] << std::endl;
-    std::string value = "10";
-    auto a = share.mutable_address_id();
-    a->set_share_id(share_id[0].getShareId());
-    a->set_job_id(share_id[0].getJobId());
-    a->set_party_id(conf->party_id);
-    computationtocomputation::Shares_Share *multiple_shares = share.add_share_list();
-    multiple_shares->set_byte(value);
+// TEST(CtoC_Test, EXCHANGESHARE)
+// {
+//     Config *conf = Config::getInstance();
+//     std::vector<qmpc::Share::AddressId> share_id(1);
+//     computationtocomputation::Shares share;
+//     std::cout << "exchangeshare id " << share_id[0] << std::endl;
+//     std::string value = "10";
+//     auto a = share.mutable_address_id();
+//     a->set_share_id(share_id[0].getShareId());
+//     a->set_job_id(share_id[0].getJobId());
+//     a->set_party_id(conf->party_id);
+//     computationtocomputation::Shares_Share *multiple_shares = share.add_share_list();
+//     multiple_shares->set_byte(value);
 
-    auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
-        Url::Parse("http://localhost:50120")
-    );
-    grpc::ClientContext context;
-    google::protobuf::Empty response;
-    std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
-        stub_->ExchangeShares(&context, &response)
-    );
-    stream->Write(share);
-    stream->WritesDone();
-    grpc::Status status = stream->Finish();
-    EXPECT_TRUE(status.ok());
+//     auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
+//         Url::Parse("http://localhost:50120")
+//     );
+//     grpc::ClientContext context;
+//     google::protobuf::Empty response;
+//     std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
+//         stub_->ExchangeShares(&context, &response)
+//     );
+//     stream->Write(share);
+//     stream->WritesDone();
+//     grpc::Status status = stream->Finish();
+//     EXPECT_TRUE(status.ok());
 
-    auto server = qmpc::ComputationToComputation::Server::getServer();
-    auto data = server->getShare(conf->party_id, share_id[0]);
-    EXPECT_EQ(value, data);
-}
-TEST(CtoC_Test, EXCHANGESHARES)
-{
-    Config *conf = Config::getInstance();
-    unsigned int length = 2;
-    std::vector<qmpc::Share::AddressId> share_ids(length);
-    std::vector<std::string> values = {"10", "11"};
-    computationtocomputation::Shares shares;
-    auto a = shares.mutable_address_id();
-    a->set_share_id(share_ids[0].getShareId());
-    a->set_job_id(share_ids[0].getJobId());
-    a->set_party_id(conf->party_id);
-    for (unsigned int i = 0; i < length; i++)
-    {
-        computationtocomputation::Shares_Share *multiple_shares = shares.add_share_list();
-        multiple_shares->set_byte(values[i]);
-    }
-    auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
-        Url::Parse("http://localhost:50120")
-    );
-    grpc::ClientContext context;
-    google::protobuf::Empty response;
-    std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
-        stub_->ExchangeShares(&context, &response)
-    );
-    stream->Write(shares);
-    stream->WritesDone();
-    grpc::Status status = stream->Finish();
-    EXPECT_TRUE(status.ok());
+//     auto server = qmpc::ComputationToComputation::Server::getServer();
+//     auto data = server->getShare(conf->party_id, share_id[0]);
+//     EXPECT_EQ(value, data);
+// }
+// TEST(CtoC_Test, EXCHANGESHARES)
+// {
+//     Config *conf = Config::getInstance();
+//     unsigned int length = 2;
+//     std::vector<qmpc::Share::AddressId> share_ids(length);
+//     std::vector<std::string> values = {"10", "11"};
+//     computationtocomputation::Shares shares;
+//     auto a = shares.mutable_address_id();
+//     a->set_share_id(share_ids[0].getShareId());
+//     a->set_job_id(share_ids[0].getJobId());
+//     a->set_party_id(conf->party_id);
+//     for (unsigned int i = 0; i < length; i++)
+//     {
+//         computationtocomputation::Shares_Share *multiple_shares = shares.add_share_list();
+//         multiple_shares->set_byte(values[i]);
+//     }
+//     auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
+//         Url::Parse("http://localhost:50120")
+//     );
+//     grpc::ClientContext context;
+//     google::protobuf::Empty response;
+//     std::shared_ptr<grpc::ClientWriter<computationtocomputation::Shares>> stream(
+//         stub_->ExchangeShares(&context, &response)
+//     );
+//     stream->Write(shares);
+//     stream->WritesDone();
+//     grpc::Status status = stream->Finish();
+//     EXPECT_TRUE(status.ok());
 
-    auto server = qmpc::ComputationToComputation::Server::getServer();
-    auto datas = server->getShares(conf->party_id, share_ids);
-    for (unsigned int i = 0; i < length; i++)
-    {
-        EXPECT_EQ(values[i], datas[i]);
-    }
-}
+//     auto server = qmpc::ComputationToComputation::Server::getServer();
+//     auto datas = server->getShares(conf->party_id, share_ids);
+//     for (unsigned int i = 0; i < length; i++)
+//     {
+//         EXPECT_EQ(values[i], datas[i]);
+//     }
+// }
 
-TEST(CtoC_Test, GetShareThrowExceptionTest)
-{
-    Config *conf = Config::getInstance();
-    qmpc::Share::AddressId share_id;
+// TEST(CtoC_Test, GetShareThrowExceptionTest)
+// {
+//     Config *conf = Config::getInstance();
+//     qmpc::Share::AddressId share_id;
 
-    auto server = qmpc::ComputationToComputation::Server::getServer();
-    EXPECT_ANY_THROW(server->getShare(conf->party_id, share_id));
-}
+//     auto server = qmpc::ComputationToComputation::Server::getServer();
+//     EXPECT_ANY_THROW(server->getShare(conf->party_id, share_id));
+// }
 
-TEST(CtoC_Test, GetSharesThrowExceptionTest)
-{
-    Config *conf = Config::getInstance();
-    unsigned int length = 1;
-    std::vector<qmpc::Share::AddressId> share_ids(length);
+// TEST(CtoC_Test, GetSharesThrowExceptionTest)
+// {
+//     Config *conf = Config::getInstance();
+//     unsigned int length = 1;
+//     std::vector<qmpc::Share::AddressId> share_ids(length);
 
-    auto server = qmpc::ComputationToComputation::Server::getServer();
-    EXPECT_ANY_THROW(server->getShares(conf->party_id, share_ids));
-}
-int main(int argc, char **argv)
-{
-    Config *conf = Config::getInstance();
+//     auto server = qmpc::ComputationToComputation::Server::getServer();
+//     EXPECT_ANY_THROW(server->getShares(conf->party_id, share_ids));
+// }
+// int main(int argc, char **argv)
+// {
+//     Config *conf = Config::getInstance();
 
-    Url ctoc_ip = conf->ip_addr_map[conf->party_id];
-    const std::string ctc_my_ip_str("0.0.0.0:" + ctoc_ip.port);
-    std::thread th1(runServer, ctc_my_ip_str);
-    sleep(3);
+//     Url ctoc_ip = conf->ip_addr_map[conf->party_id];
+//     const std::string ctc_my_ip_str("0.0.0.0:" + ctoc_ip.port);
+//     std::thread th1(runServer, ctc_my_ip_str);
+//     sleep(3);
 
-    ::testing::InitGoogleTest(&argc, argv);
-    int ok = RUN_ALL_TESTS();
-    if (ok == 0)
-        std::exit(EXIT_SUCCESS);
-    else
-        std::exit(EXIT_FAILURE);
+//     ::testing::InitGoogleTest(&argc, argv);
+//     int ok = RUN_ALL_TESTS();
+//     if (ok == 0)
+//         std::exit(EXIT_SUCCESS);
+//     else
+//         std::exit(EXIT_FAILURE);
 
-    th1.detach();
-}
+//     th1.detach();
+// }


### PR DESCRIPTION
# Summary
Stop saving shares as strings
# Purpose
Preparing to change the FixedPoint communication method
# Contents
Save shares as `computationtocomputation::Shares_Share`
# Testing Methods Performed
CI