### PR TITLE
Stop converting FixedPoint to string in cc->cc communication.

### DIFF
--- a/packages/server/computation_container/client/computation_to_computation_container/client.hpp
+++ b/packages/server/computation_container/client/computation_to_computation_container/client.hpp
@@ -73,7 +73,10 @@ private:
             }
             else
             {
-                multiple_shares->set_byte(to_string(values[i]));
+                computationtocomputation::BigIntByte* fp = multiple_shares->mutable_fp();
+                auto [sgn, byte] = values[i].getSgnByte();
+                fp->set_sgn(sgn);
+                fp->set_byte(byte);
             }
         }
         share_vec.push_back(s);

--- a/packages/server/computation_container/client/computation_to_computation_container/client.hpp
+++ b/packages/server/computation_container/client/computation_to_computation_container/client.hpp
@@ -73,7 +73,7 @@ private:
             }
             else
             {
-                computationtocomputation::BigIntByte* fp = multiple_shares->mutable_fp();
+                computationtocomputation::BigIntByte *fp = multiple_shares->mutable_fp();
                 auto [sgn, byte] = values[i].getSgnByte();
                 fp->set_sgn(sgn);
                 fp->set_byte(byte);

--- a/packages/server/computation_container/fixed_point/fixed_point.hpp
+++ b/packages/server/computation_container/fixed_point/fixed_point.hpp
@@ -14,6 +14,7 @@ namespace qmpc::Utils
 namespace mp = boost::multiprecision;
 using mp_int = boost::multiprecision::cpp_int;
 using mp_float = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<50>>;
+using SgnByte = std::pair<bool, std::string>;
 
 class FixedPoint : private boost::operators<FixedPoint>
 {
@@ -39,6 +40,15 @@ public:
     {
         mp_float v_{str};
         value = static_cast<mp_int>(v_ * shift);
+    }
+    FixedPoint(const SgnByte &P)
+    {
+        const auto &[sgn, abs_byte] = P;
+        import_bits(value, abs_byte.begin(), abs_byte.end(), 8);
+        if (sgn)
+        {
+            value *= -1;
+        }
     }
     FixedPoint &operator=(const FixedPoint &obj)
     {
@@ -70,6 +80,13 @@ public:
             ret++;
         }
         return ret;
+    }
+    SgnByte getSgnByte() const
+    {
+        bool sgn = value < 0;
+        std::string bytes;
+        export_bits(value, std::back_inserter(bytes), 8);
+        return std::make_pair(sgn, bytes);
     }
     double getDoubleVal() const
     {

--- a/packages/server/computation_container/server/computation_to_computation_container/server.hpp
+++ b/packages/server/computation_container/server/computation_to_computation_container/server.hpp
@@ -141,8 +141,11 @@ private:
         }
         else
         {
-            assert(share_value.has_byte());
-            return SV(share_value.byte());
+            assert(share_value.has_fp());
+            auto fp = share_value.fp();
+            bool sgn = fp.sgn();
+            std::string byte = fp.byte();
+            return SV(std::make_pair(sgn, byte));
         }
     }
 };

--- a/packages/server/computation_container/test/unit_test/ctoc_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctoc_test.cpp
@@ -48,7 +48,7 @@ TEST(CtoC_Test, EXCHANGESHARE)
     a->set_job_id(share_id[0].getJobId());
     a->set_party_id(conf->party_id);
     computationtocomputation::Shares_Share *multiple_shares = share.add_share_list();
-    multiple_shares->set_byte(value);
+    multiple_shares->set_num(value);
 
     auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
         Url::Parse("http://localhost:50120")
@@ -81,7 +81,7 @@ TEST(CtoC_Test, EXCHANGESHARES)
     for (unsigned int i = 0; i < length; i++)
     {
         computationtocomputation::Shares_Share *multiple_shares = shares.add_share_list();
-        multiple_shares->set_byte(values[i]);
+        multiple_shares->set_num(values[i]);
     }
     auto stub_ = createStub<computationtocomputation::ComputationToComputation>(
         Url::Parse("http://localhost:50120")

--- a/packages/server/computation_container/test/unit_test/ctoc_test.cpp
+++ b/packages/server/computation_container/test/unit_test/ctoc_test.cpp
@@ -42,7 +42,7 @@ TEST(CtoC_Test, EXCHANGESHARE)
     std::vector<qmpc::Share::AddressId> share_id(1);
     computationtocomputation::Shares share;
     std::cout << "exchangeshare id " << share_id[0] << std::endl;
-    std::string value = "10";
+    int value = 10;
     auto a = share.mutable_address_id();
     a->set_share_id(share_id[0].getShareId());
     a->set_job_id(share_id[0].getJobId());
@@ -64,7 +64,7 @@ TEST(CtoC_Test, EXCHANGESHARE)
     EXPECT_TRUE(status.ok());
 
     auto server = qmpc::ComputationToComputation::Server::getServer();
-    std::string data = server->getShare<std::string>(conf->party_id, share_id[0]);
+    int data = server->getShare<int>(conf->party_id, share_id[0]);
     EXPECT_EQ(value, data);
 }
 TEST(CtoC_Test, EXCHANGESHARES)
@@ -72,7 +72,7 @@ TEST(CtoC_Test, EXCHANGESHARES)
     Config *conf = Config::getInstance();
     unsigned int length = 2;
     std::vector<qmpc::Share::AddressId> share_ids(length);
-    std::vector<std::string> values = {"10", "11"};
+    std::vector<int> values = {10, 11};
     computationtocomputation::Shares shares;
     auto a = shares.mutable_address_id();
     a->set_share_id(share_ids[0].getShareId());
@@ -97,7 +97,7 @@ TEST(CtoC_Test, EXCHANGESHARES)
     EXPECT_TRUE(status.ok());
 
     auto server = qmpc::ComputationToComputation::Server::getServer();
-    std::vector<std::string> datas = server->getShares<std::string>(conf->party_id, share_ids);
+    std::vector<int> datas = server->getShares<int>(conf->party_id, share_ids);
     for (unsigned int i = 0; i < length; i++)
     {
         EXPECT_EQ(values[i], datas[i]);
@@ -110,7 +110,7 @@ TEST(CtoC_Test, GetShareThrowExceptionTest)
     qmpc::Share::AddressId share_id;
 
     auto server = qmpc::ComputationToComputation::Server::getServer();
-    EXPECT_ANY_THROW(server->getShare<std::string>(conf->party_id, share_id));
+    EXPECT_ANY_THROW(server->getShare<int>(conf->party_id, share_id));
 }
 
 TEST(CtoC_Test, GetSharesThrowExceptionTest)
@@ -120,7 +120,7 @@ TEST(CtoC_Test, GetSharesThrowExceptionTest)
     std::vector<qmpc::Share::AddressId> share_ids(length);
 
     auto server = qmpc::ComputationToComputation::Server::getServer();
-    EXPECT_ANY_THROW(server->getShares<std::string>(conf->party_id, share_ids));
+    EXPECT_ANY_THROW(server->getShares<int>(conf->party_id, share_ids));
 }
 int main(int argc, char **argv)
 {

--- a/proto/computation_to_computation_container/computation_to_computation.proto
+++ b/proto/computation_to_computation_container/computation_to_computation.proto
@@ -24,6 +24,11 @@ message Address{
     int32 party_id = 4; // the id of party(0, 1, 2)
 }
 
+message BigIntByte{
+    bool sgn = 1;
+    bytes byte = 2;
+}
+
 /**
  * the message of shares
 */
@@ -31,7 +36,7 @@ message Shares {
     message Share{
         oneof value{
             int64 num = 1;
-            bytes byte = 2;
+            BigIntByte fp = 2;
             bool flag = 3;
         }
     }


### PR DESCRIPTION
# Summary
Stop converting FixedPoint to string in cc->cc communication.
# Purpose
Faster communication
# Contents
Converting FixedPoint to pair<bool, std::string>
# Testing Methods Performed
CI